### PR TITLE
Use ApiParameterDescription.IsRequired when available

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/ApiParameterDescriptionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/ApiParameterDescriptionExtensions.cs
@@ -2,12 +2,24 @@
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Controllers;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     public static class ApiParameterDescriptionExtensions
     {
+        internal static bool? IsRequired(this ApiParameterDescription apiParameterDescription)
+        {
+            var property = apiParameterDescription.GetType().GetProperty("IsRequired");
+
+            if (property == null)
+            {
+                // ApiExplorer < 2.2 does not support IsRequired.
+                return null;
+            }
+
+            return (bool)property.GetValue(apiParameterDescription);
+        }
+
         internal static bool TryGetParameterInfo(
             this ApiParameterDescription apiParameterDescription,
             ApiDescription apiDescription,

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
@@ -253,7 +253,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 ? apiParameterDescription.Name.ToCamelCase()
                 : apiParameterDescription.Name;
 
-            var isRequired = customAttributes.Any(attr =>
+            var isRequired = apiParameterDescription.IsRequired() ?? customAttributes.Any(attr =>
                 new[] { typeof(RequiredAttribute), typeof(BindRequiredAttribute) }.Contains(attr.GetType()));
 
             var parameter = (apiParameterDescription.Source == BindingSource.Body)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SwaggerGeneratorTests.cs
@@ -728,7 +728,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             public bool IsDefaultResponse { get; set; }
         }
 
-        private class ApiParameterDescription22 : ApiParameterDescription
+        private class ApiParameterDescriptionStub : ApiParameterDescription
         {
             public bool IsRequired { get; set; }
 


### PR DESCRIPTION
Takes advantage of https://github.com/aspnet/Mvc/blob/release/2.2/src/Microsoft.AspNetCore.Mvc.Abstractions/ApiExplorer/ApiParameterDescription.cs#L56 added to `ApiParameterDescription` in 2.2