### PR TITLE
set charset=utf-8 for swagger.json content-type

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/Application/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/Application/SwaggerMiddleware.cs
@@ -70,7 +70,7 @@ namespace Swashbuckle.AspNetCore.Swagger
         private async Task RespondWithSwaggerJson(HttpResponse response, SwaggerDocument swagger)
         {
             response.StatusCode = 200;
-            response.ContentType = "application/json";
+            response.ContentType = "application/json;charset=utf-8";
 
             var jsonBuilder = new StringBuilder();
             using (var writer = new StringWriter(jsonBuilder))


### PR DESCRIPTION
Fix #384 

It provides an ability to correctly display commentaries in foreign languages (Russian, for instance) in swagger.json