### PR TITLE
Changed OpenApiInfo to Info to match latest code

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Once you have an API that can describe itself in Swagger, you've opened the trea
 
     services.AddSwaggerGen(c =>
     {
-        c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
+        c.SwaggerDoc("v1", new Info { Title = "My API", Version = "v1" });
     });
     ```
 


### PR DESCRIPTION
Doc was showing "OpenApiInfo" as class expected by SwaggerDoc() - latest changes expect Swashbuckle.AspNetCore.Swagger.Info