### PR TITLE
Document EmailAddressAttribute with schema.Format = "email"

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaExtensions.cs
@@ -52,6 +52,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     schema.MinLength = stringLength.MinimumLength;
                     schema.MaxLength = stringLength.MaximumLength;
                 }
+                
+                var emailAddress = attribute as EmailAddressAttribute;
+                if (emailAddress != null)
+                    schema.Format = "email";
             }
 
             if (!jsonProperty.Writable)


### PR DESCRIPTION
Adds swagger documentation for the EmailAddressAttribute data annotation by setting the schema format equal to "email".