### PR TITLE
Updating content-type header for swagger page

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -79,7 +79,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         private async Task RespondWithIndexHtml(HttpResponse response)
         {
             response.StatusCode = 200;
-            response.ContentType = "text/html";
+            response.ContentType = "text/html;charset=utf-8";
 
             using (var stream = _options.IndexStream())
             {


### PR DESCRIPTION
Adding the charset to the ContentType, when delivering the html.
Since the response is encoded in utf-8 (see line 93) it makes sense to also include that in the ContentType.

Not sure what happened to that bracket at the end of the file.