### PR TITLE
Respect PathBase for Swagger-UI.

### DIFF
--- a/src/Swashbuckle.SwaggerUi/Application/SwaggerUiMIddleware.cs
+++ b/src/Swashbuckle.SwaggerUi/Application/SwaggerUiMIddleware.cs
@@ -37,7 +37,7 @@ namespace Swashbuckle.SwaggerUi.Application
             }
 
             var template = _resourceAssembly.GetManifestResourceStream("Swashbuckle.SwaggerUi.CustomAssets.index.html");
-            var content = AssignPlaceholderValuesTo(template);
+            var content = AssignPlaceholderValuesTo(template, httpContext);
             RespondWithContentHtml(httpContext.Response, content);
         }
 
@@ -48,11 +48,11 @@ namespace Swashbuckle.SwaggerUi.Application
 			return _requestMatcher.TryMatch(request.Path, new RouteValueDictionary());
         }
 
-        private Stream AssignPlaceholderValuesTo(Stream template)
+        private Stream AssignPlaceholderValuesTo(Stream template, HttpContext httpContext)
         {
             var placeholderValues = new Dictionary<string, string>
             {
-                { "%(SwaggerUrl)", _swaggerUrl }
+                { "%(SwaggerUrl)", BuildSwaggerUrl(httpContext, _swaggerUrl) }
             };
 
             var templateText = new StreamReader(template).ReadToEnd();
@@ -70,6 +70,20 @@ namespace Swashbuckle.SwaggerUi.Application
             response.StatusCode = 200;
             response.ContentType = "text/html";
             content.CopyTo(response.Body);
+        }
+
+        private static string BuildSwaggerUrl(HttpContext httpContext, string swaggerUrl)
+        {
+            string url = string.IsNullOrEmpty(httpContext.Request.PathBase.ToString())
+                ? ""
+                : httpContext.Request.PathBase.ToString().TrimEnd('/');
+
+            if (!swaggerUrl.StartsWith("/"))
+                url += "/";
+
+            url += swaggerUrl;
+
+            return url;
         }
     }
 }

--- a/test/WebSites/Basic/AdjustPathBaseMiddleware.cs
+++ b/test/WebSites/Basic/AdjustPathBaseMiddleware.cs
@@ -1,0 +1,48 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+
+namespace Basic
+{
+    /// <summary>
+    /// Required for testing swagger behind a <see cref="HttpRequest.PathBase"/>.
+    /// This middleware allows to set the PathBase through a custom header for easier testing.
+    /// </summary>
+    public class AdjustPathBaseMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public AdjustPathBaseMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            string pathBase = GetPathBaseFromHeader(context);
+            if (pathBase != null)
+            {
+                context.Request.PathBase = pathBase + context.Request.PathBase;
+            }
+
+            await _next(context);
+        }
+
+        private string GetPathBaseFromHeader(HttpContext context)
+        {
+            StringValues pathBaseObj;
+            if (context.Request.Headers.TryGetValue("X-Forwarded-PathBase", out pathBaseObj))
+            {
+                string pathBase = pathBaseObj.ToString();
+
+                // Security Checks
+                if (!pathBase.StartsWith("/"))
+                    return null;
+
+                return pathBase;
+            }
+
+            return null;
+        }
+    }
+}

--- a/test/WebSites/Basic/Startup.cs
+++ b/test/WebSites/Basic/Startup.cs
@@ -62,6 +62,9 @@ namespace Basic
             loggerFactory.AddConsole();
             loggerFactory.AddDebug();
 
+            // For testing Swagger behind a Request.PathBase
+            app.UseMiddleware<AdjustPathBaseMiddleware>();
+
             // Configure the HTTP request pipeline.
             app.UseStaticFiles();
 


### PR DESCRIPTION
The SwaggerMiddleware already adds the Request.PathBase property to its path. The SwaggerUi-project does not yet do this. This results in a broken UI because the path to swagger can't be resolved properly.

I've added a simple middleware to the Basic-website to test this. This middleware allows to make a request with a "X-Forwarded-PathBase" header, which gets set as the PathBase.

We have this exact setup with our APIs. They are hosted behind a reverse-proxy which sends the path under which they are hosted as a HTTP header.
