### PR TITLE
Fix #305

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Template/IndexSettings.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Template/IndexSettings.cs
@@ -11,6 +11,9 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         private static readonly JsonSerializerSettings jsConfigSerializationSettings = new JsonSerializerSettings
         {
             ContractResolver = new Newtonsoft.Json.Serialization.DefaultContractResolver()
+            {
+                NamingStrategy = new Newtonsoft.Json.Serialization.DefaultNamingStrategy()
+            }
         };
 
         public IList<StylesheetDescriptor> Stylesheets { get; private set; } = new List<StylesheetDescriptor>();


### PR DESCRIPTION
In case user has overridden `JsonConvert.DefaultSettings` naming strategy (e.g. camelCase, etc.), it needs to be reset here to produce correct window.JSConfig serialized settings.