### PR TITLE
Fsharp option type support

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaRegistry.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaRegistry.cs
@@ -53,6 +53,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private Schema CreateSchema(Type type, Queue<Type> referencedTypes)
         {
+            type = GetUnderlyingType(type);
+
             var jsonContract = _jsonContractResolver.ResolveContract(type);
 
             var createReference = !_settings.CustomTypeMappings.ContainsKey(type)
@@ -107,8 +109,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private Schema CreatePrimitiveSchema(JsonPrimitiveContract primitiveContract)
         {
-            var type = Nullable.GetUnderlyingType(primitiveContract.UnderlyingType)
-                ?? primitiveContract.UnderlyingType;
+            var type = primitiveContract.UnderlyingType;
 
             if (type.GetTypeInfo().IsEnum)
                 return CreateEnumSchema(primitiveContract, type);
@@ -205,6 +206,22 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             };
 
             return schema;
+        }
+
+        /// <summary>
+        /// Unpacks actual type from Nullable-like constructs. When called over
+        /// non-nullable type, it just return it back.
+        /// </summary>
+        private Type GetUnderlyingType(Type type)
+        {
+            // Option<T>
+            if (type.FullNameSansTypeParameters() == "Microsoft.FSharp.Core.FSharpOption`1")
+            {
+                return type.GetGenericArguments().First();
+            }
+
+            // Nullable<T>
+            return Nullable.GetUnderlyingType(type) ?? type;
         }
 
         private static readonly Dictionary<Type, Func<Schema>> PrimitiveTypeMap = new Dictionary<Type, Func<Schema>>

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
@@ -88,6 +88,40 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal("string", schema.Properties["X"].Type);
         }
 
+        [Theory]
+        [InlineData(typeof(short?), "integer", "int32")]
+        [InlineData(typeof(long?), "integer", "int64")]
+        [InlineData(typeof(float?), "number", "float")]
+        [InlineData(typeof(byte?), "string", "byte")]
+        [InlineData(typeof(DateTime?), "string", "date-time")]
+        public void GetOrRegister_ReturnsPrimitiveSchema_ForNullableTypes(
+            Type systemType,
+            string expectedType,
+            string expectedFormat)
+        {
+            var schema = Subject().GetOrRegister(systemType);
+
+            Assert.Equal(expectedType, schema.Type);
+            Assert.Equal(expectedFormat, schema.Format);
+        }
+
+        [Theory]
+        [InlineData(typeof(Microsoft.FSharp.Core.FSharpOption<short>), "integer", "int32")]
+        [InlineData(typeof(Microsoft.FSharp.Core.FSharpOption<long>), "integer", "int64")]
+        [InlineData(typeof(Microsoft.FSharp.Core.FSharpOption<float>), "number", "float")]
+        [InlineData(typeof(Microsoft.FSharp.Core.FSharpOption<byte>), "string", "byte")]
+        [InlineData(typeof(Microsoft.FSharp.Core.FSharpOption<DateTime>), "string", "date-time")]
+        public void GetOrRegister_ReturnsPrimitiveSchema_ForOptionTypes(
+            Type systemType,
+            string expectedType,
+            string expectedFormat)
+        {
+            var schema = Subject().GetOrRegister(systemType);
+
+            Assert.Equal(expectedType, schema.Type);
+            Assert.Equal(expectedFormat, schema.Format);
+        }
+
         [Fact]
         public void GetOrRegister_ReturnsJsonReference_ForComplexTypes()
         {

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.csproj
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="4.2.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />


### PR DESCRIPTION
This should solve issue #471.

I tried to withhold from adding FSharp.Core reference to the project, but it seems useful to me to have it in the test library.

I'm not sure about the version bump to Microsoft.NETCore.Platforms: it helped me to build locally. Otherwise, I got "Detected package downgrade: Microsoft.NETCore.Platforms from 1.1.0 to 1.0.2." error.