### PR TITLE
MinimumAttribute / MaximumAttribute with tests

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Attributes/MaximumAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Attributes/MaximumAttribute.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen
+{
+    /// <summary>
+    /// Adds a maximum value to a given property
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class MaximumAttribute : Attribute
+    {
+        public MaximumAttribute(int maximum)
+        {
+            Maximum = maximum;
+        }
+
+        /// <summary>
+        /// The maximum value for the decorated property.
+        /// </summary>
+        public readonly int Maximum;
+    }
+}

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Attributes/MinimumAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Attributes/MinimumAttribute.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen
+{
+    /// <summary>
+    /// Adds a minimum value to a given property
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class MinimumAttribute : Attribute
+    {
+        public MinimumAttribute(int minimum)
+        {
+            Minimum = minimum;
+        }
+
+        /// <summary>
+        /// The minimum value for the decorated property.
+        /// </summary>
+        public readonly int Minimum;
+    }
+}

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaExtensions.cs
@@ -18,13 +18,19 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 if (attribute is RegularExpressionAttribute regex)
                     schema.Pattern = regex.Pattern;
 
+                if (attribute is MinimumAttribute minimum)
+                    schema.Minimum = minimum.Minimum;
+
+                if (attribute is MaximumAttribute maximum)
+                    schema.Maximum = maximum.Maximum;
+
                 if (attribute is RangeAttribute range)
                 {
-                    if (Int32.TryParse(range.Maximum.ToString(), out int maximum))
-                        schema.Maximum = maximum;
+                    if (Int32.TryParse(range.Maximum.ToString(), out int max))
+                        schema.Maximum = max;
 
-                    if (Int32.TryParse(range.Minimum.ToString(), out int minimum))
-                        schema.Minimum = minimum;
+                    if (Int32.TryParse(range.Minimum.ToString(), out int min))
+                        schema.Minimum = min;
                 }
 
                 if (attribute is MinLengthAttribute minLength)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
@@ -250,6 +250,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var schema = subject.Definitions["DataAnnotatedType"];
             Assert.Equal(1, schema.Properties["IntWithRange"].Minimum);
             Assert.Equal(12, schema.Properties["IntWithRange"].Maximum);
+            Assert.Equal(1, schema.Properties["IntWithMinimum"].Minimum);
+            Assert.Equal(12, schema.Properties["IntWithMaximum"].Maximum);
             Assert.Equal("^[3-6]?\\d{12,15}$", schema.Properties["StringWithRegularExpression"].Pattern);
             Assert.Equal(5, schema.Properties["StringWithStringLength"].MinLength);
             Assert.Equal(10, schema.Properties["StringWithStringLength"].MaxLength);
@@ -272,6 +274,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var schema = subject.Definitions["MetadataAnnotatedType"];
             Assert.Equal(1, schema.Properties["IntWithRange"].Minimum);
             Assert.Equal(12, schema.Properties["IntWithRange"].Maximum);
+            Assert.Equal(1, schema.Properties["IntWithMinimum"].Minimum);
+            Assert.Equal(12, schema.Properties["IntWithMaximum"].Maximum);
             Assert.Equal("^[3-6]?\\d{12,15}$", schema.Properties["StringWithRegularExpression"].Pattern);
             Assert.Equal(new[] { "StringWithRequired", "IntWithRequired" }, schema.Required.ToArray());
         }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Types/DataAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Types/DataAnnotatedType.cs
@@ -13,6 +13,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [Required]
         public int IntWithRequired { get; set; }
 
+        [Minimum(1)]
+        public int IntWithMinimum { get; set; }
+
+        [Maximum(12)]
+        public int IntWithMaximum { get; set; }
+
         [Range(1, 12)]
         public int IntWithRange { get; set; }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Types/MetadataAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Types/MetadataAnnotatedType.cs
@@ -10,6 +10,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
         public int IntWithRequired { get; set; }
 
+        public int IntWithMinimum { get; set; }
+
+        public int IntWithMaximum { get; set; }
+
         public int IntWithRange { get; set; }
 
         public string StringWithRegularExpression { get; set; }
@@ -22,6 +26,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
         [Required]
         public int IntWithRequired { get; set; }
+
+        [Minimum(1)]
+        public int IntWithMinimum { get; set; }
+
+        [Maximum(12)]
+        public int IntWithMaximum { get; set; }
 
         [Range(1, 12)]
         public int IntWithRange { get; set; }


### PR DESCRIPTION
these attributes were added to address the situation where sometimes it makes sense to specify one bound without the other.

An example that drove me to do this is pagination. I want the user to specify a `pageIndex` which has a minimum of 1, but no logical maximum due to an unknown quantity of data.