### PR TITLE
Fix SecurityRequirementsOperationFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,29 +637,39 @@ services.AddSwaggerGen(c =>
 // SecurityRequirementsOperationFilter.cs
 public class SecurityRequirementsOperationFilter : IOperationFilter
 {
+    private readonly IOptions<AuthorizationOptions> authorizationOptions;
+
+    public SecurityRequirementsOperationFilter(IOptions<AuthorizationOptions> authorizationOptions)
+    {
+        this.authorizationOptions = authorizationOptions;
+    }
+
     public void Apply(Operation operation, OperationFilterContext context)
     {
-        // Policy names map to scopes
-        var controllerScopes = context.ApiDescription.ControllerAttributes()
+        var controllerPolicies = context.ApiDescription.ControllerAttributes()
             .OfType<AuthorizeAttribute>()
             .Select(attr => attr.Policy);
-
-        var actionScopes = context.ApiDescription.ActionAttributes()
+        var actionPolicies = context.ApiDescription.ActionAttributes()
             .OfType<AuthorizeAttribute>()
             .Select(attr => attr.Policy);
+        var policies = controllerPolicies.Union(actionPolicies).Distinct();
+        var requiredClaimTypes = policies
+            .Select(x => this.authorizationOptions.Value.GetPolicy(x))
+            .SelectMany(x => x.Requirements)
+            .OfType<ClaimsAuthorizationRequirement>()
+            .Select(x => x.ClaimType);
 
-        var requiredScopes = controllerScopes.Union(actionScopes).Distinct();
-
-        if (requiredScopes.Any())
+        if (requiredClaimTypes.Any())
         {
             operation.Responses.Add("401", new Response { Description = "Unauthorized" });
             operation.Responses.Add("403", new Response { Description = "Forbidden" });
 
             operation.Security = new List<IDictionary<string, IEnumerable<string>>>();
-            operation.Security.Add(new Dictionary<string, IEnumerable<string>>
-            {
-                { "oauth2", requiredScopes }
-            });
+            operation.Security.Add(
+                new Dictionary<string, IEnumerable<string>>
+                {
+                    { "oauth2", requiredClaimTypes }
+                });
         }
     }
 }


### PR DESCRIPTION
The `SecurityRequirementsOperationFilter` is incorrectly mapping a policy name to claim types, there is a comment about this but it would be much better to map to the actual claim types which we can get quite easily from the AuthorizationOptions which is populated with policies like so:

```
services.AddAuthorization(
    options =>
    {
        options.AddPolicy("ReadPolicy", x => x.RequireClaim("read-customer"));
    });
```