### PR TITLE
Add DescribeAllParametersInCamelCase method to SwaggerGenOptions

### DIFF
--- a/src/Swashbuckle.SwaggerGen/Application/SwaggerGenOptions.cs
+++ b/src/Swashbuckle.SwaggerGen/Application/SwaggerGenOptions.cs
@@ -69,6 +69,11 @@ namespace Swashbuckle.SwaggerGen.Application
             _swaggerGeneratorSettings.SortKeySelector = sortKeySelector;
         }
 
+        public void DescribeAllParametersInCamelCase()
+        {
+            _swaggerGeneratorSettings.DescribeAllParametersInCamelCase = true;
+        }
+
         public void AddSecurityDefinition(string name, SecurityScheme securityScheme)
         {
             _swaggerGeneratorSettings.SecurityDefinitions.Add(name, securityScheme);

--- a/src/Swashbuckle.SwaggerGen/Generator/SwaggerGeneratorSettings.cs
+++ b/src/Swashbuckle.SwaggerGen/Generator/SwaggerGeneratorSettings.cs
@@ -45,6 +45,7 @@ namespace Swashbuckle.SwaggerGen.Generator
                 IgnoreObsoleteActions = IgnoreObsoleteActions,
                 TagSelector = TagSelector,
                 SortKeySelector = SortKeySelector,
+                DescribeAllParametersInCamelCase = DescribeAllParametersInCamelCase,
                 SecurityDefinitions = SecurityDefinitions,
                 OperationFilters = OperationFilters,
                 DocumentFilters = DocumentFilters


### PR DESCRIPTION
Hey,

Adding the DescribeAllParametersInCamelCase method to the SwaggerGenOptions class to allow the parameters camel case configuration.