### PR TITLE
added support for JsonObject.Required and JsonProperty.Required

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/MemberInfoExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/MemberInfoExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen
+{
+    public static class MemberInfoExtensions
+    {
+        /// <summary>
+        /// Gets custom attribute data.
+        /// </summary>
+        /// <param name="memberInfo">Member info.</param>
+        /// <param name="attributeType">Attribute type.</param>
+        /// <param name="inherit">Search inheritance chain.</param>
+        /// <returns>Custom attribute data</returns>
+        public static CustomAttributeData GetCustomAttributeData(this MemberInfo memberInfo, Type attributeType, bool inherit)
+        {
+            var customAttrData = memberInfo.CustomAttributes.FirstOrDefault(a => a.AttributeType == attributeType);
+            if (customAttrData == null && inherit)
+            {
+                var baseType = memberInfo.DeclaringType.BaseType;
+                var baseMemberInfo = baseType?.GetMember(memberInfo.Name).FirstOrDefault();
+                customAttrData = baseMemberInfo?.GetCustomAttributeData(attributeType, inherit);
+            }
+            return customAttrData;
+        }
+    }
+}

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/SchemaGenerator.cs
@@ -50,12 +50,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     : type.GenericTypeArguments[0];
             }
 
-            var schema = _generatorChain.GenerateSchema(type, schemaRepository);
-
-            // Set Nullable
-            schema.Nullable = isNullable;
-
-            return schema;
+            return _generatorChain.GenerateSchema(type, schemaRepository);
         }
     }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Types/JsonRequiredInheritanceTypes.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Types/JsonRequiredInheritanceTypes.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test
+{
+    public abstract class JsonRequiredRootType
+    {
+        [JsonProperty(Required = Required.Default)]
+        public virtual string RootValDefault { get; set; }
+    }
+    [JsonObject(ItemRequired = Required.AllowNull)]
+    public abstract class JsonRequiredBaseType : JsonRequiredRootType
+    {
+        public virtual string BaseValAllowNull { get; set; }
+    }
+    public class JsonRequiredChildType : JsonRequiredBaseType
+    {
+        // Required = Required.AllowNull from inherited JsonObjectAttribute
+        public string ValAllowNull { get; set; }
+
+        [JsonProperty(Required = Required.Default)]
+        public string ValDefault { get; set; }
+
+        // Required = Required.Default from inherited JsonPropertyAttribute
+        public override string RootValDefault { get; set; }
+    }
+    public class JsonRequiredAlwaysChildType : JsonRequiredBaseType
+    {
+        [JsonProperty(Required = Required.Always)]
+        public override string BaseValAllowNull { get; set; }
+        [JsonProperty(Required = Required.Always)]
+        public override string RootValDefault { get; set; }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Types/JsonRequiredNullableType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Types/JsonRequiredNullableType.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test
+{
+    [JsonObject(ItemRequired = Required.Always)]
+    public class JsonRequiredNullableType
+    {
+        [JsonProperty(Required = Required.AllowNull)]
+        public int? ValAllowNull { get; set; }
+
+        [JsonProperty(Required = Required.Default)]
+        public int? ValDefault { get; set; }
+
+        // Required = Required.Always from JsonObjectAttribute
+        [JsonProperty]
+        public int? ValWithoutReq { get; set; }
+
+        // Required = Required.Always from JsonObjectAttribute
+        public int? ValueWithoutAttr { get; set; }
+
+        [JsonProperty(Required = Required.Always)]
+        public int? ValAlways { get; set; }
+
+        [JsonProperty(Required = Required.DisallowNull)]
+        public int? ValDisallowNull { get; set; }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Types/JsonRequiredType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Types/JsonRequiredType.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test
+{
+    [JsonObject(ItemRequired = Required.Always)]
+    public class JsonRequiredType
+    {
+        [JsonProperty(Required = Required.AllowNull)]
+        public string ValAllowNull { get; set; }
+
+        [JsonProperty(Required = Required.Default)]
+        public string ValDefault { get; set; }
+
+        // Required = Required.Always from JsonObjectAttribute
+        [JsonProperty]
+        public string ValWithoutReq { get; set; }
+
+        // Required = Required.Always from JsonObjectAttribute
+        public string ValueWithoutAttr { get; set; }
+
+        [JsonProperty(Required = Required.Always)]
+        public string ValAlways { get; set; }
+
+        [JsonProperty(Required = Required.DisallowNull)]
+        public string ValDisallowNull { get; set; }
+    }
+}


### PR DESCRIPTION
The json `Required` value is now correctly determined for json annotated types and used to set `Required` and `Nullable` in the `OpenApiSchema`. The PR resolves the issue #1064.
To achieve the same behavior as Newtonsoft Json, I had to use some reflection. Let me know what you think. 