### PR TITLE
Support form file parameters

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/Model/SwaggerDocument.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/Model/SwaggerDocument.cs
@@ -213,11 +213,6 @@ namespace Swashbuckle.AspNetCore.Swagger
 
     public class NonBodyParameter : PartialSchema, IParameter
     {
-        public NonBodyParameter()
-        {
-            Extensions = new Dictionary<string, object>();
-        }
-
         public string Name { get; set; }
 
         public string In { get; set; }
@@ -225,9 +220,6 @@ namespace Swashbuckle.AspNetCore.Swagger
         public string Description { get; set; }
 
         public bool Required { get; set; }
-
-        [JsonExtensionData]
-        public Dictionary<string, object> Extensions { get; private set; }
     }
 
     public class Schema

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/ApiParameterDescriptionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/ApiParameterDescriptionExtensions.cs
@@ -8,16 +8,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     public static class ApiParameterDescriptionExtensions
     {
-        public static bool IsPartOfCancellationToken(this ApiParameterDescription parameterDescription)
-        {
-            if (parameterDescription.Source != BindingSource.ModelBinding) return false;
-
-            var name = parameterDescription.Name;
-            return name == "CanBeCanceled"
-                || name == "IsCancellationRequested"
-                || name.StartsWith("WaitHandle.");
-        }
-
         internal static bool TryGetParameterInfo(
             this ApiParameterDescription apiParameterDescription,
             ApiDescription apiDescription,

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaExtensions.cs
@@ -61,6 +61,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 // TODO: Handle jagged primitive array and error on jagged object array
                 partialSchema.Items = new PartialSchema();
                 partialSchema.Items.PopulateFrom(schema.Items);
+                partialSchema.CollectionFormat = "multi";
             }
 
             partialSchema.Default = schema.Default;

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Fakes/FakeApiDescriptionGroupCollectionProvider.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Fakes/FakeApiDescriptionGroupCollectionProvider.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Collections.ObjectModel;
 using System.Reflection;
 using System.Buffers;
+using System.Threading;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Routing;
@@ -19,11 +20,12 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Mvc.Internal;
 using Microsoft.AspNetCore.Mvc.DataAnnotations.Internal;
-using Moq;
-using Newtonsoft.Json;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.AspNetCore.Mvc.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Newtonsoft.Json;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
@@ -139,7 +141,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 new DefaultValidationMetadataProvider(),
                 new DataAnnotationsMetadataProvider(
                     Options.Create(new MvcDataAnnotationsLocalizationOptions()),
-                    null)
+                    null),
+                new BindingSourceMetadataProvider(typeof(CancellationToken), BindingSource.Special),
+                new BindingSourceMetadataProvider(typeof(IFormFile), BindingSource.FormFile),
+                new BindingSourceMetadataProvider(typeof(IFormFileCollection), BindingSource.FormFile),
+                new BindingSourceMetadataProvider(typeof(IEnumerable<IFormFile>), BindingSource.FormFile)
             };
 
             var compositeDetailsProvider = new DefaultCompositeMetadataDetailsProvider(detailsProviders);

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Fakes/FakeController.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Fakes/FakeController.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
-using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json.Linq;
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json.Linq;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
@@ -46,11 +47,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void AcceptsComplexType(ComplexType param)
         { }
 
-        public void AcceptsModelBoundParams(string stringWithNoAttributes)
+        public void AcceptsBindingAnnotatedParams(string stringWithNoAttributes)
         { }
 
         // Use this version when https://github.com/aspnet/Mvc/issues/7435 is resolved
-        //public void AcceptsModelBoundParams(
+        //public void AcceptsBindingAnnotatedParams(
         //    string stringWithNoAttributes,
         //    [BindRequired]string stringWithBindRequired)
         //    [BindRequired]int intWithBindRequired)
@@ -63,7 +64,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             [Required]int intWithRequired)
         { }
 
-        public void AcceptsModelBoundType(ModelBoundType param)
+        public void AcceptsBindingAnnotatedType(BindingAnnotatedType param)
         { }
 
         public void AcceptsDataAnnotatedType(DataAnnotatedType param)
@@ -91,6 +92,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         { }
 
         public void AcceptsComplexTypeFromBody([FromBody]ComplexType param)
+        { }
+
+        public void AcceptsIFormFile(IFormFile formFile)
         { }
 
         public void AcceptsCancellationToken(CancellationToken cancellationToken)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Types/BindingAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Types/BindingAnnotatedType.cs
@@ -2,7 +2,7 @@
 
 namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
-    public class ModelBoundType
+    public class BindingAnnotatedType
     {
         public string StringWithNoAttributes { get; set; }
 

--- a/test/WebSites/Basic/Controllers/FileUploadsController.cs
+++ b/test/WebSites/Basic/Controllers/FileUploadsController.cs
@@ -1,0 +1,28 @@
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Basic.Controllers
+{
+    public class FileUploadsController
+    {
+        [HttpPost("file")]
+        public IActionResult PostFile(IFormFile file)
+        {
+            throw new NotImplementedException();
+        }
+
+        [HttpPost("form-with-file")]
+        public IActionResult PostFormWithFile(FormWithFile formWithFile)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class FormWithFile
+    {
+        public string Name { get; set; }
+
+        public IFormFile File { get; set; }
+    }
+}


### PR DESCRIPTION
Addresses #193 by generating a correct description (e.g. in=formData, type=file) for parameters of type `IFormFile`