### PR TITLE
ReDoc 2.0.0-rc.1

### DIFF
--- a/README-v5.md
+++ b/README-v5.md
@@ -19,7 +19,7 @@ Once you have an API that can describe itself in Swagger, you've opened the trea
 
 |Swashbuckle Version|ASP.NET Core|Swagger / OpenAPI Spec.|swagger-ui|ReDoc UI|
 |----------|----------|----------|----------|----------|
-|[master](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/tree/master)|>=2.0.0|2.0, 3.0|3.19.5|1.22.2|
+|[master](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/tree/master)|>=2.0.0|2.0, 3.0|3.19.5|2.0.0-rc.0|
 |[5.0.0-beta](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/tree/v5.0.0-beta)|>=2.0.0|2.0, 3.0|3.19.5|1.22.2|
 |[4.0.0](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/tree/v4.0.0)|>=2.0.0|2.0|3.19.5|1.22.2|
 |[3.0.0](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/tree/v3.0.0)|>=1.0.4|2.0|3.17.1|1.20.0|
@@ -196,7 +196,11 @@ The steps described above will get you up and running with minimal setup. Howeve
     * [Retrieve Swagger Directly from a Startup Assembly](#retrieve-swagger-directly-from-a-startup-assembly)
 
 * [Swashbuckle.AspNetCore.ReDoc](#swashbuckleaspnetcoreredoc)
-    * Docs coming soon
+    * [Change Releative Path to the UI](#redoc-change-relative-path-to-the-ui)
+    * [Change Document Title](#redoc-change-document-title)
+    * [Apply ReDoc Parameters](#apply-redoc-parameters)
+    * [Inject Custom CSS](#redoc-inject-custom-css)
+    * [Customize index.html](#redoc-customize-indexhtml)
 
 ## Swashbuckle.AspNetCore.Swagger ##
 
@@ -1154,3 +1158,91 @@ Where ...
 * [swaggerdoc] is the name of the swagger document you want to retrieve, as configured in your startup class
 
 Checkout the [CliExample app](test/WebSites/CliExample) for more inspiration. It leverages the MSBuild Exec command to generate Swagger JSON at build-time.
+
+## Swashbuckle.AspNetCore.ReDoc ##
+
+<h3 id="redoc-change-relative-path-to-the-ui">Change Relative Path to the UI</h3>
+
+By default, the ReDoc UI will be exposed at "/api-docs". If necessary, you can alter this when enabling the ReDoc middleware:
+
+```csharp
+app.UseReDoc(c =>
+{
+    c.RoutePrefix = "docs"
+    ...
+}
+```
+
+<h3 id="redoc-change-document-title">Change Document Title</h3>
+
+By default, the ReDoc UI will have a generic document title. You can alter this when enabling the ReDoc middleware:
+
+```csharp
+app.UseReDoc(c =>
+{
+    c.DocumentTitle = "My API Docs";
+    ...
+}
+```
+
+### Apply ReDoc Parameters ###
+
+ReDoc ships with it's own set of configuration parameters, all described here https://github.com/Rebilly/ReDoc/blob/master/README.md#redoc-options-object. In Swashbuckle, most of these are surfaced through the ReDoc middleware options:
+
+```csharp
+app.UseReDoc(c =>
+{
+    c.SpecUrl("/v1/swagger.json");
+    c.UntrustedSpec();
+    c.ScrollYOffset(10);
+    c.HideHostname();
+    c.HideDownloadButton());
+    c.ExpandResponses("200,201");
+    c.RequiredPropsFirst();
+    c.NoAutoAuth();
+    c.PathInMiddlePanel();
+    c.HideLoading();
+    c.NativeScrollbars();
+    c.DisableSearch();
+    c.OnlyRequiredInSamples();
+    c.SortPropsAlphabetically();
+});
+```
+
+_Using `c.SpecUrl("/v1/swagger.json")` multiple times within the same `UseReDoc(...)` will not add multiple urls._
+
+<h3 id="redoc-inject-custom-css">Inject Custom CSS</h3>
+
+To tweak the look and feel, you can inject additional CSS stylesheets by adding them to your `wwwroot` folder and specifying the relative paths in the middleware options:
+
+```csharp
+app.UseReDoc(c =>
+{
+    ...
+    c.InjectStylesheet("/redoc/custom.css");
+}
+```
+
+It is also possible to modify the theme by using the `AdditionalItems` property, see https://github.com/Rebilly/ReDoc/blob/master/README.md#redoc-options-object for more information.
+
+```csharp
+app.UseReDoc(c =>
+{
+    ...
+    c.ConfigObject.AdditionalItems = ...
+}
+```
+
+<h3 id="redoc-customize-indexhtml">Customize index.html</h3>
+
+To customize the UI beyond the basic options listed above, you can provide your own version of the ReDoc index.html page:
+
+```csharp
+app.UseReDoc(c =>
+{
+    c.IndexStream = () => GetType().Assembly
+        .GetManifestResourceStream("CustomIndex.ReDoc.index.html"); // requires file to be added as an embedded resource
+});
+```
+
+_To get started, you should base your custom index.html on the [default version](src/Swashbuckle.AspNetCore.ReDoc/index.html)_

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocBuilderExtensions.cs
@@ -5,8 +5,6 @@ namespace Microsoft.AspNetCore.Builder
 {
     public static class ReDocBuilderExtensions
     {
-        private const string EmbeddedFilesNamespace = "Swashbuckle.AspNetCore.ReDoc.node_modules.redoc.dist";
-
         public static IApplicationBuilder UseReDoc(
             this IApplicationBuilder app,
             Action<ReDocOptions> setupAction = null)

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
@@ -1,26 +1,26 @@
-﻿using System.Reflection;
-using System.Threading.Tasks;
-using System.Text.RegularExpressions;
-using System.Linq;
-using System.Text;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.FileProviders;
-using Microsoft.AspNetCore.StaticFiles;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 
 namespace Swashbuckle.AspNetCore.ReDoc
 {
     public class ReDocMiddleware
     {
-        private const string EmbeddedFileNamespace = "Swashbuckle.AspNetCore.ReDoc.node_modules.redoc.dist";
+        private const string EmbeddedFileNamespace = "Swashbuckle.AspNetCore.ReDoc.node_modules.redoc.bundles";
 
         private readonly ReDocOptions _options;
         private readonly StaticFileMiddleware _staticFileMiddleware;

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocOptions.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocOptions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Swashbuckle.AspNetCore.ReDoc
 {
@@ -51,17 +50,6 @@ namespace Swashbuckle.AspNetCore.ReDoc
         /// This is often useful when there are fixed positioned elements at the top of the page, such as navbars, headers etc
         /// </summary>
         public int? ScrollYOffset { get; set; }
-
-        /// <summary>
-        /// If set, warnings are not rendered at the top of documentation (they still are logged to the console)
-        /// </summary>
-        public bool SupressWarnings { get; set; } = false;
-
-        /// <summary>
-        /// If set, enables lazy rendering mode in ReDoc. This mode is useful for APIs with big number of operations (e.g. > 50).
-        /// In this mode ReDoc shows initial screen ASAP and then renders the rest operations asynchronously while showing progress bar on the top
-        /// </summary>
-        public bool LazyRendering { get; set; } = false;
 
         /// <summary>
         /// If set, the protocol and hostname is not shown in the operation definition

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocOptions.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocOptions.cs
@@ -105,6 +105,21 @@ namespace Swashbuckle.AspNetCore.ReDoc
         /// </summary>
         public bool NativeScrollbars { get; set; } = false;
 
+        /// <summary>
+        /// Disable search indexing and search box
+        /// </summary>
+        public bool DisableSearch { get; set; } = false;
+
+        /// <summary>
+        /// Show only required fields in request samples
+        /// </summary>
+        public bool OnlyRequiredInSamples { get; set; } = false;
+
+        /// <summary>
+        /// Sort properties alphabetically
+        /// </summary>
+        public bool SortPropsAlphabetically { get; set; } = false;
+
         [JsonExtensionData]
         public Dictionary<string, object> AdditionalItems = new Dictionary<string, object>();
     }

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocOptionsExtensions.cs
@@ -17,5 +17,125 @@ namespace Microsoft.AspNetCore.Builder
             builder.AppendLine($"<link href='{path}' rel='stylesheet' media='{media}' type='text/css' />");
             options.HeadContent = builder.ToString();
         }
+
+        /// <summary>
+        /// Sets the Swagger JSON endpoint. Can be fully-qualified or relative to the redoc page
+        /// </summary>
+        public static void SpecUrl(this ReDocOptions options, string url)
+        {
+            options.SpecUrl = url;
+        }
+
+        /// <summary>
+        /// If enabled, the spec is considered untrusted and all HTML/markdown is sanitized to prevent XSS.
+        /// Disabled by default for performance reasons. Enable this option if you work with untrusted user data!
+        /// </summary>
+        /// <param name="options"></param>
+        public static void EnableUntrustedSpec(this ReDocOptions options)
+        {
+            options.ConfigObject.UntrustedSpec = true;
+        }
+
+        /// <summary>
+        /// Specifies a vertical scroll-offset in pixels.
+        /// This is often useful when there are fixed positioned elements at the top of the page, such as navbars, headers etc
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="offset"></param>
+        public static void ScrollYOffset(this ReDocOptions options, int offset)
+        {
+            options.ConfigObject.ScrollYOffset = offset;
+        }
+
+        /// <summary>
+        /// Controls if the protocol and hostname is shown in the operation definition
+        /// </summary>
+        public static void HideHostname(this ReDocOptions options)
+        {
+            options.ConfigObject.HideHostname = true;
+        }
+
+        /// <summary>
+        /// Do not show "Download" spec button. THIS DOESN'T MAKE YOUR SPEC PRIVATE, it just hides the button
+        /// </summary>
+        public static void HideDownloadButton(this ReDocOptions options)
+        {
+            options.ConfigObject.HideDownloadButton = true;
+        }
+
+        /// <summary>
+        /// Specify which responses to expand by default by response codes.
+        /// Values should be passed as comma-separated list without spaces e.g. "200,201". Special value "all" expands all responses by default.
+        /// Be careful: this option can slow-down documentation rendering time.
+        /// Default is "all"
+        /// </summary>
+        public static void ExpandResponses(this ReDocOptions options, string responses)
+        {
+            options.ConfigObject.ExpandResponses = responses;
+        }
+
+        /// <summary>
+        /// Show required properties first ordered in the same order as in required array
+        /// </summary>
+        public static void RequiredPropsFirst(this ReDocOptions options)
+        {
+            options.ConfigObject.RequiredPropsFirst = true;
+        }
+
+        /// <summary>
+        /// Do not inject Authentication section automatically
+        /// </summary>
+        public static void NoAutoAuth(this ReDocOptions options)
+        {
+            options.ConfigObject.NoAutoAuth = true;
+        }
+
+        /// <summary>
+        /// Show path link and HTTP verb in the middle panel instead of the right one
+        /// </summary>
+        public static void PathInMiddlePanel(this ReDocOptions options)
+        {
+            options.ConfigObject.PathInMiddlePanel = true;
+        }
+
+        /// <summary>
+        /// Do not show loading animation. Useful for small docs
+        /// </summary>
+        public static void HideLoading(this ReDocOptions options)
+        {
+            options.ConfigObject.HideLoading = true;
+        }
+
+        /// <summary>
+        /// Use native scrollbar for sidemenu instead of perfect-scroll (scrolling performance optimization for big specs)
+        /// </summary>
+        public static void NativeScrollbars(this ReDocOptions options)
+        {
+            options.ConfigObject.NativeScrollbars = true;
+        }
+
+        /// <summary>
+        /// Disable search indexing and search box
+        /// </summary>
+        public static void DisableSearch(this ReDocOptions options)
+        {
+            options.ConfigObject.DisableSearch = true;
+        }
+
+        /// <summary>
+        /// Show only required fields in request samples
+        /// </summary>
+        public static void OnlyRequiredInSamples(this ReDocOptions options)
+        {
+            options.ConfigObject.OnlyRequiredInSamples = true;
+        }
+
+        /// <summary>
+        /// Sort properties alphabetically
+        /// </summary>
+        public static void SortPropsAlphabetically(this ReDocOptions options)
+        {
+            options.ConfigObject.SortPropsAlphabetically = true;
+        }
     }
 }

--- a/src/Swashbuckle.AspNetCore.ReDoc/Swashbuckle.AspNetCore.ReDoc.csproj
+++ b/src/Swashbuckle.AspNetCore.ReDoc/Swashbuckle.AspNetCore.ReDoc.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\version.props" />
 
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="index.html" />
-    <EmbeddedResource Include="node_modules/redoc/dist/redoc.min.*" />
+    <EmbeddedResource Include="node_modules/redoc/bundles/redoc.standalone.js" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Swashbuckle.AspNetCore.ReDoc/index.html
+++ b/src/Swashbuckle.AspNetCore.ReDoc/index.html
@@ -1,27 +1,28 @@
 ﻿<!DOCTYPE html>
 <html>
 <head>
-  <title>%(DocumentTitle)</title>
-  <!-- needed for adaptive design -->
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>%(DocumentTitle)</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
 
-  <!--
-  ReDoc doesn't change outer page styles
-  -->
-  <style>
-    body {
-      margin: 0;
-      padding: 0;
-    }
-  </style>
-  %(HeadContent)
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+        }
+    </style>
+    %(HeadContent)
 </head>
 <body>
-  <redoc></redoc>
-  <script src="redoc.min.js"></script>
-  <script type="text/javascript">
-    Redoc.init('%(SpecUrl)', JSON.parse('%(ConfigObject)'));
-  </script>
+    <div id="redoc-container"></div>
+    <script src="redoc.standalone.js"></script>
+    <script type="text/javascript">
+        Redoc.init('%(SpecUrl)', JSON.parse('%(ConfigObject)'), document.getElementById('redoc-container'))
+    </script>
 </body>
 </html>

--- a/src/Swashbuckle.AspNetCore.ReDoc/package-lock.json
+++ b/src/Swashbuckle.AspNetCore.ReDoc/package-lock.json
@@ -4,95 +4,36 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@angular/animations": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-4.1.1.tgz",
-      "integrity": "sha1-EAD4si3CAxqMNtIl6y3PX2wNCvU="
-    },
-    "@angular/common": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-4.1.1.tgz",
-      "integrity": "sha1-CIoTpwxTkMXJYTqgV1S3TuGOGvs="
-    },
-    "@angular/compiler": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-4.1.1.tgz",
-      "integrity": "sha1-/GJFkFZGX2JMOsb2ja3Mm6dMSuA="
-    },
-    "@angular/compiler-cli": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-4.1.1.tgz",
-      "integrity": "sha1-jOqJ7hISnD8O21WFPhizexZPKVM=",
+    "@babel/runtime": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
+      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
       "requires": {
-        "@angular/tsc-wrapped": "4.1.1",
-        "minimist": "^1.2.0",
-        "reflect-metadata": "^0.1.2"
+        "regenerator-runtime": "0.12.1"
       }
-    },
-    "@angular/core": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-4.1.1.tgz",
-      "integrity": "sha1-EjBkXIQvimoFBAPUlH+YLn73DGA="
-    },
-    "@angular/forms": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-4.1.1.tgz",
-      "integrity": "sha1-avOffEFunwOMOffuW/pR2dpVC/A="
-    },
-    "@angular/platform-browser": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-4.1.1.tgz",
-      "integrity": "sha1-4vVFtFjnhYzAsgsK5MyZI3Vg+3I="
-    },
-    "@angular/platform-browser-dynamic": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-4.1.1.tgz",
-      "integrity": "sha1-aCiBA1FA4i1JiryhOZB6qBh/a/o="
-    },
-    "@angular/platform-server": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-4.1.1.tgz",
-      "integrity": "sha1-Jj5ePWAUAamfo1Ru5X/J/C5/TKo=",
-      "requires": {
-        "parse5": "^3.0.1",
-        "xhr2": "^0.1.4"
-      }
-    },
-    "@angular/tsc-wrapped": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@angular/tsc-wrapped/-/tsc-wrapped-4.1.1.tgz",
-      "integrity": "sha1-reeTzb5kxlDF9ZRv9CTGo1d7Cdg=",
-      "requires": {
-        "tsickle": "^0.21.0"
-      }
-    },
-    "@types/node": {
-      "version": "10.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.2.tgz",
-      "integrity": "sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ=="
     },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
-    "autolinker": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.15.3.tgz",
-      "integrity": "sha1-NCQX2PLzRhsUzwkIjV7fh5HcmDI="
-    },
-    "builtin-status-codes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+    "big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "call-me-maybe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
       "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+    },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "clipboard": {
       "version": "2.0.1",
@@ -100,34 +41,15 @@
       "integrity": "sha512-7yhQBmtN+uYZmfRjjVjKa0dZdWuabzpSKGtyQZN+9C8xlC788SSJjOHWh7tzurfwTqTD5UDYAhIv5fRJg3sHjQ==",
       "optional": true,
       "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
+        "good-listener": "1.2.2",
+        "select": "1.1.2",
+        "tiny-emitter": "2.0.2"
       }
     },
-    "commander": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
-      "optional": true
-    },
-    "core-js": {
-      "version": "2.4.1",
-      "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-      "requires": {
-        "ms": "^2.1.1"
-      }
+    "decko": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decko/-/decko-1.2.0.tgz",
+      "integrity": "sha1-/UPHNelnuAEzBohKVvvmZZlraBc="
     },
     "delegate": {
       "version": "3.2.0",
@@ -135,20 +57,35 @@
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
       "optional": true
     },
-    "dropkickjs": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/dropkickjs/-/dropkickjs-2.1.10.tgz",
-      "integrity": "sha1-8TyUAhQdoJ50rfTmN5jXkiBEOPI="
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
-    "es6-promise": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+    "dompurify": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-1.0.8.tgz",
+      "integrity": "sha512-vetRFbN1SXSPfP3ClIiYnxTrXquSqakBEOoB5JESn0SVcSYzpu6ougjakpKnskGctYdlNpwf+riUHSkG7d4XUw=="
+    },
+    "emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "eventemitter3": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "foreach": {
       "version": "2.0.5",
@@ -160,42 +97,44 @@
       "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
       "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
     },
+    "global": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
+      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "requires": {
+        "min-document": "2.19.0",
+        "process": "0.5.2"
+      }
+    },
     "good-listener": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "optional": true,
       "requires": {
-        "delegate": "^3.1.2"
+        "delegate": "3.2.0"
       }
     },
-    "hint.css": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/hint.css/-/hint.css-2.3.2.tgz",
-      "integrity": "sha1-2cC2BHRfS4jpGvKhblhhVAxMTZ0="
+    "hoist-non-react-statics": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz",
+      "integrity": "sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==",
+      "requires": {
+        "react-is": "16.7.0"
+      }
     },
-    "https-browserify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "json-pointer": {
@@ -203,196 +142,236 @@
       "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.0.tgz",
       "integrity": "sha1-jlAFUKaqxUZKRzN32leqbMIoKNc=",
       "requires": {
-        "foreach": "^2.0.4"
+        "foreach": "2.0.5"
       }
     },
-    "json-schema-ref-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-3.3.1.tgz",
-      "integrity": "sha512-stQTMhec2R/p2L9dH4XXRlpNCP0mY8QrLd/9Kl+8SHJQmwHtE1nDfXH4wbsSM+GkJMl8t92yZbI0OIol432CIQ==",
+    "json5": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "requires": {
-        "call-me-maybe": "^1.0.1",
-        "debug": "^3.0.0",
-        "es6-promise": "^4.1.1",
-        "js-yaml": "^3.9.1",
-        "ono": "^4.0.2",
-        "z-schema": "^3.18.2"
+        "minimist": "1.2.0"
       }
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    "loader-utils": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+      "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+      "requires": {
+        "big.js": "5.2.2",
+        "emojis-list": "2.1.0",
+        "json5": "1.0.1"
+      }
     },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
     },
-    "lunr": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-1.0.0.tgz",
-      "integrity": "sha1-XJJ2ySyRrDWpJBtQGNRnI9kuL18="
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "4.0.0"
+      }
     },
     "mark.js": {
       "version": "8.11.1",
       "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
       "integrity": "sha1-GA8fnr74sOY45BZq1S24eb6y/8U="
     },
+    "marked": {
+      "version": "git+https://github.com/markedjs/marked.git#fb48827236ed3a43e611d2adb3c070ca3f55ed8e"
+    },
+    "memoize-one": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.1.0.tgz",
+      "integrity": "sha512-2GApq0yI/b22J2j9rhbrAlsHb0Qcz+7yWxeLG8h+95sl1XPUgeLimQSOdur4Vw7cUhrBHwaUZxWFZueojqNRzA=="
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "requires": {
+        "dom-walk": "0.1.1"
+      }
+    },
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+    "mobx-react": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-5.4.3.tgz",
+      "integrity": "sha512-WC8yFlwvJ91hy8j6CrydAuFteUafcuvdITFQeHl3LRIf5ayfT/4W3M/byhEYD2BcJWejeXr8y4Rh2H26RunCRQ==",
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
+        "hoist-non-react-statics": "3.2.1",
+        "react-lifecycles-compat": "3.0.4"
       }
     },
-    "ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "ono": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.10.tgz",
       "integrity": "sha512-4Xz4hlbq7MzV0I3vKfZwRvyj8tCbXODqBNzFqtkjP+KTV93zzDRju8kw1qnf6P5kcZ2+xlIq6wSCqA+euSKxhA==",
       "requires": {
-        "format-util": "^1.0.3"
+        "format-util": "1.0.3"
       }
     },
-    "openapi-sampler": {
-      "version": "1.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0-beta.8.tgz",
-      "integrity": "sha1-v0P/R3N/xOH5iNDiCC1JeI9B3q0=",
+    "polished": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-2.3.1.tgz",
+      "integrity": "sha512-0mGyvVrHVRN92wfohriBWmMF4JLEnGgpZbpwPrNDhpB8NrX6lYI8GGWXEfrmrF+ZXg52Jkwd+D0rxViOvXM9RQ==",
       "requires": {
-        "json-pointer": "^0.6.0"
+        "@babel/runtime": "7.2.0"
       }
-    },
-    "parse5": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "perfect-scrollbar": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-0.8.1.tgz",
-      "integrity": "sha512-RNC5tX/JMRYR+qVdJTEAWnRxw0Yf9lvbO8lTuAOvgDODkiA8lveTSkvrNMhmaGKEyimJpJl+myb/syVS9YyPuw=="
     },
     "prismjs": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.15.0.tgz",
       "integrity": "sha512-Lf2JrFYx8FanHrjoV5oL8YHCclLQgbJcVZR+gikGGMqz6ub5QVWDTM6YIwm3BuPxM/LOV+rKns3LssXNLIf+DA==",
       "requires": {
-        "clipboard": "^2.0.0"
+        "clipboard": "2.0.1"
       }
     },
-    "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    "process": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
     },
-    "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+    "prop-types": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "loose-envify": "1.4.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "react-dropdown": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/react-dropdown/-/react-dropdown-1.6.3.tgz",
+      "integrity": "sha512-UAcVCsxeIkn5N7xpHr+WHDPbtUO+LsJyGiUT5PsdkVVPDJp9e42oxGICDyjcQ5rWa7DS0ctmn770JcM4gIvTiQ==",
+      "requires": {
+        "classnames": "2.2.6"
+      }
+    },
+    "react-hot-loader": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.6.3.tgz",
+      "integrity": "sha512-FUvRO8dwbeLnc3mgLn8ARuSh8NnLBYJyiRjFn+grY/5GupSyPqv0U7ixgwXro77hwDplhm8z9wU7FlJ8kZqiAQ==",
+      "requires": {
+        "fast-levenshtein": "2.0.6",
+        "global": "4.3.2",
+        "hoist-non-react-statics": "2.5.5",
+        "loader-utils": "1.2.3",
+        "lodash.merge": "4.6.1",
+        "prop-types": "15.6.2",
+        "react-lifecycles-compat": "3.0.4",
+        "shallowequal": "1.1.0",
+        "source-map": "0.7.3"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        }
+      }
+    },
+    "react-is": {
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.7.0.tgz",
+      "integrity": "sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g=="
+    },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-tabs": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-2.3.0.tgz",
+      "integrity": "sha512-pYaefgVy76/36AMEP+B8YuVVzDHa3C5UFZ3REU78zolk0qMxEhKvUFofvDCXyLZwf0RZjxIfiwok1BEb18nHyA==",
+      "requires": {
+        "classnames": "2.2.6",
+        "prop-types": "15.6.2"
       }
     },
     "redoc": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/redoc/-/redoc-1.22.2.tgz",
-      "integrity": "sha512-CaCCxqEkE3vdwmbesviYl8e/J7B/blT3HE1Hb+dR2KhIx1NfZYro4dOstIpjtjERIBBILsLIwYdUtPhrf3+CNA==",
+      "version": "2.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.0.tgz",
+      "integrity": "sha512-xH0xZ0mYFgWp4aUk9TAsGUKlyiT5Ph0MvhO3rK/cKUaCUZ+vwuOANA00Sf5hOMtXnjsXgJxC7i7fJ7tyX2yxWg==",
       "requires": {
-        "core-js": "^2.5.1",
-        "dropkickjs": "~2.1.10",
-        "hint.css": "2.3.2",
-        "https-browserify": "^1.0.0",
-        "json-pointer": "^0.6.0",
-        "json-schema-ref-parser": "^3.3.1",
-        "lunr": "^1.0.0",
-        "mark.js": "^8.11.1",
-        "openapi-sampler": "1.0.0-beta.8",
-        "perfect-scrollbar": "^0.8.1",
-        "prismjs": "^1.8.1",
-        "remarkable": "1.7.1",
-        "scrollparent": "^2.0.1",
-        "slugify": "^1.2.1",
-        "stream-http": "^2.6.1",
-        "ts-helpers": "^1.1.2",
-        "zone.js": "^0.8.17"
+        "classnames": "2.2.6",
+        "decko": "1.2.0",
+        "dompurify": "1.0.8",
+        "eventemitter3": "3.1.0",
+        "json-pointer": "0.6.0",
+        "json-schema-ref-parser": "6.0.2",
+        "lunr": "2.3.5",
+        "mark.js": "8.11.1",
+        "marked": "git+https://github.com/markedjs/marked.git#fb48827236ed3a43e611d2adb3c070ca3f55ed8e",
+        "memoize-one": "4.1.0",
+        "mobx-react": "5.4.3",
+        "openapi-sampler": "1.0.0-beta.14",
+        "perfect-scrollbar": "1.4.0",
+        "polished": "2.3.1",
+        "prismjs": "1.15.0",
+        "prop-types": "15.6.2",
+        "react-dropdown": "1.6.3",
+        "react-hot-loader": "4.6.3",
+        "react-tabs": "2.3.0",
+        "slugify": "1.3.2",
+        "stickyfill": "1.1.1",
+        "tslib": "1.9.3"
       },
       "dependencies": {
-        "core-js": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
-        }
-      }
-    },
-    "reflect-metadata": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.12.tgz",
-      "integrity": "sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A=="
-    },
-    "remarkable": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.1.tgz",
-      "integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=",
-      "requires": {
-        "argparse": "~0.1.15",
-        "autolinker": "~0.15.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "0.1.16",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
-          "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
+        "json-schema-ref-parser": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.0.2.tgz",
+          "integrity": "sha512-EENU7mrmuBAdjSsAEJD8mMvodZyDhLBEfuSUBSIMuXqjs+cfMbFaxS8f6+ky675jetRzGzCdhzAU3y2VEtquvQ==",
           "requires": {
-            "underscore": "~1.7.0",
-            "underscore.string": "~2.4.0"
+            "call-me-maybe": "1.0.1",
+            "js-yaml": "3.12.0",
+            "ono": "4.0.10"
           }
+        },
+        "lunr": {
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.5.tgz",
+          "integrity": "sha512-EtnfmHsHJTr3u24sito9JctSxej5Ds0SgUD2Lm+qRHyLgM7BGesFlW14eNh1mil0fV5Muh8gf3dBBXzADlUlzQ=="
+        },
+        "openapi-sampler": {
+          "version": "1.0.0-beta.14",
+          "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0-beta.14.tgz",
+          "integrity": "sha512-NNmH9YAN5AaCE4w6MQXdCrmsOJJQTswHVSp075+h+iiG+OTonpZE8HzwocozovD2imx4lamkuxGLs4E4bO4Z+g==",
+          "requires": {
+            "json-pointer": "0.6.0"
+          }
+        },
+        "perfect-scrollbar": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.4.0.tgz",
+          "integrity": "sha512-/2Sk/khljhdrsamjJYS5NjrH+GKEHEwh7zFSiYyxROyYKagkE4kSn2zDQDRTOMo8mpT2jikxx6yI1dG7lNP/hw=="
         }
       }
     },
-    "rxjs": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.3.1.tgz",
-      "integrity": "sha1-nsyeciJH5PRJDTCoeFd6N0D9DLc=",
-      "requires": {
-        "symbol-observable": "^1.0.1"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "scrollparent": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.0.1.tgz",
-      "integrity": "sha1-cV1bnMV3YPsivczDvvtb/gaxoxc="
+    "regenerator-runtime": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "select": {
       "version": "1.1.2",
@@ -400,53 +379,25 @@
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
       "optional": true
     },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+    },
     "slugify": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.2.tgz",
       "integrity": "sha512-RB7T2QO4+F8zc5UA+yujQb8V5GDmyiGzCW7e/x5CyKUEx0xzI9Hz5ptOS85GDBHlDx6LDooyHxw5FwKkximL5Q=="
-    },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-    },
-    "source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "requires": {
-        "source-map": "^0.5.6"
-      }
     },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
-    "stream-http": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
-      "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.6",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
-    "string_decoder": {
+    "stickyfill": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+      "resolved": "https://registry.npmjs.org/stickyfill/-/stickyfill-1.1.1.tgz",
+      "integrity": "sha1-OUE/7p0CXHSn5ZzuyyN4TMDxfwI="
     },
     "tiny-emitter": {
       "version": "2.0.2",
@@ -454,85 +405,10 @@
       "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow==",
       "optional": true
     },
-    "to-arraybuffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
-    },
-    "ts-helpers": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ts-helpers/-/ts-helpers-1.1.2.tgz",
-      "integrity": "sha1-/Gm+nx87rtAfsaDvjUz+dIgU2DU="
-    },
-    "tsickle": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.21.6.tgz",
-      "integrity": "sha1-U7Abl5xcE/2xOvs/uVgXflmRWI0=",
-      "requires": {
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "source-map": "^0.5.6",
-        "source-map-support": "^0.4.2"
-      }
-    },
-    "typescript": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
-      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ="
-    },
-    "underscore": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
-    },
-    "underscore.string": {
-      "version": "2.4.0",
-      "resolved": "http://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
-      "integrity": "sha1-jN2PusTi0uoefi6Al8QvRCKA+Fs="
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "validator": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-10.8.0.tgz",
-      "integrity": "sha512-mXqMxfCh5NLsVgYVKl9WvnHNDPCcbNppHSPPowu0VjtSsGWVY+z8hJF44edLR1nbLNzi3jYoYsIl8KZpioIk6g=="
-    },
-    "xhr2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
-      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8="
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-    },
-    "z-schema": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.24.1.tgz",
-      "integrity": "sha512-2eR8eq/v1coNqyBc5HzswEcoLbw+S33RMnR326uiuOIr97ve5vwPNMDrKS1IRCB12bZ3a8BrfGxrRwuSXUyPvw==",
-      "requires": {
-        "commander": "^2.7.1",
-        "core-js": "^2.5.7",
-        "lodash.get": "^4.0.0",
-        "lodash.isequal": "^4.0.0",
-        "validator": "^10.0.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.5.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
-        }
-      }
-    },
-    "zone.js": {
-      "version": "0.8.26",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.26.tgz",
-      "integrity": "sha512-W9Nj+UmBJG251wkCacIkETgra4QgBo/vgoEkb4a2uoLzpQG7qF9nzwoLXWU5xj3Fg2mxGvEDh47mg24vXccYjA=="
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     }
   }
 }

--- a/src/Swashbuckle.AspNetCore.ReDoc/package-lock.json
+++ b/src/Swashbuckle.AspNetCore.ReDoc/package-lock.json
@@ -5,11 +5,11 @@
   "requires": true,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
-      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+      "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
       "requires": {
-        "regenerator-runtime": "0.12.1"
+        "regenerator-runtime": "^0.12.0"
       }
     },
     "argparse": {
@@ -17,7 +17,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "big.js": {
@@ -36,14 +36,14 @@
       "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "clipboard": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.1.tgz",
-      "integrity": "sha512-7yhQBmtN+uYZmfRjjVjKa0dZdWuabzpSKGtyQZN+9C8xlC788SSJjOHWh7tzurfwTqTD5UDYAhIv5fRJg3sHjQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
+      "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
       "optional": true,
       "requires": {
-        "good-listener": "1.2.2",
-        "select": "1.1.2",
-        "tiny-emitter": "2.0.2"
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
       }
     },
     "decko": {
@@ -63,9 +63,9 @@
       "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "dompurify": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-1.0.8.tgz",
-      "integrity": "sha512-vetRFbN1SXSPfP3ClIiYnxTrXquSqakBEOoB5JESn0SVcSYzpu6ougjakpKnskGctYdlNpwf+riUHSkG7d4XUw=="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-1.0.9.tgz",
+      "integrity": "sha512-lt9f3A3RO1OCNaWdA+s/k7YVn0Typ5MbAKmX94PLCZbs8wLNccX3Bj4xXA7GLKOoDb/MeVoAoeIJarZD1JUnjg=="
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -102,8 +102,8 @@
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
       }
     },
     "good-listener": {
@@ -112,7 +112,7 @@
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "optional": true,
       "requires": {
-        "delegate": "3.2.0"
+        "delegate": "^3.1.2"
       }
     },
     "hoist-non-react-statics": {
@@ -120,7 +120,7 @@
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz",
       "integrity": "sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==",
       "requires": {
-        "react-is": "16.7.0"
+        "react-is": "^16.3.2"
       }
     },
     "js-tokens": {
@@ -129,12 +129,12 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "json-pointer": {
@@ -142,15 +142,25 @@
       "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.0.tgz",
       "integrity": "sha1-jlAFUKaqxUZKRzN32leqbMIoKNc=",
       "requires": {
-        "foreach": "2.0.5"
+        "foreach": "^2.0.4"
+      }
+    },
+    "json-schema-ref-parser": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.0.3.tgz",
+      "integrity": "sha512-Ds/0541IPed88JSiMb3CBeUsxfL5Eosc0r97z0QMSXiBJTYKZLhOAGZd8zFVfpkKaRb4zDAnumyFYxnHLmbQmw==",
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.12.1",
+        "ono": "^4.0.11"
       }
     },
     "json5": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "^1.2.0"
       }
     },
     "loader-utils": {
@@ -158,9 +168,9 @@
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
       "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
       "requires": {
-        "big.js": "5.2.2",
-        "emojis-list": "2.1.0",
-        "json5": "1.0.1"
+        "big.js": "^5.2.2",
+        "emojis-list": "^2.0.0",
+        "json5": "^1.0.1"
       }
     },
     "lodash.merge": {
@@ -173,8 +183,13 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
-        "js-tokens": "4.0.0"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "lunr": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.5.tgz",
+      "integrity": "sha512-EtnfmHsHJTr3u24sito9JctSxej5Ds0SgUD2Lm+qRHyLgM7BGesFlW14eNh1mil0fV5Muh8gf3dBBXzADlUlzQ=="
     },
     "mark.js": {
       "version": "8.11.1",
@@ -182,19 +197,21 @@
       "integrity": "sha1-GA8fnr74sOY45BZq1S24eb6y/8U="
     },
     "marked": {
-      "version": "git+https://github.com/markedjs/marked.git#fb48827236ed3a43e611d2adb3c070ca3f55ed8e"
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.0.tgz",
+      "integrity": "sha512-HduzIW2xApSXKXJSpCipSxKyvMbwRRa/TwMbepmlZziKdH8548WSoDP4SxzulEKjlo8BE39l+2fwJZuRKOln6g=="
     },
     "memoize-one": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.1.0.tgz",
-      "integrity": "sha512-2GApq0yI/b22J2j9rhbrAlsHb0Qcz+7yWxeLG8h+95sl1XPUgeLimQSOdur4Vw7cUhrBHwaUZxWFZueojqNRzA=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+      "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
     },
     "min-document": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "requires": {
-        "dom-walk": "0.1.1"
+        "dom-walk": "^0.1.0"
       }
     },
     "minimist": {
@@ -207,8 +224,8 @@
       "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-5.4.3.tgz",
       "integrity": "sha512-WC8yFlwvJ91hy8j6CrydAuFteUafcuvdITFQeHl3LRIf5ayfT/4W3M/byhEYD2BcJWejeXr8y4Rh2H26RunCRQ==",
       "requires": {
-        "hoist-non-react-statics": "3.2.1",
-        "react-lifecycles-compat": "3.0.4"
+        "hoist-non-react-statics": "^3.0.0",
+        "react-lifecycles-compat": "^3.0.2"
       }
     },
     "object-assign": {
@@ -217,19 +234,32 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "ono": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.10.tgz",
-      "integrity": "sha512-4Xz4hlbq7MzV0I3vKfZwRvyj8tCbXODqBNzFqtkjP+KTV93zzDRju8kw1qnf6P5kcZ2+xlIq6wSCqA+euSKxhA==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
+      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
       "requires": {
-        "format-util": "1.0.3"
+        "format-util": "^1.0.3"
       }
     },
-    "polished": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-2.3.1.tgz",
-      "integrity": "sha512-0mGyvVrHVRN92wfohriBWmMF4JLEnGgpZbpwPrNDhpB8NrX6lYI8GGWXEfrmrF+ZXg52Jkwd+D0rxViOvXM9RQ==",
+    "openapi-sampler": {
+      "version": "1.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0-beta.14.tgz",
+      "integrity": "sha512-NNmH9YAN5AaCE4w6MQXdCrmsOJJQTswHVSp075+h+iiG+OTonpZE8HzwocozovD2imx4lamkuxGLs4E4bO4Z+g==",
       "requires": {
-        "@babel/runtime": "7.2.0"
+        "json-pointer": "^0.6.0"
+      }
+    },
+    "perfect-scrollbar": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.4.0.tgz",
+      "integrity": "sha512-/2Sk/khljhdrsamjJYS5NjrH+GKEHEwh7zFSiYyxROyYKagkE4kSn2zDQDRTOMo8mpT2jikxx6yI1dG7lNP/hw=="
+    },
+    "polished": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-2.3.3.tgz",
+      "integrity": "sha512-59V4fDbdxtH4I1m9TWxFsoGJbC8nnOpUYo5uFmvMfKp9Qh+6suo4VMUle1TGIIUZIGxfkW+Rs485zPk0wcwR2Q==",
+      "requires": {
+        "@babel/runtime": "^7.2.0"
       }
     },
     "prismjs": {
@@ -237,7 +267,7 @@
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.15.0.tgz",
       "integrity": "sha512-Lf2JrFYx8FanHrjoV5oL8YHCclLQgbJcVZR+gikGGMqz6ub5QVWDTM6YIwm3BuPxM/LOV+rKns3LssXNLIf+DA==",
       "requires": {
-        "clipboard": "2.0.1"
+        "clipboard": "^2.0.0"
       }
     },
     "process": {
@@ -250,8 +280,8 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
       "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "requires": {
-        "loose-envify": "1.4.0",
-        "object-assign": "4.1.1"
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "react-dropdown": {
@@ -259,7 +289,7 @@
       "resolved": "https://registry.npmjs.org/react-dropdown/-/react-dropdown-1.6.3.tgz",
       "integrity": "sha512-UAcVCsxeIkn5N7xpHr+WHDPbtUO+LsJyGiUT5PsdkVVPDJp9e42oxGICDyjcQ5rWa7DS0ctmn770JcM4gIvTiQ==",
       "requires": {
-        "classnames": "2.2.6"
+        "classnames": "^2.2.3"
       }
     },
     "react-hot-loader": {
@@ -267,26 +297,21 @@
       "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.6.3.tgz",
       "integrity": "sha512-FUvRO8dwbeLnc3mgLn8ARuSh8NnLBYJyiRjFn+grY/5GupSyPqv0U7ixgwXro77hwDplhm8z9wU7FlJ8kZqiAQ==",
       "requires": {
-        "fast-levenshtein": "2.0.6",
-        "global": "4.3.2",
-        "hoist-non-react-statics": "2.5.5",
-        "loader-utils": "1.2.3",
-        "lodash.merge": "4.6.1",
-        "prop-types": "15.6.2",
-        "react-lifecycles-compat": "3.0.4",
-        "shallowequal": "1.1.0",
-        "source-map": "0.7.3"
+        "fast-levenshtein": "^2.0.6",
+        "global": "^4.3.0",
+        "hoist-non-react-statics": "^2.5.0",
+        "loader-utils": "^1.1.0",
+        "lodash.merge": "^4.6.1",
+        "prop-types": "^15.6.1",
+        "react-lifecycles-compat": "^3.0.4",
+        "shallowequal": "^1.0.2",
+        "source-map": "^0.7.3"
       },
       "dependencies": {
         "hoist-non-react-statics": {
           "version": "2.5.5",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
           "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-        },
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         }
       }
     },
@@ -305,67 +330,37 @@
       "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-2.3.0.tgz",
       "integrity": "sha512-pYaefgVy76/36AMEP+B8YuVVzDHa3C5UFZ3REU78zolk0qMxEhKvUFofvDCXyLZwf0RZjxIfiwok1BEb18nHyA==",
       "requires": {
-        "classnames": "2.2.6",
-        "prop-types": "15.6.2"
+        "classnames": "^2.2.0",
+        "prop-types": "^15.5.0"
       }
     },
     "redoc": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.0.tgz",
-      "integrity": "sha512-xH0xZ0mYFgWp4aUk9TAsGUKlyiT5Ph0MvhO3rK/cKUaCUZ+vwuOANA00Sf5hOMtXnjsXgJxC7i7fJ7tyX2yxWg==",
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.1.tgz",
+      "integrity": "sha512-8PCUWEqkI3D5SXmreYJNHo5GtcOEOVgJecXws4XR6vKwLylYiNSVAh0DzvEa+oehDvVBI4iZcizi+hXAXOfxMA==",
       "requires": {
-        "classnames": "2.2.6",
-        "decko": "1.2.0",
-        "dompurify": "1.0.8",
-        "eventemitter3": "3.1.0",
-        "json-pointer": "0.6.0",
-        "json-schema-ref-parser": "6.0.2",
-        "lunr": "2.3.5",
-        "mark.js": "8.11.1",
-        "marked": "git+https://github.com/markedjs/marked.git#fb48827236ed3a43e611d2adb3c070ca3f55ed8e",
-        "memoize-one": "4.1.0",
-        "mobx-react": "5.4.3",
+        "classnames": "^2.2.6",
+        "decko": "^1.2.0",
+        "dompurify": "^1.0.7",
+        "eventemitter3": "^3.0.0",
+        "json-pointer": "^0.6.0",
+        "json-schema-ref-parser": "^6.0.1",
+        "lunr": "^2.3.2",
+        "mark.js": "^8.11.1",
+        "marked": "^0.6.0",
+        "memoize-one": "^4.0.0",
+        "mobx-react": "^5.2.5",
         "openapi-sampler": "1.0.0-beta.14",
-        "perfect-scrollbar": "1.4.0",
-        "polished": "2.3.1",
-        "prismjs": "1.15.0",
-        "prop-types": "15.6.2",
-        "react-dropdown": "1.6.3",
-        "react-hot-loader": "4.6.3",
-        "react-tabs": "2.3.0",
-        "slugify": "1.3.2",
-        "stickyfill": "1.1.1",
-        "tslib": "1.9.3"
-      },
-      "dependencies": {
-        "json-schema-ref-parser": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.0.2.tgz",
-          "integrity": "sha512-EENU7mrmuBAdjSsAEJD8mMvodZyDhLBEfuSUBSIMuXqjs+cfMbFaxS8f6+ky675jetRzGzCdhzAU3y2VEtquvQ==",
-          "requires": {
-            "call-me-maybe": "1.0.1",
-            "js-yaml": "3.12.0",
-            "ono": "4.0.10"
-          }
-        },
-        "lunr": {
-          "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.5.tgz",
-          "integrity": "sha512-EtnfmHsHJTr3u24sito9JctSxej5Ds0SgUD2Lm+qRHyLgM7BGesFlW14eNh1mil0fV5Muh8gf3dBBXzADlUlzQ=="
-        },
-        "openapi-sampler": {
-          "version": "1.0.0-beta.14",
-          "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0-beta.14.tgz",
-          "integrity": "sha512-NNmH9YAN5AaCE4w6MQXdCrmsOJJQTswHVSp075+h+iiG+OTonpZE8HzwocozovD2imx4lamkuxGLs4E4bO4Z+g==",
-          "requires": {
-            "json-pointer": "0.6.0"
-          }
-        },
-        "perfect-scrollbar": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-1.4.0.tgz",
-          "integrity": "sha512-/2Sk/khljhdrsamjJYS5NjrH+GKEHEwh7zFSiYyxROyYKagkE4kSn2zDQDRTOMo8mpT2jikxx6yI1dG7lNP/hw=="
-        }
+        "perfect-scrollbar": "^1.4.0",
+        "polished": "^2.0.2",
+        "prismjs": "^1.15.0",
+        "prop-types": "^15.6.2",
+        "react-dropdown": "^1.6.2",
+        "react-hot-loader": "^4.3.5",
+        "react-tabs": "^2.0.0",
+        "slugify": "^1.3.1",
+        "stickyfill": "^1.1.1",
+        "tslib": "^1.9.3"
       }
     },
     "regenerator-runtime": {
@@ -385,9 +380,14 @@
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "slugify": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.2.tgz",
-      "integrity": "sha512-RB7T2QO4+F8zc5UA+yujQb8V5GDmyiGzCW7e/x5CyKUEx0xzI9Hz5ptOS85GDBHlDx6LDooyHxw5FwKkximL5Q=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.4.tgz",
+      "integrity": "sha512-KP0ZYk5hJNBS8/eIjGkFDCzGQIoZ1mnfQRYS5WM3273z+fxGWXeN0fkwf2ebEweydv9tioZIHGZKoF21U07/nw=="
+    },
+    "source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/src/Swashbuckle.AspNetCore.ReDoc/package.json
+++ b/src/Swashbuckle.AspNetCore.ReDoc/package.json
@@ -3,18 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "redoc": "1.22.2",
-    "@angular/common": "4.1.1",
-    "@angular/compiler": "4.1.1",
-    "@angular/compiler-cli": "4.1.1",
-    "@angular/core": "4.1.1",
-    "@angular/forms": "4.1.1",
-    "@angular/platform-browser": "4.1.1",
-    "@angular/platform-browser-dynamic": "4.1.1",
-    "@angular/platform-server": "4.1.1",
-    "@angular/animations": "4.1.1",
-    "core-js": "2.4.1",
-    "rxjs": "5.3.1",
-    "typescript": "2.5.2"
+    "redoc": "2.0.0-rc.0"
   }
 }

--- a/src/Swashbuckle.AspNetCore.ReDoc/package.json
+++ b/src/Swashbuckle.AspNetCore.ReDoc/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "redoc": "2.0.0-rc.0"
+    "redoc": "2.0.0-rc.1"
   }
 }


### PR DESCRIPTION
- Updated ReDoc to version 2.0.0-rc.1. This enables OpenAPI 3.0 support.
- Added documentation in README-v5 for ReDoc options.
- Removed ReDoc options that are not in 2.0.0-rc.1. (While doing this I also noticed why the "SupressWarnings" do not work in pre version 5 Swashbuckle, it should be "SuppressWarnings".)
- Added extension methods for ReDoc options.

Since ReDoc is not yet in stable 2.0 this PR should (if considered ok) be merged before Swashbuckle 5.0 is released (since ReDoc 1.x does not work with OpenAPI 3) or when ReDoc 2.0 is released.