### PR TITLE
Fix body parameter handling

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsOperationFilter.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Linq;
-using System.Xml.XPath;
-using System.Reflection;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Xml.XPath;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi.Models;
 
@@ -50,7 +50,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             if (methodNode != null)
             {
                 ApplyMethodXmlToOperation(operation, methodNode);
-                ApplyParamsXmlToActionParameters(operation.Parameters, context.ApiDescription, methodNode);
+                ApplyParamsXmlToActionParameters(operation.Parameters, operation.RequestBody, context.ApiDescription, methodNode);
                 ApplyResponsesXmlToResponses(operation.Responses, methodNode.Select(ResponsesXPath)); // will override controller-level response tags
             }
 
@@ -89,6 +89,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private void ApplyParamsXmlToActionParameters(
             IList<OpenApiParameter> parameters,
+            OpenApiRequestBody requestBody,
             ApiDescription apiDescription,
             XPathNavigator methodNode)
         {
@@ -105,6 +106,19 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 var paramNode = methodNode.SelectSingleNode(string.Format(ParamXPath, actionParameter.Name));
                 if (paramNode != null)
                     parameter.Description = XmlCommentsTextHelper.Humanize(paramNode.InnerXml);
+            }
+
+            if (requestBody != null)
+            {
+                var actionParameter = apiDescription.ParameterDescriptions
+                    .FirstOrDefault(p => p.IsFromBody());
+
+                if (actionParameter != null)
+                {
+                    var paramNode = methodNode.SelectSingleNode(string.Format(ParamXPath, actionParameter.Name));
+                    if (paramNode != null)
+                        requestBody.Description = XmlCommentsTextHelper.Humanize(paramNode.InnerXml);
+                }
             }
         }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Fakes/FakeController.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Fakes/FakeController.cs
@@ -97,6 +97,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void AcceptsComplexTypeFromBody([FromBody]ComplexType param)
         { }
 
+        public void AcceptsComplexTypeFromBodyThatIsRequired([FromBody, Required]ComplexType param)
+        { }
+
         public void AcceptsComplexTypeFromForm([FromForm]ComplexType param)
         { }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Fakes/XmlAnnotatedController.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Fakes/XmlAnnotatedController.cs
@@ -18,11 +18,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         /// <param name="param1">description for param1</param>
         /// <param name="param2">description for param2</param>
         /// <param name="param3">description for param3</param>
+        /// <param name="param4">description for param4</param>
         /// <response code="200">action-level description for 200</response>
         public void XmlAnnotatedAction(
             int param1,
             IEnumerable<ComplexType> param2,
-            [FromQuery(Name = "Param-3")]string param3)
+            [FromQuery(Name = "Param-3")]string param3,
+            [FromBody] object param4)
         { }
 
         public void AcceptsXmlAnnotatedTypeFromQuery([FromQuery]XmlAnnotatedType param1)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/SwaggerGeneratorTests.cs
@@ -405,6 +405,27 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var requestBody = swagger.Paths["/collection"].Operations[OperationType.Post].RequestBody;
             Assert.NotNull(requestBody);
+            Assert.False(requestBody.Required);
+            Assert.Equal(new[] { "application/json", "text/json", "application/*+json" }, requestBody.Content.Keys);
+            Assert.All(requestBody.Content.Values, mediaType =>
+            {
+                Assert.NotNull(mediaType.Schema);
+                Assert.NotNull(mediaType.Schema.Reference);
+                Assert.Equal("ComplexType", mediaType.Schema.Reference.Id);
+            });
+        }
+
+        [Fact]
+        public void GetSwagger_GeneratesRequestBody_ForFirstApiParameterThatIsBoundToBody_ThatIsRequired()
+        {
+            var subject = Subject(setupApis: apis => apis
+                .Add("POST", "collection", nameof(FakeController.AcceptsComplexTypeFromBodyThatIsRequired)));
+
+            var swagger = subject.GetSwagger("v1");
+
+            var requestBody = swagger.Paths["/collection"].Operations[OperationType.Post].RequestBody;
+            Assert.NotNull(requestBody);
+            Assert.True(requestBody.Required);
             Assert.Equal(new[] { "application/json", "text/json", "application/*+json" }, requestBody.Content.Keys);
             Assert.All(requestBody.Content.Values, mediaType =>
             {

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsOperationFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsOperationFilterTests.cs
@@ -37,7 +37,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                     new OpenApiParameter { Name = "param2" }, 
                     new OpenApiParameter { Name = "Param-3" } 
                 },
-                Responses = new OpenApiResponses()
+                Responses = new OpenApiResponses(),
+                RequestBody = new OpenApiRequestBody()
             };
             var filterContext = FilterContextFor(nameof(XmlAnnotatedController.XmlAnnotatedAction));
 
@@ -46,6 +47,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal("description for param1", operation.Parameters[0].Description);
             Assert.Equal("description for param2", operation.Parameters[1].Description);
             Assert.Equal("description for param3", operation.Parameters[2].Description);
+            Assert.Equal("description for param4", operation.RequestBody.Description);
         }
 
         [Fact]


### PR DESCRIPTION
While porting an application from version 4.0.1 to 5.0.0-rc2, I found that the `Required` property was not being set to true for the request body if bound to a controller parameter, as well as the `Description` property not being set to the XML documentation for such a parameter.

This PR fixes both of these cases.

This was probably broken by the body moving from being a parameter in the V2 schema to a distinct concept in the V3 schema.