### PR TITLE
Update SchemaIdManager.cs

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaIdManager.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaIdManager.cs
@@ -26,7 +26,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 if (_schemaIdMap.Any(entry => entry.Value == schemaId))
                     throw new InvalidOperationException(string.Format(
                         "Conflicting schemaIds: Identical schemaIds detected for types {0} and {1}. " +
-                        "See config settings - \"UseFullTypeNameInSchemaIds\" or \"CustomSchemaIds\" for a workaround",
+                        "See config settings - \"CustomSchemaIds\" for a workaround",
                         type.FullName, _schemaIdMap.First(entry => entry.Value == schemaId).Key));
 
                 _schemaIdMap.Add(type, schemaId);


### PR DESCRIPTION
UseFullTypeNameInSchemaIds is not available in the AspNetCore codebase.