### PR TITLE
Makes configure actions optional.

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Application/SwaggerGenServiceCollectionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Application/SwaggerGenServiceCollectionExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static IServiceCollection AddSwaggerGen(
             this IServiceCollection services,
-            Action<SwaggerGenOptions> setupAction)
+            Action<SwaggerGenOptions> setupAction = null)
         {
             services.Configure<MvcOptions>(c =>
                 c.Conventions.Add(new SwaggerApplicationConvention()));
@@ -24,9 +24,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static void ConfigureSwaggerGen(
             this IServiceCollection services,
-            Action<SwaggerGenOptions> setupAction)
+            Action<SwaggerGenOptions> setupAction = null)
         {
-            services.Configure(setupAction);
+            services.Configure(setupAction ?? (opts => { }));
         }
 
         private static ISwaggerProvider CreateSwaggerProvider(IServiceProvider serviceProvider)

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Application/SwaggerUIBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Application/SwaggerUIBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Builder
 
         public static IApplicationBuilder UseSwaggerUI(
             this IApplicationBuilder app,
-            Action<SwaggerUIOptions> setupAction)
+            Action<SwaggerUIOptions> setupAction = null)
         {
             var options = new SwaggerUIOptions();
             setupAction?.Invoke(options);


### PR DESCRIPTION
Configuration may be fetched via other sources like this:

```
services.AddSingleton<IConfigureOptions<SwaggerGenOptions>, MySwaggerOptionsConfigurator>();
services.AddSingleton<IConfigureOptions<SwaggerUIOptions>, MySwaggerOptionsConfigurator>();
```

Then the Action is really "dont-care". As it is now, I have to provide an empty lambda :/