### PR TITLE
Use action name or route name for OperationIds

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Once you have an API that can describe itself in Swagger, you've opened the trea
 
     ```csharp
     [HttpPost]
-    public void Create([FromBody]Product product)
+    public void CreateProduct([FromBody]Product product)
     ...
 
     [HttpGet]
-    public IEnumerable<Product> Search([FromQuery]string keywords)
+    public IEnumerable<Product> SearchProducts([FromQuery]string keywords)
     ...
     ```
 
@@ -150,6 +150,7 @@ The steps described above will get you up and running with minimal setup. Howeve
 
 * [Swashbuckle.AspNetCore.SwaggerGen](#swashbuckleaspnetcoreswaggergen)
 
+    * [Assign Explicit OperationIds](#assign-explicit-operationids)
     * [List Operations Responses](#list-operation-responses)
     * [Flag Required Parameters and Schema Properties](#flag-required-parameters-and-schema-properties)
     * [Include Descriptions from XML Comments](#include-descriptions-from-xml-comments)
@@ -236,6 +237,26 @@ services.AddMvc()
 ```
 
 ## Swashbuckle.AspNetCore.SwaggerGen ##
+
+### Assign Explicit OperationIds ###
+
+In Swagger, Operations can be a assigned a unique `operationId`. This is often used by code generation tools (e.g. client libraries) and so, it's important for the value to follow common programming conventions while also revealing the purpose of the operation. To best meet these goals, Swashbuckle requires API authors to provide the value explicitly and provides two different options to do so:
+
+__Option 1) Action Names__
+
+```csharp
+[[HttpGet("{id}")]]
+public IActionResult GetProductById(int id) // operationId = "GetProductById"
+```
+
+__Option 2) Route Names__
+
+```csharp
+[[HttpGet("{id}", Name = "GetProductById")]]
+public IActionResult Get(int id) // operationId = "GetProductById"
+```
+
+_NOTE: In both cases, API authors are responsible for ensuring the uniqueness of `OperationId`s across all Operations_
 
 ### List Operation Responses ###
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Application/ConfigureSwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Application/ConfigureSwaggerGeneratorOptions.cs
@@ -43,7 +43,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             target.DocInclusionPredicate = source.DocInclusionPredicate;
             target.IgnoreObsoleteActions = source.IgnoreObsoleteActions;
             target.ConflictingActionsResolver = source.ConflictingActionsResolver;
-            target.TagSelector = source.TagSelector;
+            target.TagsSelector = source.TagsSelector;
             target.SortKeySelector = source.SortKeySelector;
             target.DescribeAllParametersInCamelCase = source.DescribeAllParametersInCamelCase;
             target.SecurityDefinitions = new Dictionary<string, SecurityScheme>(source.SecurityDefinitions);

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Application/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Application/SwaggerGenOptionsExtensions.cs
@@ -58,15 +58,38 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Provide a custom strategy for assigning a default "tag" to actions
+        /// Provide a custom strategy for assigning "operationId" to operations
+        /// </summary>
+        public static void CustomOperationIds(
+            this SwaggerGenOptions swaggerGenOptions,
+            Func<ApiDescription, string> operationIdSelector)
+        {
+            swaggerGenOptions.SwaggerGeneratorOptions.OperationIdSelector = operationIdSelector;
+        }
+
+        /// <summary>
+        /// Provide a custom strategy for assigning a default "tag" to operations
         /// </summary>
         /// <param name="swaggerGenOptions"></param>
         /// <param name="tagSelector"></param>
+        [Obsolete("Deprecated: Use the overload that accepts a Func that returns a list of tags")]
         public static void TagActionsBy(
             this SwaggerGenOptions swaggerGenOptions,
             Func<ApiDescription, string> tagSelector)
         {
-            swaggerGenOptions.SwaggerGeneratorOptions.TagSelector = tagSelector;
+            swaggerGenOptions.SwaggerGeneratorOptions.TagsSelector = (apiDesc) => new[] { tagSelector(apiDesc) };
+        }
+
+        /// <summary>
+        /// Provide a custom strategy for assigning "tags" to actions
+        /// </summary>
+        /// <param name="swaggerGenOptions"></param>
+        /// <param name="tagsSelector"></param>
+        public static void TagActionsBy(
+            this SwaggerGenOptions swaggerGenOptions,
+            Func<ApiDescription, IList<string>> tagsSelector)
+        {
+            swaggerGenOptions.SwaggerGeneratorOptions.TagsSelector = tagsSelector;
         }
 
         /// <summary>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/ApiDescriptionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/ApiDescriptionExtensions.cs
@@ -37,24 +37,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             return (methodInfo != null);
         }
 
-        internal static string FriendlyId(this ApiDescription apiDescription)
-        {
-            var parts = (apiDescription.RelativePathSansQueryString() + "/" + apiDescription.HttpMethod.ToLower())
-                .Split('/');
-
-            var builder = new StringBuilder();
-            foreach (var part in parts) 
-            {
-                var trimmed = part.Trim('{', '}');
-                builder.AppendFormat("{0}{1}",
-                    (part.StartsWith("{") ? "By" : string.Empty),
-                    trimmed.ToTitleCase()
-                );
-            }
-
-            return builder.ToString();
-        }
-
         internal static string RelativePathSansQueryString(this ApiDescription apiDescription)
         {
             return apiDescription.RelativePath.Split('?').First();

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
@@ -164,8 +164,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             var operation = new Operation
             {
-                Tags = new[] { _options.TagSelector(apiDescription) },
-                OperationId = apiDescription.FriendlyId(),
+                OperationId = _options.OperationIdSelector(apiDescription),
+                Tags = _options.TagsSelector(apiDescription),
                 Consumes = CreateConsumes(apiDescription, customAttributes),
                 Produces = CreateProduces(apiDescription, customAttributes),
                 Parameters = CreateParameters(apiDescription, schemaRegistry),

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Fakes/FakeApiDescriptionGroupCollectionProvider.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Fakes/FakeApiDescriptionGroupCollectionProvider.cs
@@ -79,8 +79,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             if (httpMethod != null)
                 descriptor.ActionConstraints.Add(new HttpMethodActionConstraint(new[] { httpMethod }));
 
-            descriptor.AttributeRouteInfo = new AttributeRouteInfo { Template = routeTemplate };
-
             descriptor.MethodInfo = controllerType.GetMethod(actionName);
             if (descriptor.MethodInfo == null)
                 throw new InvalidOperationException(
@@ -106,6 +104,16 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             descriptor.RouteValues = new Dictionary<string, string> {
                 { "controller", controllerType.Name.Replace("Controller", string.Empty) }
+            };
+
+            var httpMethodAttribute = descriptor.MethodInfo.GetCustomAttributes()
+                .OfType<HttpMethodAttribute>()
+                .FirstOrDefault();
+
+            descriptor.AttributeRouteInfo = new AttributeRouteInfo
+            {
+                Template = httpMethodAttribute?.Template ?? routeTemplate,
+                Name = httpMethodAttribute?.Name
             };
 
             return descriptor;

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Fakes/FakeController.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Fakes/FakeController.cs
@@ -139,6 +139,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             throw new NotImplementedException();
         }
 
+        [HttpGet(Name = "GetResource")]
+        public IActionResult AnnotatedWithRouteName()
+        {
+           throw new NotImplementedException();
+        }
+
         [Obsolete]
         public void MarkedObsolete()
         { }

--- a/test/WebSites/Basic/Controllers/CrudActionsController.cs
+++ b/test/WebSites/Basic/Controllers/CrudActionsController.cs
@@ -26,7 +26,7 @@ namespace Basic.Controllers
         /// </remarks>
         /// <param name="product"></param>
         /// <returns></returns>
-        [HttpPost]
+        [HttpPost(Name = "CreateProduct")]
         public Product Create([FromBody, Required]Product product)
         {
             return product;
@@ -37,8 +37,8 @@ namespace Basic.Controllers
         /// </summary>
         /// <param name="keywords">A list of search terms</param>
         /// <returns></returns>
-        [HttpGet]
-        public IEnumerable<Product> Search([FromQuery(Name = "kw")]string keywords = "foobar")
+        [HttpGet(Name = "SearchProducts")]
+        public IEnumerable<Product> Get([FromQuery(Name = "kw")]string keywords = "foobar")
         {
             return new[]
             {
@@ -52,8 +52,8 @@ namespace Basic.Controllers
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
-        [HttpGet("{id}")]
-        public Product GetById(int id)
+        [HttpGet("{id}", Name = "GetProduct")]
+        public Product Get(int id)
         {
             return new Product { Id = id, Description = "A product" };
         }
@@ -63,7 +63,7 @@ namespace Basic.Controllers
         /// </summary>
         /// <param name="id"></param>
         /// <param name="product"></param>
-        [HttpPut("{id}")]
+        [HttpPut("{id}", Name = "UpdateProduct")]
         public void Update(int id, [FromBody, Required]Product product)
         {
         }
@@ -73,8 +73,8 @@ namespace Basic.Controllers
         /// </summary>
         /// <param name="id"></param>
         /// <param name="updates"></param>
-        [HttpPatch("{id}")]
-        public void PartialUpdate(int id, [FromBody, Required]IDictionary<string, object> updates)
+        [HttpPatch("{id}", Name = "PatchProduct")]
+        public void Patch(int id, [FromBody, Required]IDictionary<string, object> updates)
         {
         }
 
@@ -82,7 +82,7 @@ namespace Basic.Controllers
         /// Deletes a specific product
         /// </summary>
         /// <param name="id"></param>
-        [HttpDelete("{id}")]
+        [HttpDelete("{id}", Name = "DeleteProduct")]
         public void Delete(int id)
         {
         }

--- a/test/WebSites/Basic/Controllers/DataAnnotationsController.cs
+++ b/test/WebSites/Basic/Controllers/DataAnnotationsController.cs
@@ -8,7 +8,7 @@ namespace Basic.Controllers
     {
         [HttpPost("payments/authorize")]
         [Produces("application/json", Type = typeof(int))]
-        public IActionResult Authorize([FromBody]PaymentRequest request)
+        public IActionResult AuthorizePayment([FromBody]PaymentRequest request)
         {
             if (!ModelState.IsValid)
                 return new BadRequestObjectResult(ModelState);

--- a/test/WebSites/Basic/Controllers/ResponseTypeAnnotationsController.cs
+++ b/test/WebSites/Basic/Controllers/ResponseTypeAnnotationsController.cs
@@ -17,7 +17,7 @@ namespace Basic.Controllers
         [HttpPost]
         [ProducesResponseType(typeof(int), 201)]
         [ProducesResponseType(typeof(IDictionary<string, string>), 400)]
-        public IActionResult Create([FromBody, Required]Order order)
+        public IActionResult CreateOrder([FromBody, Required]Order order)
         {
             return new CreatedResult("/orders/1", 1);
         }

--- a/test/WebSites/Basic/Controllers/SwaggerAnnotationsController.cs
+++ b/test/WebSites/Basic/Controllers/SwaggerAnnotationsController.cs
@@ -8,6 +8,7 @@ namespace Basic.Controllers
     public class SwaggerAnnotationsController
     {
         [HttpPost("/carts")]
+        [SwaggerOperation(OperationId = "CreateCart")]
         [SwaggerResponse(201, "The cart was created", typeof(Cart))]
         [SwaggerResponse(400, "The cart data is invalid")]
         public Cart Create([FromBody]Cart cart)
@@ -16,8 +17,9 @@ namespace Basic.Controllers
         }
 
         [HttpGet("/carts/{id}")]
+        [SwaggerOperation(OperationId = "GetCart")]
         [SwaggerOperationFilter(typeof(AddCartsByIdGetExternalDocs))]
-        public Cart GetById(int id)
+        public Cart Get(int id)
         {
             return new Cart { Id = id };
         }

--- a/test/WebSites/Basic/Startup.cs
+++ b/test/WebSites/Basic/Startup.cs
@@ -90,6 +90,7 @@ namespace Basic
             {
                 c.RoutePrefix = ""; // serve the UI at root
                 c.SwaggerEndpoint("/swagger/v1/swagger.json", "V1 Docs");
+                c.DisplayOperationId();
             });
         }
     }

--- a/test/WebSites/CliExample/Controllers/ProductsController.cs
+++ b/test/WebSites/CliExample/Controllers/ProductsController.cs
@@ -8,7 +8,7 @@ namespace CliExample.Controllers
     public class ProductsController
     {
         [HttpGet]
-        public IEnumerable<Product> GetAll()
+        public IEnumerable<Product> GetProducts()
         {
             return new[]
             {

--- a/test/WebSites/ConfigFromFile/Controllers/ProductsController.cs
+++ b/test/WebSites/ConfigFromFile/Controllers/ProductsController.cs
@@ -9,7 +9,7 @@ namespace ConfigFromFile.Controllers
     {
         // GET api/values
         [HttpGet]
-        public IEnumerable<Product> Get()
+        public IEnumerable<Product> GetProducts()
         {
             throw new NotImplementedException();
         }

--- a/test/WebSites/CustomUIConfig/Controllers/ProductsController.cs
+++ b/test/WebSites/CustomUIConfig/Controllers/ProductsController.cs
@@ -5,10 +5,10 @@ namespace CustomUIConfig.Controllers
 {
     [Route("/products")]
     [Produces("application/json")]
-    public class ProdutcsController
+    public class ProductsController
     {
         [HttpGet]
-        public IEnumerable<Product> GetAll()
+        public IEnumerable<Product> GetProducts()
         {
             return new[]
             {

--- a/test/WebSites/CustomUIIndex/Controllers/ProductsController.cs
+++ b/test/WebSites/CustomUIIndex/Controllers/ProductsController.cs
@@ -8,7 +8,7 @@ namespace CustomUIIndex.Controllers
     public class ProductsController
     {
         [HttpGet]
-        public IEnumerable<Product> GetAll()
+        public IEnumerable<Product> GetProducts()
         {
             return new[]
             {

--- a/test/WebSites/MultipleVersions/V1/ProductsController.cs
+++ b/test/WebSites/MultipleVersions/V1/ProductsController.cs
@@ -10,7 +10,7 @@ namespace MultipleVersions.V1
     public class ProductsController
     {
         [HttpGet]
-        public IEnumerable<Product> GetAll()
+        public IEnumerable<Product> GetProducts()
         {
             return new[]
             {

--- a/test/WebSites/MultipleVersions/V2/ProductsController.cs
+++ b/test/WebSites/MultipleVersions/V2/ProductsController.cs
@@ -10,18 +10,18 @@ namespace MultipleVersions.V2
     public class ProductsController
     {
         [HttpPost]
-        public int Create([FromBody, Required]Product product)
+        public int CreateProduct([FromBody, Required]Product product)
         {
             return 1;
         }
 
         [HttpPut("{id}")]
-        public void Update(int id, [FromBody, Required]Product product)
+        public void UpdateProduct(int id, [FromBody, Required]Product product)
         {
         }
 
         [HttpDelete("{id}")]
-        public void Delete(int id)
+        public void DeleteProduct(int id)
         {
         }
     }

--- a/test/WebSites/OAuth2Integration/ResourceServer/Controllers/ProductsController.cs
+++ b/test/WebSites/OAuth2Integration/ResourceServer/Controllers/ProductsController.cs
@@ -10,7 +10,7 @@ namespace OAuth2Integration.ResourceServer.Controllers
     {
         [HttpGet]
         [Authorize("readAccess")]
-        public IEnumerable<Product> GetAll()
+        public IEnumerable<Product> GetProducts()
         {
             yield return new Product
             {
@@ -21,7 +21,7 @@ namespace OAuth2Integration.ResourceServer.Controllers
 
         [HttpGet("{id}")]
         [Authorize("readAccess")]
-        public Product GetById(int id)
+        public Product GetProduct(int id)
         {
             return new Product
             {
@@ -33,13 +33,13 @@ namespace OAuth2Integration.ResourceServer.Controllers
 
         [HttpPost]
         [Authorize("writeAccess")]
-        public void Post([FromBody]Product product)
+        public void CreateProduct([FromBody]Product product)
         {
         }
 
         [HttpDelete("{id}")]
         [Authorize("writeAccess")]
-        public void Delete(int id)
+        public void DeleteProduct(int id)
         {
         }
     }

--- a/test/WebSites/ReDoc/Controllers/ProductsController.cs
+++ b/test/WebSites/ReDoc/Controllers/ProductsController.cs
@@ -9,13 +9,13 @@ namespace ReDoc.Controllers
     public class ProductsController
     {
         [HttpPost]
-        public int Create([FromBody, Required]Product product)
+        public int CreateProduct([FromBody, Required]Product product)
         {
             return 1;
         }
 
         [HttpGet]
-        public IEnumerable<Product> GetAll()
+        public IEnumerable<Product> GetProducts()
         {
             return new[]
             {
@@ -25,23 +25,23 @@ namespace ReDoc.Controllers
         }
 
         [HttpGet("{id}")]
-        public Product GetById(int id)
+        public Product GetProduct(int id)
         {
             return new Product { Id = id, Description = "A product" };
         }
 
         [HttpPut("{id}")]
-        public void Update(int id, [FromBody, Required]Product product)
+        public void UpdateProduct(int id, [FromBody, Required]Product product)
         {
         }
 
         [HttpPatch("{id}")]
-        public void PartialUpdate(int id, [FromBody, Required]IDictionary<string, object> updates)
+        public void PatchProduct(int id, [FromBody, Required]IDictionary<string, object> updates)
         {
         }
 
         [HttpDelete("{id}")]
-        public void Delete(int id)
+        public void DeleteProduct(int id)
         {
         }
     }


### PR DESCRIPTION
Addresses #333.

In summary, this removes the code that automatically creates an `OperationId` from route and parameter info, and reverts to explicit assignment, using route name if provided (e.g. `[HttpGet("products", Name = "GetProducts")]`) or else the action name.

Trying to maintain a systematic way to generate a meaningful `OperationId` that works for everyone has proved to be extremely difficult, if not impossible. Given that the `OperationId` is used by many code-gen tools in the generation of client libraries, I believe the explicit approach makes most sense.

With that said, this puts the onus on developers to come up with meaningful and unique names. 