### PR TITLE
Added document name format

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/Application/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/Application/SwaggerMiddleware.cs
@@ -60,7 +60,7 @@ namespace Swashbuckle.AspNetCore.Swagger
             documentName = null;
             if (request.Method != "GET") return false;
 
-			var routeValues = new RouteValueDictionary();
+            var routeValues = new RouteValueDictionary();
             if (!_requestMatcher.TryMatch(request.Path, routeValues) || !routeValues.ContainsKey("documentName")) return false;
 
             documentName = routeValues["documentName"].ToString();

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Application/SwaggerGenOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Application/SwaggerGenOptions.cs
@@ -43,6 +43,16 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         }
 
         /// <summary>
+        /// Define document name format which depends on value.
+        /// </summary>
+        /// <param name="docNameFormatString">Document name format string</param>
+        public void DocNameFormat(string docNameFormatString)
+        {
+            string.Format(docNameFormatString, 0);
+            _swaggerGeneratorSettings.DocumentNameFormat = docNameFormatString;
+        }
+
+        /// <summary>
         /// Define one or more documents to be created by the Swagger generator
         /// </summary>
         /// <param name="name">A URI-friendly name that uniquely identifies the document</param>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
@@ -25,20 +25,23 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         }
 
         public SwaggerDocument GetSwagger(
-            string documentName,
+            string documentVersion,
             string host = null,
             string basePath = null,
             string[] schemes = null)
         {
             var schemaRegistry = _schemaRegistryFactory.Create();
 
+            var documentNameFormat = _settings.DocumentNameFormat;
+            string documentName = documentNameFormat == null ? documentVersion
+                                                      : string.Format(documentNameFormat, documentVersion);
             Info info;
             if (!_settings.SwaggerDocs.TryGetValue(documentName, out info))
                 throw new UnknownSwaggerDocument(documentName);
 
             var apiDescriptions = _apiDescriptionsProvider.ApiDescriptionGroups.Items
                 .SelectMany(group => group.Items)
-                .Where(apiDesc => _settings.DocInclusionPredicate(documentName, apiDesc))
+                .Where(apiDesc => _settings.DocInclusionPredicate(documentVersion, apiDesc))
                 .Where(apiDesc => !_settings.IgnoreObsoleteActions || !apiDesc.IsObsolete())
                 .OrderBy(_settings.SortKeySelector);
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGeneratorSettings.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGeneratorSettings.cs
@@ -36,6 +36,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public IList<IDocumentFilter> DocumentFilters { get; private set; }
 
+        public string DocumentNameFormat { get; set; }
+
         internal SwaggerGeneratorSettings Clone()
         {
             return new SwaggerGeneratorSettings
@@ -48,7 +50,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 DescribeAllParametersInCamelCase = DescribeAllParametersInCamelCase,
                 SecurityDefinitions = SecurityDefinitions,
                 OperationFilters = OperationFilters,
-                DocumentFilters = DocumentFilters
+                DocumentFilters = DocumentFilters,
+                DocumentNameFormat = DocumentNameFormat
             };
         }
     }


### PR DESCRIPTION
Added ability to set document name format to allow usage like this 
```C#
options.DocNameFormat("Version {0}");

options.SwaggerDoc("Version 1", new Info
{
    Title = "Ha Ha Taxi API version 1",
    Version = "1",
});
```

Which is absolutely logical where name is set to value meaning name and version is set to value meaning version.