### PR TITLE
Add link to Swashbuckle.AspNetCore.Filters in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,14 @@ Additionally, there's add-on packages (CLI tools, [an alternate UI](https://gith
 |Swashbuckle.AspNetCore.Annotations|Includes a set of custom attributes that can be applied to controllers, actions and models to enrich the generated Swagger|
 |Swashbuckle.AspNetCore.Cli (Beta)|Provides a CLI interface for retrieving Swagger directly from a startup assembly, and writing to file|
 |Swashbuckle.AspNetCore.ReDoc|Exposes an embedded version of the ReDoc UI (an alternative to swagger-ui)|
-|[Swashbuckle.AspNetCore.Filters](https://github.com/mattfrear/Swashbuckle.AspNetCore.Filters)| Some useful 3rd party filters which add additional documentation, e.g. request and response examples |
+
+## Community Packages ##
+
+These packages are provided by the open-source community.
+
+|Package|Description|
+|---------|-----------|
+|[Swashbuckle.AspNetCore.Filters](https://github.com/mattfrear/Swashbuckle.AspNetCore.Filters)| Some useful Swashbuckle filters which add additional documentation, e.g. request and response examples, a file upload button, etc. See its Readme for more details |
 
 # Configuration & Customization #
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Additionally, there's add-on packages (CLI tools, [an alternate UI](https://gith
 |Swashbuckle.AspNetCore.Annotations|Includes a set of custom attributes that can be applied to controllers, actions and models to enrich the generated Swagger|
 |Swashbuckle.AspNetCore.Cli (Beta)|Provides a CLI interface for retrieving Swagger directly from a startup assembly, and writing to file|
 |Swashbuckle.AspNetCore.ReDoc|Exposes an embedded version of the ReDoc UI (an alternative to swagger-ui)|
+|[Swashbuckle.AspNetCore.Filters](https://github.com/mattfrear/Swashbuckle.AspNetCore.Filters)| Some useful 3rd party filters which add additional documentation, e.g. request and response examples |
 
 # Configuration & Customization #
 


### PR DESCRIPTION
Hello

I am the maintainer of Swashbuckle.Examples and Swashbuckle.AspNetCore.Filters (was Swashbuckle.AspNetCore.Examples), two small packages which contain a few Swashbuckle OperationFilters I have written and find useful, and apparently others find useful too as they get around 300 downloads per day.

Is it cheeky of me to add a link to my package in your readme?