### PR TITLE
Support default value for enums (required revert to inline enu…

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Application/ConfigureSchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Application/ConfigureSchemaGeneratorOptions.cs
@@ -33,6 +33,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             target.CustomTypeMappings = new Dictionary<Type, Func<OpenApiSchema>>(source.CustomTypeMappings);
             target.DescribeAllEnumsAsStrings = source.DescribeAllEnumsAsStrings;
             target.DescribeStringEnumsInCamelCase = source.DescribeStringEnumsInCamelCase;
+            target.UseReferencedDefinitionsForEnums = source.UseReferencedDefinitionsForEnums;
             target.SchemaIdSelector = source.SchemaIdSelector;
             target.IgnoreObsoleteProperties = source.IgnoreObsoleteProperties;
             target.GeneratePolymorphicSchemas = source.GeneratePolymorphicSchemas;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Application/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Application/SwaggerGenOptionsExtensions.cs
@@ -187,6 +187,14 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Use referenced schema definitions instead of inline schema's for enum types
+        /// </summary>
+        public static void UseReferencedDefinitionsForEnums(this SwaggerGenOptions swaggerGenOptions)
+        {
+            swaggerGenOptions.SchemaGeneratorOptions.UseReferencedDefinitionsForEnums = true;
+        }
+
+        /// <summary>
         /// Provide a custom strategy for generating the unique Id's that are used to reference object Schema's
         /// </summary>
         /// <param name="swaggerGenOptions"></param>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/SwaggerGenerator.cs
@@ -213,7 +213,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             if (defaultValue != null && schema.Reference == null)
             {
-                schema.Default = OpenApiAnyFactory.TryCreateFrom(defaultValue, out IOpenApiAny openApiAny)
+                schema.Default = OpenApiAnyFactory.TryCreateFor(schema, defaultValue, out IOpenApiAny openApiAny)
                     ? openApiAny
                     : null;
             }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/ObjectSchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/ObjectSchemaGenerator.cs
@@ -72,7 +72,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             {
                 if (attribute is DefaultValueAttribute defaultValue)
                 {
-                    schema.Default = OpenApiAnyFactory.TryCreateFrom(defaultValue.Value, out IOpenApiAny openApiAny)
+                    schema.Default = OpenApiAnyFactory.TryCreateFor(schema, defaultValue.Value, out IOpenApiAny openApiAny)
                         ? openApiAny
                         : schema.Default;
                 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/PrimitiveSchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/PrimitiveSchemaGenerator.cs
@@ -71,7 +71,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     .Select(value =>
                     {
                         value = Convert.ChangeType(value, enumUnderlyingType);
-                        return OpenApiAnyFactory.TryCreateFrom(value, out IOpenApiAny openApiAny) ? openApiAny : null;
+                        return OpenApiAnyFactory.TryCreateFor(schema, value, out IOpenApiAny openApiAny) ? openApiAny : null;
                     })
                     .ToList();
             }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/ReferencedSchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/ReferencedSchemaGenerator.cs
@@ -14,7 +14,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             var jsonContract = ContractResolver.ResolveContract(type);
 
-            return type.IsEnum // enum
+            return (type.IsEnum && Options.UseReferencedDefinitionsForEnums) // enum
                 || (jsonContract is JsonObjectContract) // regular object
                 || (jsonContract is JsonArrayContract && ((JsonArrayContract)jsonContract).CollectionItemType == jsonContract.UnderlyingType) // self-referencing array
                 || (jsonContract is JsonDictionaryContract && ((JsonDictionaryContract)jsonContract).DictionaryValueType == jsonContract.UnderlyingType); // self-referencing dictionary

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/SchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/SchemaGeneratorOptions.cs
@@ -21,6 +21,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public bool DescribeStringEnumsInCamelCase { get; set; }
 
+        public bool UseReferencedDefinitionsForEnums { get; set; }
+
         public Func<Type, string> SchemaIdSelector { get; set; }
 
         public bool IgnoreObsoleteProperties { get; set; }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
@@ -69,26 +69,26 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             {
                 var exampleString = XmlCommentsTextHelper.Humanize(exampleNode.InnerXml);
                 var memberType = (memberInfo.MemberType & MemberTypes.Field) != 0 ? ((FieldInfo) memberInfo).FieldType : ((PropertyInfo) memberInfo).PropertyType;
-                propertySchema.Example = ConvertToOpenApiType(exampleString, memberType);
+                propertySchema.Example = ConvertToOpenApiType(memberType, propertySchema, exampleString);
             }
         }
 
-        private static IOpenApiAny ConvertToOpenApiType(string value, Type type)
+        private static IOpenApiAny ConvertToOpenApiType(Type memberType, OpenApiSchema schema, string stringValue)
         {
-            object typedExample;
+            object typedValue;
 
             try
             {
-                typedExample = TypeDescriptor.GetConverter(type).ConvertFrom(value);
+                typedValue = TypeDescriptor.GetConverter(memberType).ConvertFrom(stringValue);
             }
             catch (Exception)
             {
-                return new OpenApiString(value);
+                return null;
             }
 
-            return OpenApiAnyFactory.TryCreateFrom(typedExample, out IOpenApiAny openApiAny)
+            return OpenApiAnyFactory.TryCreateFor(schema, typedValue, out IOpenApiAny openApiAny)
                 ? openApiAny
-                : new OpenApiString(value);
+                : null;
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Fakes/FakeController.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Fakes/FakeController.cs
@@ -73,6 +73,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void AcceptsOptionalParameter(string param = "foobar")
         { }
 
+        public void AcceptsOptionalJsonConvertedEnum(JsonConvertedEnum param = JsonConvertedEnum.Value1)
+        { }
+
         public void AcceptsStringFromRoute([FromRoute]string param)
         { }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Types/XmlAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Types/XmlAnnotatedType.cs
@@ -9,10 +9,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
     public class XmlAnnotatedType
     {
         /// <summary>
-        /// summary for Property
+        /// summary for BoolProperty
         /// </summary>
-        /// <example>property example</example>
-        public string Property { get; set; }
+        /// <example>true</example>
+        public bool BoolProperty { get; set; }
 
         /// <summary>
         /// summary for IntProperty
@@ -27,22 +27,22 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public long LongProperty { get; set; }
 
         /// <summary>
-        /// summary for DoubleProperty
-        /// </summary>
-        /// <example>1.25</example>
-        public double DoubleProperty { get; set; }
-
-        /// <summary>
         /// summary for FloatProperty
         /// </summary>
         /// <example>1.2</example>
         public float FloatProperty { get; set; }
 
         /// <summary>
-        /// summary for ByteProperty
+        /// summary for DoubleProperty
         /// </summary>
-        /// <example>16</example>
-        public byte ByteProperty { get; set; }
+        /// <example>1.25</example>
+        public double DoubleProperty { get; set; }
+
+        /// <summary>
+        /// summary for EnumProperty
+        /// </summary>
+        /// <example>2</example>
+        public IntEnum EnumProperty { get; set; }
 
         /// <summary>
         /// summary for GuidProperty
@@ -51,16 +51,23 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public Guid GuidProperty { get; set; }
 
         /// <summary>
+        /// summary for StringProperty
+        /// </summary>
+        /// <example>example for StringProperty</example>
+        public string StringProperty { get; set; }
+
+
+        /// <summary>
         /// summary for BadExampleIntProperty
         /// </summary>
         /// <example>property bad example</example>
         public int BadExampleIntProperty { get; set; }
 
         /// <summary>
-        /// summary for Field
+        /// summary for StringField
         /// </summary>
-        /// <example>field example</example>
-        public string Field;
+        /// <example>example for StringField</example>
+        public string StringField;
 
         /// <summary>
         /// summary for BoolField

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SwaggerGeneratorTests.cs
@@ -301,6 +301,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
         [Theory]
         [InlineData(nameof(FakeController.AcceptsOptionalParameter), "param", "foobar")]
+        [InlineData(nameof(FakeController.AcceptsOptionalJsonConvertedEnum), "param", "Value1")]
         [InlineData(nameof(FakeController.AcceptsDataAnnotatedType), "StringWithDefaultValue", "foobar")]
         public void GetSwagger_SetsDefaultValue_IfApiParameterIsOptionalOrHasDefaultValueAttribute(
             string actionFixtureName,

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsMemberNameHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsMemberNameHelperTests.cs
@@ -60,10 +60,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
-        [InlineData(typeof(XmlAnnotatedType), "Property",
-            "P:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedType.Property")]
-        [InlineData(typeof(XmlAnnotatedType), "Field",
-            "F:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedType.Field")]
+        [InlineData(typeof(XmlAnnotatedType), "StringProperty",
+            "P:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedType.StringProperty")]
+        [InlineData(typeof(XmlAnnotatedType), "StringField",
+            "F:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedType.StringField")]
         [InlineData(typeof(XmlAnnotatedType.NestedType), "Property",
             "P:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedType.NestedType.Property")]
         [InlineData(typeof(XmlAnnotatedGenericType<int,string>), "GenericProperty",

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsOperationFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsOperationFilterTests.cs
@@ -53,14 +53,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         {
             var operation = new OpenApiOperation
             {
-                Parameters = new List<OpenApiParameter>() { new OpenApiParameter { Name = "Property" } },
+                Parameters = new List<OpenApiParameter>() { new OpenApiParameter { Name = "StringProperty" } },
                 Responses = new OpenApiResponses()
             };
             var filterContext = FilterContextFor(nameof(XmlAnnotatedController.AcceptsXmlAnnotatedTypeFromQuery));
 
             Subject().Apply(operation, filterContext);
 
-            Assert.Equal("summary for Property", operation.Parameters.First().Description);
+            Assert.Equal("summary for StringProperty", operation.Parameters.First().Description);
         }
 
         [Fact]


### PR DESCRIPTION
Addresses #868

- Revert to inline enum schema's by default (as defaults are parameter/member specific and not type specific) with option to use referenced enum schemas if desired.
- Refactor `OpenApiAnyFactory` to support string enums
