### PR TITLE
Allow the SwaggerUI Document title to be configurable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default end-of-line to UNIX
+* text=auto eol=lf

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The steps described above will get you up and running with minimal setup. Howeve
 
 * [Swashbuckle.AspNetCore.SwaggerUI](#swashbuckleaspnetcoreswaggerui)
     * [Change Releative Path to the UI](#change-relative-path-to-the-ui)
+    * [Change Document Title](#change-document-title)
     * [List Multiple Swagger Documents](#list-multiple-swagger-documents)
     * [Apply swagger-ui Parameters](#apply-swagger-ui-parameters)
     * [Inject Custom CSS](#inject-custom-css)
@@ -687,6 +688,18 @@ By default, the Swagger UI will be exposed at "/swagger". If neccessary, you can
 app.UseSwaggerUI(c =>
 {
     c.RoutePrefix = "api-docs"
+    ...
+}
+```
+
+### Change Document Title ###
+
+By default, the Swagger UI will have a generic document title. When you have multiple Swagger pages open, it can be difficult to tell them apart. You can alter this when enabling the SwaggerUi middleware:
+
+```csharp
+app.UseSwaggerUi(c =>
+{
+    c.DocumentTitle("My Swagger UI");
     ...
 }
 ```

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Application/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Application/SwaggerUIOptions.cs
@@ -50,6 +50,15 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         }
 
         /// <summary>
+        /// Change the title of the Swagger UI
+        /// </summary>
+        /// <param name="value">Title given to Swagger UI</param>
+        public void DocumentTitle(string value)
+        {
+            IndexSettings.DocTitle = value;
+        }
+
+        /// <summary>
         /// Controls how the API listing is displayed. See swagger-ui project for more info
         /// </summary>
         /// <param name="value">"none", "list" (default) or "full"</param>

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Template/IndexSettings.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Template/IndexSettings.cs
@@ -12,6 +12,8 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
     {
         public IList<StylesheetDescriptor> Stylesheets { get; private set; } = new List<StylesheetDescriptor>();
 
+        public string DocTitle { get; set; } = "Swagger UI";
+
         public JSConfig JSConfig { get; private set; } = new JSConfig();
 
         public IDictionary<string, string> ToTemplateParameters()
@@ -24,6 +26,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
 
             return new Dictionary<string, string>
             {
+                { "%(DocumentTitle)", DocTitle },
                 { "%(StylesheetsHtml)", GetStylesheetsHtml() },
                 { "%(JSConfig)", GetJSConfigJson() }
             };

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Template/index.html
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Template/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="x-ua-compatible" content="IE=edge">
-  <title>Swagger UI</title>
+  <title>%(DocumentTitle)</title>
   <link rel="icon" type="image/png" href="images/favicon-32x32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="images/favicon-16x16.png" sizes="16x16" />
   <link href='css/typography.css' media='screen' rel='stylesheet' type='text/css'/>

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -16,5 +16,16 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
             Assert.Contains("/ext/custom-script.js", content);
             Assert.Contains("<link href='/ext/custom-stylesheet.css' rel='stylesheet' media='screen' type='text/css' />", content);
         }
+
+        [Fact]
+        public async Task SwaggerUIIndex_PageTitleChanged_IfConfigured()
+        {
+            var client = new TestSite(typeof(CustomUIConfig.Startup)).BuildClient();
+
+            var response = await client.GetAsync("/swagger/");
+            var content = await response.Content.ReadAsStringAsync();
+
+            Assert.Contains("<title>Custom API - Swagger UI</title>", content);
+        }
     }
 }

--- a/test/WebSites/CustomUIConfig/Startup.cs
+++ b/test/WebSites/CustomUIConfig/Startup.cs
@@ -33,6 +33,7 @@ namespace CustomUIConfig
                 c.SupportedSubmitMethods(new[] { "get", "post", "put", "patch" });
                 c.InjectOnCompleteJavaScript("/ext/custom-script.js");
                 c.InjectStylesheet("/ext/custom-stylesheet.css");
+                c.DocumentTitle("Custom API - Swagger UI");
             });
         }
     }


### PR DESCRIPTION
By default, the Swagger UI will have a generic document title (e.g. 'Swagger UI'). When you have multiple Swagger pages open, it can be difficult to tell them apart.