### PR TITLE
Make httpMethod not case-sensitive

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
@@ -117,7 +117,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
                 var apiDescription = (group.Count() > 1) ? _options.ConflictingActionsResolver(group) : group.Single();
 
-                switch (httpMethod)
+                switch (httpMethod.ToUpper())
                 {
                     case "GET":
                         pathItem.Get = CreateOperation(apiDescription, schemaRegistry);


### PR DESCRIPTION
Improves reliability of the function in case the user passes a lowercase `httpMethod`.