### PR TITLE
Fix Swashbuckle not tagging write-only properties

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaRegistry.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaRegistry.cs
@@ -231,6 +231,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private OpenApiSchema CreateObjectSchema(JsonObjectContract jsonContract, Queue<Type> referencedTypes)
         {
             var applicableJsonProperties = jsonContract.Properties
+                .Where(prop => prop.Readable)
                 .Where(prop => !prop.Ignored)
                 .Where(prop => !(_options.IgnoreObsoleteProperties && prop.IsObsolete()))
                 .Select(prop => prop);

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaRegistry.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SchemaRegistry.cs
@@ -231,7 +231,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private OpenApiSchema CreateObjectSchema(JsonObjectContract jsonContract, Queue<Type> referencedTypes)
         {
             var applicableJsonProperties = jsonContract.Properties
-                .Where(prop => prop.Readable)
                 .Where(prop => !prop.Ignored)
                 .Where(prop => !(_options.IgnoreObsoleteProperties && prop.IsObsolete()))
                 .Select(prop => prop);
@@ -265,6 +264,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             if (!jsonProperty.Writable)
                 OpenApiSchema.ReadOnly = true;
+
+            if (!jsonProperty.Readable)
+                OpenApiSchema.WriteOnly = true;
 
             if (jsonProperty.TryGetMemberInfo(out MemberInfo memberInfo))
                 OpenApiSchema.AssignAttributeMetadata(memberInfo.GetCustomAttributes(true));

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
@@ -174,12 +174,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Null(schema.Properties["Property4"].Format);
             Assert.Equal("string", schema.Properties["Property5"].Type);
             Assert.Null(schema.Properties["Property5"].Format);
-            Assert.Equal(false, schema.Properties["Property1"].ReadOnly);
-            Assert.Equal(false, schema.Properties["Property2"].ReadOnly);
-            Assert.Equal(false, schema.Properties["Property3"].ReadOnly);
-            Assert.Equal(false, schema.Properties["Property4"].ReadOnly);
             Assert.Equal(false, schema.Properties["Property5"].ReadOnly);
+            Assert.Equal(false, schema.Properties["Property5"].WriteOnly);
             Assert.Equal(true, schema.Properties["Property6"].ReadOnly);
+            Assert.Equal(false, schema.Properties["Property6"].WriteOnly);
+            Assert.Equal(false, schema.Properties["Property7"].ReadOnly);
+            Assert.Equal(true, schema.Properties["Property7"].WriteOnly);
         }
 
         [Fact]
@@ -450,7 +450,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var componentOpenApiSchema = subject.Schemas["ComplexType"];
             Assert.NotNull(componentOpenApiSchema);
             Assert.Equal("object", componentOpenApiSchema.Type);
-            Assert.Equal(6, componentOpenApiSchema.Properties.Count);
+            Assert.Equal(7, componentOpenApiSchema.Properties.Count);
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
@@ -174,6 +174,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Null(schema.Properties["Property4"].Format);
             Assert.Equal("string", schema.Properties["Property5"].Type);
             Assert.Null(schema.Properties["Property5"].Format);
+            Assert.Equal(false, schema.Properties["Property1"].ReadOnly);
+            Assert.Equal(false, schema.Properties["Property2"].ReadOnly);
+            Assert.Equal(false, schema.Properties["Property3"].ReadOnly);
+            Assert.Equal(false, schema.Properties["Property4"].ReadOnly);
+            Assert.Equal(false, schema.Properties["Property5"].ReadOnly);
+            Assert.Equal(true, schema.Properties["Property6"].ReadOnly);
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SchemaRegistryTests.cs
@@ -444,7 +444,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var componentOpenApiSchema = subject.Schemas["ComplexType"];
             Assert.NotNull(componentOpenApiSchema);
             Assert.Equal("object", componentOpenApiSchema.Type);
-            Assert.Equal(5, componentOpenApiSchema.Properties.Count);
+            Assert.Equal(6, componentOpenApiSchema.Properties.Count);
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SwaggerGeneratorTests.cs
@@ -386,7 +386,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.All(requestBody.Content.Values, mediaType =>
             {
                 Assert.NotNull(mediaType.Schema);
-                Assert.Equal(5, mediaType.Schema.Properties.Count);
+                Assert.Equal(6, mediaType.Schema.Properties.Count);
                 Assert.NotNull(mediaType.Encoding);
             });
         }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Types/ComplexType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/TestFixtures/Types/ComplexType.cs
@@ -13,5 +13,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public string Property4 { get; set; }
 
         public char Property5 { get; set; }
+
+        public string Property6 { get; }
+
+        public string Property7 { set { } }
     }
 }


### PR DESCRIPTION
Fix, with tests, for #1027.

Note that the API test for `ComplexType` is now returning six properties (i.e. ignoring the new write-only property) automatically; it was only Swashbuckle that needed to be changed to also ignore it.

I hope I've put the check for non-readable properties in a sensible place, but let me know if not!