### PR TITLE
Generic parameter in generic base controller - part of issue #730

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/XmlCommentsMemberNameHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/XmlCommentsMemberNameHelper.cs
@@ -7,13 +7,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     public class XmlCommentsMemberNameHelper
     {
-        public static string GetMemberNameForMethod(MethodInfo method)
+        public static string GetMemberNameForMethod(MethodInfo method, Type[] inputParametersTypes)
         {
             var builder = new StringBuilder("M:");
 
             // If method is from a constructed generic type, use the generic type
             var sourceMethod = method.DeclaringType.IsConstructedGenericType
-                ? method.DeclaringType.GetGenericTypeDefinition().GetMethod(method.Name)
+                ? method.DeclaringType.GetGenericTypeDefinition().GetMethods().FirstOrDefault(x => x.Name == method.Name && x.GetParameters().Select(p => p.ParameterType).SequenceEqual(inputParametersTypes))
                 : method;
 
             builder.Append(sourceMethod.DeclaringType.FullNameSansTypeArguments().Replace("+", "."));

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/XmlCommentsMemberNameHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/XmlCommentsMemberNameHelper.cs
@@ -7,19 +7,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     public class XmlCommentsMemberNameHelper
     {
-        public static string GetMemberNameForMethod(MethodInfo method, Type[] inputParametersTypes)
+        public static string GetMemberNameForMethod(MethodInfo method)
         {
             var builder = new StringBuilder("M:");
 
-            // If method is from a constructed generic type, use the generic type
-            var sourceMethod = method.DeclaringType.IsConstructedGenericType
-                ? method.DeclaringType.GetGenericTypeDefinition().GetMethods().FirstOrDefault(x => x.Name == method.Name && x.GetParameters().Select(p => p.ParameterType).SequenceEqual(inputParametersTypes))
-                : method;
+            builder.Append(method.DeclaringType.FullNameSansTypeArguments().Replace("+", "."));
+            builder.Append($".{method.Name}");
 
-            builder.Append(sourceMethod.DeclaringType.FullNameSansTypeArguments().Replace("+", "."));
-            builder.Append($".{sourceMethod.Name}");
-
-            var parameters = sourceMethod.GetParameters();
+            var parameters = method.GetParameters();
             if (parameters.Any())
             {
                 var tokens = parameters.Select(p =>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/XmlCommentsOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/XmlCommentsOperationFilter.cs
@@ -29,7 +29,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             var controllerActionDescriptor = context.ApiDescription.ActionDescriptor as ControllerActionDescriptor;
             if (controllerActionDescriptor == null) return;
 
-            var memberName = XmlCommentsMemberNameHelper.GetMemberNameForMethod(controllerActionDescriptor.MethodInfo);
+            var memberName = XmlCommentsMemberNameHelper.GetMemberNameForMethod(controllerActionDescriptor.MethodInfo, controllerActionDescriptor.Parameters.Select(x => x.ParameterType).ToArray());
             var methodNode = _xmlNavigator.SelectSingleNode(string.Format(MemberXPath, memberName));
 
             if (methodNode != null)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/XmlCommentsOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/XmlCommentsOperationFilter.cs
@@ -29,7 +29,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             var controllerActionDescriptor = context.ApiDescription.ActionDescriptor as ControllerActionDescriptor;
             if (controllerActionDescriptor == null) return;
 
-            var memberName = XmlCommentsMemberNameHelper.GetMemberNameForMethod(controllerActionDescriptor.MethodInfo, controllerActionDescriptor.Parameters.Select(x => x.ParameterType).ToArray());
+            var memberName = XmlCommentsMemberNameHelper.GetMemberNameForMethod(controllerActionDescriptor.MethodInfo);
             var methodNode = _xmlNavigator.SelectSingleNode(string.Format(MemberXPath, memberName));
 
             if (methodNode != null)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/TypeExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/TypeExtensions.cs
@@ -9,6 +9,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     {
         internal static string FullNameSansTypeArguments(this Type type)
         {
+            if (string.IsNullOrEmpty(type.FullName))
+            {
+                return string.Empty;
+            }
+
             var fullName = type.FullName;
             var chopIndex = fullName.IndexOf("[[");
             return (chopIndex == -1) ? fullName : fullName.Substring(0, chopIndex);

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Annotations/XmlCommentsMemberNameHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Annotations/XmlCommentsMemberNameHelperTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -25,7 +26,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [InlineData(typeof(XmlAnnotatedType), "AcceptsArrayOfConstructedGenericType",
             "M:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedType.AcceptsArrayOfConstructedGenericType(System.Nullable{System.Int32}[])")]
         [InlineData(typeof(XmlAnnotatedGenericType<int,string>), "AcceptsTypeParameters",
-            "M:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedGenericType`2.AcceptsTypeParameters(System.Int32,`0,`1)")]
+            "M:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedGenericType`2.AcceptsTypeParameters(System.Int32,System.Int32,System.String)")]
         public void GetMemberNameForMethod_ReturnsCorrectXmlCommentsMemberName_ForGivenMethodInfo(
             Type declaringType, 
             string name,


### PR DESCRIPTION
Checking if the full name of the type is null before trying to use it to get the name without the type arguments. When using generic parameters in generic base controllers, this is needed because they get here with null full names.

Also added fix for multiple methods with the same name in generic base controllers. Not selecting the source method differently for generic types anymore because it doesn't seem to be needed. From initial tests, the value gets selected correctly from the XML documentation file.

Fixed #730