### PR TITLE
[Bugfix] Ignore missing properties when mapping metadata

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
@@ -39,8 +39,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             if (schema.Properties == null) return;
             foreach (var entry in schema.Properties)
             {
+                if (!jsonObjectContract.Properties.Contains(entry.Key))
+                {
+                    continue;
+                }
                 var jsonProperty = jsonObjectContract.Properties[entry.Key];
-                if (jsonProperty == null) continue;
 
                 if (jsonProperty.TryGetMemberInfo(out MemberInfo memberInfo))
                 {

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
@@ -89,6 +89,28 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal(expectedValueString, GetOpenApiPrimitiveValue(openApiPrimitive).ToString());
         }
 
+        [Theory]
+        [InlineData(typeof(XmlAnnotatedType), "MissingStringProperty", "string")]
+        [InlineData(typeof(XmlAnnotatedType), "MissingIntegerProperty", "integer")]
+        public void Apply_IgnoresNonexistingProperty(Type type,
+            string propertyName,
+            string propertyType)
+        {
+            var schema = new OpenApiSchema
+            {
+                Properties = new Dictionary<string, OpenApiSchema>()
+                {
+                    { propertyName, new OpenApiSchema() { Type = propertyType } }
+                }
+            };
+            var filterContext = FilterContextFor(type);
+
+            Subject().Apply(schema, filterContext);
+
+            var openApiSchema = schema.Properties[propertyName];
+            Assert.Equal(propertyType, openApiSchema.Type);
+        }
+
         private static object GetOpenApiPrimitiveValue(IOpenApiPrimitive primitive)
         {
             return primitive.GetType().GetProperty("Value").GetValue(primitive);


### PR DESCRIPTION
This code:
```
var jsonProperty = jsonObjectContract.Properties[entry.Key];
if (jsonProperty == null) continue;
```
will fail with at the first line with an exception when entry.Key is not present in the dictionary. The check should be done beforehand. I added a rudimentary test that fails without this change, but passes after the change is introduced. Thanks.