### PR TITLE
Force JsonConvert not to use formatting

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIIndexMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIIndexMiddleware.cs
@@ -59,8 +59,8 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
             {
                 { "%(DocumentTitle)", _options.DocumentTitle },
                 { "%(HeadContent)", _options.HeadContent },
-                { "%(ConfigObject)", JsonConvert.SerializeObject(_options.ConfigObject) },
-                { "%(OAuthConfigObject)", JsonConvert.SerializeObject(_options.OAuthConfigObject) }
+                { "%(ConfigObject)", JsonConvert.SerializeObject(_options.ConfigObject, Formatting.None) },
+                { "%(OAuthConfigObject)", JsonConvert.SerializeObject(_options.OAuthConfigObject, Formatting.None) }
             };
         }
     }


### PR DESCRIPTION
If the application has default `JsonConvert` options configured as following, the Swagger-UI completely fails to load:

```csharp
JsonConvert.DefaultSettings = () => new JsonSerializerSettings
{
    Formatting = Formatting.Indented
};
```

This happens because the generated configuration object looks like this:

```javascript
  window.onload = function () {
    var configObject = JSON.parse('{
  "urls": [
    {
      "url": "/swagger/v1/swagger.json",
      "name": "v1"
    }
  ],
  "validatorUrl": null
}');
```

That is, the generated configuration contains new lines, which breaks the JavaScript with `SyntaxError: unterminated string literal` error.

Passing `Formatting.None` to `JsonConvert.SerializeObject` should ensure Swagger-UI does not depend on the external configuration and in turn does not break if the `Indented` formatting is used.