### PR TITLE
Improve UnknownSwaggerDocument error message

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/Model/ISwaggerProvider.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/Model/ISwaggerProvider.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Swashbuckle.AspNetCore.Swagger
 {
@@ -13,8 +15,11 @@ namespace Swashbuckle.AspNetCore.Swagger
 
     public class UnknownSwaggerDocument : Exception
     {
-        public UnknownSwaggerDocument(string documentName)
-            : base(string.Format("Unknown Swagger document - {0}", documentName))
+        public UnknownSwaggerDocument(string documentName, IEnumerable<string> knownDocuments)
+            : base(string.Format("Unknown Swagger document - \"{0}\". Known Swagger documents: {1}{2}",
+                documentName,
+                Environment.NewLine,
+                string.Join(Environment.NewLine, knownDocuments?.Select(x => $"\"{x}\""))))
         {}
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
@@ -43,7 +43,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             string[] schemes = null)
         {
             if (!_options.SwaggerDocs.TryGetValue(documentName, out Info info))
-                throw new UnknownSwaggerDocument(documentName);
+                throw new UnknownSwaggerDocument(documentName, _options.SwaggerDocs.Select(x => x.Key));
 
             var applicableApiDescriptions = _apiDescriptionsProvider.ApiDescriptionGroups.Items
                 .SelectMany(group => group.Items)

--- a/version.props
+++ b/version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.0.1</VersionPrefix>
+    <VersionPrefix>4.0.2</VersionPrefix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
When an UnknownSwaggerDocument is passed include the known documents in
the error message so that the user can identify examples of valid
options.

For example in my case this helped me know that a semi-colon got into my command some how:
![image](https://user-images.githubusercontent.com/1037467/48719894-8589a600-ebec-11e8-8369-ff698adce506.png)
