### PR TITLE
Upgrade swagger-ui to 3.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Once you have an API that can describe itself in Swagger, you've opened the trea
 
 |Swashbuckle Version|ASP.NET Core|Swagger (OpenAPI) Spec.|swagger-ui|
 |----------|----------|----------|----------|
-|[master](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/tree/master)|>=2.0.0|2.0|3.18.0|
+|[master](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/tree/master)|>=2.0.0|2.0|3.19.0|
 |[3.0.0](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/tree/v3.0.0)|>=1.0.4|2.0|3.17.1|
 |[2.5.0](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/tree/v2.5.0)|>=1.0.4|2.0|3.16.0|
 |[1.2.0](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/tree/v1.2.0)|>=1.0.4|2.0|2.2.10|

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/package-lock.json
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "swagger-ui-dist": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.18.0.tgz",
-      "integrity": "sha1-1vLuDNnae+RHKYQ/QjzHCALPg84="
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.19.0.tgz",
+      "integrity": "sha512-4/S7ZP8uPVn3vrCls46QG6RF4paqRFkDBcfSlyFetZHdPcjAu0hr38ZkaG4n8689R0tiqWDiubnEQUII+ulymA=="
     }
   }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/package.json
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "swagger-ui-dist": "3.18.0"
+    "swagger-ui-dist": "3.19.0"
   }
 }


### PR DESCRIPTION
I'm mostly interested in https://github.com/swagger-api/swagger-js/pull/1278 which was released with swagger-client@3.8.15.