### PR TITLE
Honor BindRequired and BindNever attributes

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/ApiParameterDescriptionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/ApiParameterDescriptionExtensions.cs
@@ -21,7 +21,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 return !parameterDescription.RouteInfo.IsOptional;
 
             if (parameterDescription.ModelMetadata != null)
-                return parameterDescription.ModelMetadata.IsRequired;
+                return (parameterDescription.ModelMetadata.IsRequired || parameterDescription.ModelMetadata.IsBindingRequired);
 
             return false;
         }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/JsonPropertyExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/JsonPropertyExtensions.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Newtonsoft.Json.Serialization;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
@@ -13,12 +14,18 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             return jsonProperty.Required == Newtonsoft.Json.Required.AllowNull
                 || jsonProperty.Required == Newtonsoft.Json.Required.Always
-                || jsonProperty.HasAttribute<RequiredAttribute>();
+                || jsonProperty.HasAttribute<RequiredAttribute>()
+                || jsonProperty.HasAttribute<BindRequiredAttribute>();
         }
 
         internal static bool IsObsolete(this JsonProperty jsonProperty)
         {
             return jsonProperty.HasAttribute<ObsoleteAttribute>();
+        }
+
+        internal static bool BindNever(this JsonProperty jsonProperty)
+        {
+            return jsonProperty.HasAttribute<BindNeverAttribute>();
         }
 
         internal static bool HasAttribute<T>(this JsonProperty jsonProperty)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaRegistry.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaRegistry.cs
@@ -204,7 +204,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private Schema CreateObjectSchema(JsonObjectContract jsonContract, Queue<Type> referencedTypes)
         {
             var applicableJsonProperties = jsonContract.Properties
-                .Where(prop => !prop.Ignored)
+                .Where(prop => !prop.Ignored && !prop.BindNever())
                 .Where(prop => !(_settings.IgnoreObsoleteProperties && prop.IsObsolete()))
                 .Select(prop => prop);
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaExtensions.cs
@@ -17,7 +17,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             foreach (var attribute in propInfo.GetCustomAttributes(false))
             {
-
                 var defaultValue = attribute as DefaultValueAttribute;
                 if (defaultValue != null)
                     schema.Default = defaultValue.Value;

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
@@ -109,6 +109,21 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
+        public void GetOrRegister_DefinesObjectSchema_ForBindingTypes()
+        {
+            var subject = Subject();
+
+            subject.GetOrRegister(typeof(BindingType));
+
+            var schema = subject.Definitions["BindingType"];
+            Assert.NotNull(schema);
+            Assert.Equal("string", schema.Properties["Property1"].Type);
+            Assert.False(schema.Properties.ContainsKey("Property2"));
+            Assert.Equal("string", schema.Properties["Property3"].Type);
+            Assert.Equal(new[] { "Property3" }, schema.Required.ToArray());
+        }
+
+        [Fact]
         public void GetOrRegister_DefinesObjectSchema_ForComplexTypes()
         {
             var subject = Subject();

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SwaggerGeneratorTests.cs
@@ -601,6 +601,20 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Null(operation.Parameters); // first one has no parameters
         }
 
+        [Fact(Skip = "It will work in ASP.NET Core 2.1")]
+        public void GetSwagger_SetsRequiredParameter_ForRequireAndBindRequireAttributes()
+        {
+            var subject = Subject(setupApis: apis => apis
+                .Add("GET", "collection", nameof(FakeActions.AcceptsRequiredParameters)));
+
+            var swagger = subject.GetSwagger("v1");
+
+            var operation = swagger.Paths["/collection"].Get;
+            Assert.NotNull(operation.Parameters);
+            Assert.NotNull(operation.Parameters[0]);
+            Assert.True(operation.Parameters[0].Required);
+        }
+
         private SwaggerGenerator Subject(
             Action<FakeApiDescriptionGroupCollectionProvider> setupApis = null,
             Action<SwaggerGeneratorSettings> configure = null)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Fakes/FakeActions.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Fakes/FakeActions.cs
@@ -86,6 +86,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void AcceptsGenericType(IEnumerable<string> param1)
         {}
 
+        public void AcceptsRequiredParameters([Required] string queryParam)
+        { }
+
         public void AcceptsGenericGenericType(IEnumerable<KeyValuePair<string, string>> param1)
         {}
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Types/BindingType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Types/BindingType.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test
+{
+    public class BindingType
+    {
+        public string Property1 { get; set; }
+
+        [BindNever]
+        public string Property2 { get; set; }
+
+        [BindRequired]
+        public string Property3 { get; set; }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/661 and adds support for BindRequired and BindNever attributes for models
```C#
public class BindingType
{
    public string Property1 { get; set; }

    [BindNever]
    public string Property2 { get; set; }

    [BindRequired]
    public string Property3 { get; set; }
}
```

It also should work for action's parameters (but only in ASP.NET Core 2.1 preview-2 and higher)
```C#
public void AcceptsRequiredParameters([Required, BindRequired] string queryParam) { }
```