### PR TITLE
failing type conversion of short enums

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/OpenApiAnyFactory.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/OpenApiAnyFactory.cs
@@ -13,6 +13,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             if (schema.Type == "boolean" && TryCast(value, out bool boolValue))
                 openApiAny = new OpenApiBoolean(boolValue);
 
+            else if (schema.Type == "integer" && schema.Format == "int32" && TryCast(value, out short shortValue))
+                openApiAny = new OpenApiInteger(shortValue); // preliminary unboxing is required; simply casting to int won't suffice
+
             else if (schema.Type == "integer" && schema.Format == "int32" && TryCast(value, out int intValue))
                 openApiAny = new OpenApiInteger(intValue);
 


### PR DESCRIPTION
An enum of type short leads to a casting error. In order to cast a short enum to int, one must unbox first.
If you wish to fix it in a different way, just throw this pull request away.

https://stackoverflow.com/questions/7648871/directly-unboxing-a-boxed-int-to-short

I wanted to quickly address the issue in test Apply_SetsPropertyExample_FromPropertyExampleTags, but failed to get the test right in a first attempt. Maybe you have an idea how to construct a test case.