### PR TITLE
Return "Not Modified" as description for 304 Response

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
@@ -434,6 +434,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             { "1\\d{2}", "Information" },
             { "2\\d{2}", "Success" },
+            { "304", "Not Modified" },
             { "3\\d{2}", "Redirect" },
             { "400", "Bad Request" },
             { "401", "Unauthorized" },

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SwaggerGeneratorTests.cs
@@ -409,6 +409,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [InlineData(nameof(FakeController.ReturnsComplexType), "200", "Success", new string[] { "application/json", "text/json" })]
         [InlineData(nameof(FakeController.ReturnsJObject), "200", "Success", new string[] { "application/json", "text/json" })]
         [InlineData(nameof(FakeController.ReturnsActionResult), "200", "Success", new string[] { })]
+        [InlineData(nameof(FakeController.AnnotatedWithWithNotModifiedResponseTypeAttributes), "304", "Not Modified", new string[] { })]
         public void GetSwagger_GeneratesResponses_ForSupportedApiResponseTypes(
             string actionFixtureName,
             string expectedStatusCode,

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Fakes/FakeController.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Fakes/FakeController.cs
@@ -151,5 +151,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [Obsolete]
         public void MarkedObsolete()
         { }
+
+        [ProducesResponseType(typeof(void), 304)]
+        public IActionResult AnnotatedWithWithNotModifiedResponseTypeAttributes()
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
Currently all 3xx responses are described as "Redirect", but 304 should be "Not Modified".