### PR TITLE
Update responseattribute to have an overload that uses HttpStatusCode

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/SwaggerResponseAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/SwaggerResponseAttribute.cs
@@ -11,7 +11,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             this.Description = description;
         }
-
+        public SwaggerResponseAttribute(HttpStatusCode statusCode, Type type = null, string description = null)
+            : base(type == null ? typeof(void) : type, (int)statusCode)
+        {
+            this.Description = description;
+        }
         public string Description { get; set; }
     }
 }


### PR DESCRIPTION
just created an overload that takes care of not having to cast statuscode to int every single time 👍 

see https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/461