### PR TITLE
Add Using info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Once you have an API that can describe itself in Swagger, you've opened the trea
 2. In the _ConfigureServices_ method of _Startup.cs_, register the Swagger generator, defining one or more Swagger documents.
 
     ```csharp
+    using Swashbuckle.AspNetCore.Swagger;
+    
     services.AddMvc();
 
     services.AddSwaggerGen(c =>


### PR DESCRIPTION
The default instructions leave the user wondering where Info lives - the project won't compile without a Google.