### PR TITLE
Added enum support for DocExpansion in SwaggerUIOptions #513

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Application/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Application/SwaggerUIOptions.cs
@@ -62,9 +62,22 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// Controls how the API listing is displayed. See swagger-ui project for more info
         /// </summary>
         /// <param name="value">"none", "list" (default) or "full"</param>
-        public void DocExpansion(string value)
+        public void DocExpansion(Models.DocExpansion value)
         {
-            IndexSettings.JSConfig.DocExpansion = value;
+            switch (value)
+            {
+                case Models.DocExpansion.None:
+                    IndexSettings.JSConfig.DocExpansion = "none";
+                    break;
+                case Models.DocExpansion.List:
+                    IndexSettings.JSConfig.DocExpansion = "list";
+                    break;
+                case Models.DocExpansion.Full:
+                    IndexSettings.JSConfig.DocExpansion = "full";
+                    break;
+                default:
+                    break;
+            }
         }
 
         /// <summary>

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Application/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Application/SwaggerUIOptions.cs
@@ -61,7 +61,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// <summary>
         /// Controls how the API listing is displayed. See swagger-ui project for more info
         /// </summary>
-        /// <param name="value">"none", "list" (default) or "full"</param>
+        /// <param name="value">DocExpansion Type (None, List, Full)</param>
         public void DocExpansion(Models.DocExpansion value)
         {
             switch (value)

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Model/DocExpansion.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Model/DocExpansion.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Swashbuckle.AspNetCore.SwaggerUI.Models
+{
+    public enum DocExpansion
+    {
+        None,
+        List,
+        Full
+    }
+}

--- a/test/WebSites/CustomUIConfig/Startup.cs
+++ b/test/WebSites/CustomUIConfig/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Swashbuckle.AspNetCore.Swagger;
+using Swashbuckle.AspNetCore.SwaggerUI.Models;
 
 namespace CustomUIConfig
 {
@@ -29,7 +30,7 @@ namespace CustomUIConfig
                 c.SwaggerEndpoint("/swagger/v1/swagger.json", "V1 Docs");
                 c.EnabledValidator();
                 c.BooleanValues(new object[] { 0, 1 });
-                c.DocExpansion("full");
+                c.DocExpansion(DocExpansion.Full);
                 c.SupportedSubmitMethods(new[] { "get", "post", "put", "patch" });
                 c.InjectOnCompleteJavaScript("/ext/custom-script.js");
                 c.InjectStylesheet("/ext/custom-stylesheet.css");


### PR DESCRIPTION
- Created `DocExpansion` enum for more intuitive and fool-proof setting of DocExpansion type in Swagger UI

Usage of the DocExpansion functionality will now look like the following:
```
c.DocExpansion(DocExpansion.None); //Instead of c.DocExpansion("none")
c.DocExpansion(DocExpansion.List); //Instead of c.DocExpansion("list")
c.DocExpansion(DocExpansion.Full); //Instead of c.DocExpansion("full")
```