### PR TITLE
Fixes array of nullable type causes out of bound exception

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/SchemaGenerator.cs
@@ -40,10 +40,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             // Check if is nullable
             var isNullable = type.IsNullable() || type.IsFSharpOption();
 
-            // Update type
-            type = isNullable
-                ? type.GenericTypeArguments[0]
-                : type;
+            if (isNullable)
+            {
+                type = type.IsArray
+                    ? type.GetGenericArguments()[0].MakeArrayType()
+                    : type.GenericTypeArguments[0];
+            }
 
             var schema = _generatorChain.GenerateSchema(type, schemaRepository);
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGen/SchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGen/SchemaGeneratorTests.cs
@@ -146,6 +146,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [Theory]
         [InlineData(typeof(int[]), "integer", "int32")]
         [InlineData(typeof(IEnumerable<string>), "string", null)]
+        [InlineData(typeof(DateTime?[]), "string", "date-time")]
         public void GenerateSchema_GeneratesArraySchema_IfEnumerableType(
             Type type,
             string expectedItemsType,


### PR DESCRIPTION
Array of the nullable types like `DateTime?[]` cause OutOfBoundException in SwaggerGenerator.

This PR fixes it.