### PR TITLE
Don't create a new ISwaggerProvider on every resolution (address #541)

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Application/SwaggerGenServiceCollectionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Application/SwaggerGenServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.Configure(setupAction ?? (opts => { }));
 
-            services.AddTransient(CreateSwaggerProvider);
+            services.AddSingleton(CreateSwaggerProvider);
 
             return services;
         }


### PR DESCRIPTION
The existing behavior has AddSwaggerGen() register the SwaggerGenerator
as a transient; every resolution of ISwaggerProvider generates a new
instance. Each creation causes all Document, Operation, and Schema
filters to be registered again.

This is slow, and requires that filters check before adding an extension
to avoid generating exceptions.

This may address a problem I encountered and reported in #541 