### PR TITLE
Escape `dotnet-swagger.dll` path in CLI tool

### DIFF
--- a/src/Swashbuckle.AspNetCore.Cli/Program.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/Program.cs
@@ -41,7 +41,7 @@ namespace Swashbuckle.AspNetCore.Cli
                         "exec --depsfile {0} --runtimeconfig {1} {2} _{3}", // note the underscore
                         EscapePath(depsFile),
                         EscapePath(runtimeConfig),
-                        typeof(Program).GetTypeInfo().Assembly.Location,
+                        EscapePath(typeof(Program).GetTypeInfo().Assembly.Location),
                         string.Join(" ", args)
                     ));
 


### PR DESCRIPTION
If `dotnet-swagger.dll` is placed in a path with spaces then the assembly location used when respawning `dotnet` is not escaped.

Fixes #845 