### PR TITLE
SwaggerSchemaFilterAttribute on structs

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/SwaggerSchemaFilterAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/SwaggerSchemaFilterAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false)]
     public class SwaggerSchemaFilterAttribute : Attribute
     {
         public SwaggerSchemaFilterAttribute(Type type)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Annotations/SwaggerAttributesSchemaFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Annotations/SwaggerAttributesSchemaFilterTests.cs
@@ -2,6 +2,8 @@
 using Xunit;
 using Moq;
 using Swashbuckle.AspNetCore.Swagger;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
@@ -10,12 +12,20 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [Fact]
         public void Apply_DelegatesToSpecifiedFilter_IfTypeDecoratedWithFilterAttribute()
         {
-            var schema = new Schema { };
-            var filterContext = FilterContextFor(typeof(SwaggerAnnotatedType));
+            IEnumerable<Schema> schemas;
+            var filterContexts = new[]
+            {
+                FilterContextFor(typeof(SwaggerAnnotatedClass)),
+                FilterContextFor(typeof(SwaggerAnnotatedStruct))
+            };
 
-            Subject().Apply(schema, filterContext);
+            schemas = filterContexts.Select(c => {
+                var schema = new Schema();
+                Subject().Apply(schema, c);
+                return schema;
+            });
 
-            Assert.NotEmpty(schema.Extensions);
+            Assert.All(schemas, s => Assert.NotEmpty(s.Extensions));
         }
 
         private SchemaFilterContext FilterContextFor(Type type)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Types/SwaggerAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Types/SwaggerAnnotatedType.cs
@@ -7,7 +7,7 @@
     }
 
     [SwaggerSchemaFilter(typeof(VendorExtensionsSchemaFilter))]
-    public class SwaggerAnnotatedStruct
+    public struct SwaggerAnnotatedStruct
     {
         public string Property { get; set; }
     }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Types/SwaggerAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Types/SwaggerAnnotatedType.cs
@@ -1,7 +1,13 @@
 ﻿namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
     [SwaggerSchemaFilter(typeof(VendorExtensionsSchemaFilter))]
-    public class SwaggerAnnotatedType
+    public class SwaggerAnnotatedClass
+    {
+        public string Property { get; set; }
+    }
+
+    [SwaggerSchemaFilter(typeof(VendorExtensionsSchemaFilter))]
+    public class SwaggerAnnotatedStruct
     {
         public string Property { get; set; }
     }


### PR DESCRIPTION
Added `Struct` to `AttributeTargets` of `SwaggerSchemaFilterAttribute` so that you can document value types.

* Minor changes to `SwaggerSchemaFilterAttribute` and `SwaggerAttributesSchemaFilterTests`