### PR TITLE
Remove hash from redirect uri

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
@@ -91,7 +91,7 @@
 
     // If oauth2RedirectUrl isn't specified, use the built-in default
     if (!configObject.hasOwnProperty("oauth2RedirectUrl"))
-      configObject.oauth2RedirectUrl = window.location.href.replace("index.html", "oauth2-redirect.html");
+      configObject.oauth2RedirectUrl = window.location.href.replace("index.html", "oauth2-redirect.html").split('#')[0];
 
     // Build a system
     const ui = SwaggerUIBundle(configObject);

--- a/test/WebSites/OAuth2Integration/Startup.cs
+++ b/test/WebSites/OAuth2Integration/Startup.cs
@@ -133,6 +133,7 @@ namespace OAuth2Integration
                     c.OAuthScopeSeparator(" ");
                     c.OAuthAdditionalQueryStringParams(new Dictionary<string, string> { { "foo", "bar" }});
                     c.OAuthUseBasicAuthenticationWithAccessCodeGrant();
+                    c.ConfigObject.DeepLinking = true;
                 });
             });
         }


### PR DESCRIPTION
Hello, 

There is a bug when you activate DeepLinking and load the swagger ui with it.

To reproduce in the oauth2 sample activate deeplinking run it and go to http://localhost:50581/resource-server/swagger/index.html#/Products/get_products then try to authenticate.


Would be nice to have it also  for version 4 as we can't use version 5.0.0-beta because https://github.com/mattfrear/Swashbuckle.AspNetCore.Filters is not available with the breaking changes.

Thanks