### PR TITLE
Add $ref field to NonBodyParameter

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/Model/SwaggerDocument.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/Model/SwaggerDocument.cs
@@ -226,6 +226,9 @@ namespace Swashbuckle.AspNetCore.Swagger
 
         public bool Required { get; set; }
 
+        [JsonProperty("$ref")]
+        public string Ref { get; set; }
+
         [JsonExtensionData]
         public Dictionary<string, object> Extensions { get; private set; }
     }


### PR DESCRIPTION
Adding the possibility to reference global parameters is the only thing that was missing to better integrate with AutoRest and AspNet Versioning. 
Api Version parameter should be global and referenced by actions so that AutoRest generates a client with implicit version instead of a parameter for each method.