### PR TITLE
ASP.NET Core 3.0 support

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/SchemaGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
@@ -11,8 +10,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     {
         private readonly ChainableSchemaGenerator _generatorChain;
 
-        public SchemaGenerator(IOptions<SchemaGeneratorOptions> optionsAccessor, IOptions<MvcJsonOptions> jsonOptionsAccessor)
-            : this(optionsAccessor.Value, jsonOptionsAccessor.Value?.SerializerSettings)
+        public SchemaGenerator(IOptions<SchemaGeneratorOptions> optionsAccessor, IOptions<JsonSerializerSettings> serializerSettingsAccessor)
+            : this(optionsAccessor.Value, serializerSettingsAccessor.Value)
         { }
 
         public SchemaGenerator(SchemaGeneratorOptions options, JsonSerializerSettings serializerSettings)


### PR DESCRIPTION
Add support for ASP.NET Core 3.0 by removing usage of `MvcJsonOptions`.

This would be a breaking change as part 5.0.0 due to the change to the `SchemaGenerator` constructor.

`Newtonsoft.Json` would still be required, with ASP.NET Core 3.0 having to explicitly reference it if not already in use,, and `IOptions<JsonSerializerSettings>` would have to be manually registered with the application's services if not already present for any version of ASP.NET Core.

This PR is very much a _"bare-minimum"_ suggestion of an approach to unblock ASP.NET Core 3.0 preview 3 and later apps by fixing the runtime error in such applications.

```
crit: Microsoft.AspNetCore.Hosting.Internal.GenericWebHostService[6]
      Application startup exception
System.TypeLoadException: Could not load type 'Microsoft.AspNetCore.Mvc.MvcJsonOptions' from assembly 'Microsoft.AspNetCore.Mvc.Formatters.Json, Version=3.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'.
   at System.Signature.GetSignature(Void* pCorSig, Int32 cCorSig, RuntimeFieldHandleInternal fieldHandle, IRuntimeMethodInfo methodHandle, RuntimeType declaringType)
   at System.Signature..ctor(IRuntimeMethodInfo methodHandle, RuntimeType declaringType)
   at System.Reflection.RuntimeConstructorInfo.get_Signature()
   at System.Reflection.RuntimeConstructorInfo.GetParametersNoCopy()
   at System.Reflection.RuntimeConstructorInfo.GetParameters()
   at Microsoft.Extensions.Internal.ActivatorUtilities.ConstructorMatcher..ctor(ConstructorInfo constructor)
   at Microsoft.Extensions.Internal.ActivatorUtilities.CreateInstance(IServiceProvider provider, Type instanceType, Object[] parameters)
   at Microsoft.AspNetCore.Builder.UseMiddlewareExtensions.<>c__DisplayClass4_0.<UseMiddleware>b__0(RequestDelegate next)
   at Microsoft.AspNetCore.Builder.Internal.ApplicationBuilder.Build()
   at Microsoft.AspNetCore.Hosting.Internal.GenericWebHostService.StartAsync(CancellationToken cancellationToken)
```

Relates to #1030.