### PR TITLE
Include .map files from swagger-ui-dist to prevent 404s

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="index.html" />
-    <EmbeddedResource Include="node_modules/swagger-ui-dist/**/*" Exclude="node_modules/swagger-ui-dist/**/*.map;node_modules/swagger-ui-dist/index.html" />
+    <EmbeddedResource Include="node_modules/swagger-ui-dist/**/*" Exclude="node_modules/swagger-ui-dist/index.html" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Chrome dev tools send requests for the `.map` files for the bundled css and js files from swagger-ui-dist. If those are included via swashbuckle, it would prevent the 404s on the server hosting the Swagger UI.