### PR TITLE
Removed ByteOrderMark from .json response

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/Application/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/Application/SwaggerMiddleware.cs
@@ -72,7 +72,7 @@ namespace Swashbuckle.AspNetCore.Swagger
             response.StatusCode = 200;
             response.ContentType = "application/json";
 
-            using (var writer = new StreamWriter(response.Body, Encoding.UTF8, 1024, true))
+            using (var writer = new StreamWriter(response.Body, new UTF8Encoding(false), 1024, true))
             {
                 _swaggerSerializer.Serialize(writer, swagger);
             }


### PR DESCRIPTION
Removes the BOM from the response as a BOM is not required and not recommended for UTF-8 (https://stackoverflow.com/a/2223926/5173536)

@domaindrivendev I've modified the integrationTests to check for the absence of a BOM and all are passing locally. Let me know if you want me to change some things.

Fixes #574 