### PR TITLE
Properties which implement KeyedCollection should emit uniqueItems: true

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaRegistry.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaRegistry.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -199,17 +200,18 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private Schema CreateArraySchema(JsonArrayContract arrayContract, Queue<Type> referencedTypes)
         {
+            var uniqueTypes = new[] {typeof(ISet<>), typeof(KeyedCollection<,>)};
             var type = arrayContract.UnderlyingType;
             var itemType = arrayContract.CollectionItemType ?? typeof(object);
 
-            var isASet = (type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(ISet<>)
-                || type.GetInterfaces().Any(i => i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == typeof(ISet<>)));
+            var isAUniqueCollection = (type.GetTypeInfo().IsGenericType && uniqueTypes.Contains(type.GetGenericTypeDefinition())
+                || type.GetInterfaces().Any(i => i.GetTypeInfo().IsGenericType && uniqueTypes.Contains(i.GetGenericTypeDefinition())));
 
             return new Schema
             {
                 Type = "array",
                 Items = CreateSchema(itemType, referencedTypes),
-                UniqueItems = isASet
+                UniqueItems = isAUniqueCollection
             };
         }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -71,6 +72,17 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetOrRegister_ReturnsSetSchema_ForSetTypes()
         {
             var schema = Subject().GetOrRegister(typeof(ISet<string>));
+
+            Assert.Equal("array", schema.Type);
+            Assert.Equal("string", schema.Items.Type);
+            Assert.Equal(true, schema.UniqueItems);
+        }
+
+
+        [Fact]
+        public void GetOrRegister_ReturnsSetSchema_ForKeyedCollectionTypes()
+        {
+            var schema = Subject().GetOrRegister(typeof(KeyedCollection<string, string>));
 
             Assert.Equal("array", schema.Type);
             Assert.Equal("string", schema.Items.Type);


### PR DESCRIPTION
Fixes #945 
KeyedCollection by it's nature is a collection of unique items, so uniqueItems: true should be set in the schema for properties of this type or implementing this type