### PR TITLE
Removing hard coded reference to Microsoft.NETCore.Platforms

### DIFF
--- a/test/Swashbuckle.AspNetCore.IntegrationTests/Swashbuckle.AspNetCore.IntegrationTests.csproj
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/Swashbuckle.AspNetCore.IntegrationTests.csproj
@@ -31,7 +31,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.0.0" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.0.2" />
     <PackageReference Include="Moq" Version="4.6.25-*" />
   </ItemGroup>
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.csproj
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.csproj
@@ -25,7 +25,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="1.0.0" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.0.2" />
     <PackageReference Include="Moq" Version="4.6.25-*" />
   </ItemGroup>
 


### PR DESCRIPTION
Removes the reference to Microsoft.NETCore.Platforms from the test apps.

Fixes #478 