### PR TITLE
Generate schema / references for enum action parameters #358

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaExtensions.cs
@@ -87,6 +87,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             partialSchema.UniqueItems = schema.UniqueItems;
             partialSchema.Enum = schema.Enum;
             partialSchema.MultipleOf = schema.MultipleOf;
+
+            var nonBodyParam = partialSchema as NonBodyParameter;
+            if (nonBodyParam != null)
+                nonBodyParam.Ref = schema.Ref;
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaRegistry.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaRegistry.cs
@@ -62,7 +62,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     // Type is self-referencing
                     jsonContract.IsSelfReferencingArrayOrDictionary() ||
                     // Enums are strings and type describes an enum
-                    (_settings.DescribeAllEnumsAsStrings && type.IsEnumType()));
+                    type.IsEnumType());
 
             return createReference
                 ? CreateReferenceSchema(type, referencedTypes)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaRegistry.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaRegistry.cs
@@ -57,7 +57,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             var createReference = !_settings.CustomTypeMappings.ContainsKey(type)
                 && type != typeof(object)
-                && (jsonContract is JsonObjectContract || jsonContract.IsSelfReferencingArrayOrDictionary());
+                && (// Type describes an object
+                    jsonContract is JsonObjectContract ||
+                    // Type is self-referencing
+                    jsonContract.IsSelfReferencingArrayOrDictionary() ||
+                    // Enums are strings and type describes an enum
+                    (_settings.DescribeAllEnumsAsStrings && type.IsEnumType()));
 
             return createReference
                 ? CreateReferenceSchema(type, referencedTypes)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
@@ -192,7 +192,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             if (schema == null)
                 nonBodyParam.Type = "string";
             else
+            {
                 nonBodyParam.PopulateFrom(schema);
+
+                if (schema.Ref != null)
+                    nonBodyParam.Ref = schema.Ref;
+            }
 
             if (nonBodyParam.Type == "array")
                 nonBodyParam.CollectionFormat = "multi";

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
@@ -192,12 +192,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             if (schema == null)
                 nonBodyParam.Type = "string";
             else
-            {
                 nonBodyParam.PopulateFrom(schema);
-
-                if (schema.Ref != null)
-                    nonBodyParam.Ref = schema.Ref;
-            }
 
             if (nonBodyParam.Type == "array")
                 nonBodyParam.CollectionFormat = "multi";

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
@@ -320,9 +320,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var subject = Subject(c => c.DescribeAllEnumsAsStrings = true);
 
             var schema = subject.GetOrRegister(typeof(AnEnum));
-
-            Assert.Equal("string", schema.Type);
-            Assert.Equal(new[] { "Value1", "Value2", "X" }, schema.Enum);
+            Assert.Equal("#/definitions/AnEnum", schema.Ref);
+            Assert.Equal(new[] { "Value1", "Value2", "X" }, subject.Definitions["AnEnum"].Enum);
         }
 
         [Fact]
@@ -336,8 +335,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var schema = subject.GetOrRegister(typeof(AnEnum));
 
-            Assert.Equal("string", schema.Type);
-            Assert.Equal(new[] { "value1", "value2", "x" }, schema.Enum);
+            Assert.Equal("#/definitions/AnEnum", schema.Ref);
+            Assert.Equal(new[] { "value1", "value2", "x" }, subject.Definitions["AnEnum"].Enum);
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
@@ -44,11 +44,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [Fact]
         public void GetOrRegister_ReturnsEnumSchema_ForEnumTypes()
         {
-            var schema = Subject().GetOrRegister(typeof(AnEnum));
-            Assert.Equal("integer", schema.Type);
-            Assert.Equal("int32", schema.Format);
-            Assert.Contains(AnEnum.Value1, schema.Enum);
-            Assert.Contains(AnEnum.Value2, schema.Enum);
+            var subject = Subject();
+            var schema = subject.GetOrRegister(typeof(AnEnum));
+            Assert.Equal("#/definitions/AnEnum", schema.Ref);
+            Assert.Contains(AnEnum.Value1, subject.Definitions["AnEnum"].Enum);
+            Assert.Contains(AnEnum.Value2, subject.Definitions["AnEnum"].Enum);
         }
 
         [Theory]
@@ -234,10 +234,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [Fact]
         public void GetOrRegister_HonorsStringEnumConverters_ConfiguredViaAttributes()
         {
-            var schema = Subject().GetOrRegister(typeof(JsonConvertedEnum));
+            var subject = Subject();
+            var schema = subject.GetOrRegister(typeof(JsonConvertedEnum));
 
-            Assert.Equal("string", schema.Type);
-            Assert.Equal(new[] { "Value1", "Value2", "X" }, schema.Enum);
+            Assert.Equal("#/definitions/JsonConvertedEnum", schema.Ref);
+            Assert.Equal(new[] { "Value1", "Value2", "X" }, subject.Definitions["JsonConvertedEnum"].Enum);
         }
 
         [Fact]
@@ -250,8 +251,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var schema = subject.GetOrRegister(typeof(AnEnum));
 
-            Assert.Equal("string", schema.Type);
-            Assert.Equal(new[] { "value1", "value2", "x" }, schema.Enum);
+            Assert.Equal("#/definitions/AnEnum", schema.Ref);
+            Assert.Equal(new[] { "value1", "value2", "x" }, subject.Definitions["AnEnum"].Enum);
         }
 
         [Fact]

--- a/test/WebSites/Basic/Controllers/EnumParamsController.cs
+++ b/test/WebSites/Basic/Controllers/EnumParamsController.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Basic.Controllers
+{
+    [Route("/enumparams")]
+    [Produces("application/json")]
+    public class EnumParamsController
+    {
+        /// <summary>
+        /// Retrieve all products matching the input status
+        /// </summary>
+        /// <param name="status">Status filter for products</param>
+        /// <returns>List of matching products</returns>
+        [HttpGet]
+        public List<Product> ProductsByStatus(ProductStatus status = ProductStatus.All) =>
+            new List<Product>();
+    }
+}

--- a/test/WebSites/Basic/Startup.cs
+++ b/test/WebSites/Basic/Startup.cs
@@ -48,6 +48,7 @@ namespace Basic
                 c.OperationFilter<AssignOperationVendorExtensions>();
                 c.OperationFilter<FormDataOperationFilter>();
 
+                c.DescribeAllEnumsAsStrings();
                 //c.DescribeAllParametersInCamelCase();
             });
 


### PR DESCRIPTION
This basically changes the behavior of `DescribeAllEnumsAsStrings` for Enum types to generate a `Ref` for the parameter rather than generate the supported values inline.

Addresses #358