### PR TITLE
Support to map swagger UI to application root url

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Application/SwaggerUIBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Application/SwaggerUIBuilderExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Builder
             // to inject parameters into "index.html"
             var fileServerOptions = new FileServerOptions
             {
-                RequestPath = $"/{options.RoutePrefix}",
+                RequestPath = string.IsNullOrWhiteSpace(options.RoutePrefix) ? string.Empty : $"/{options.RoutePrefix}",
                 FileProvider = new SwaggerUIFileProvider(options.IndexSettings.ToTemplateParameters()),
                 EnableDefaultFiles = true, // serve index.html at /{options.RoutePrefix}/
             };


### PR DESCRIPTION
UseSwaggerUI will check for special case empty RoutePrefix and allow mapping swagger UI to application root url.