### PR TITLE
Add swagger dotnet tool

### DIFF
--- a/src/Swashbuckle.AspNetCore.Cli/Swashbuckle.AspNetCore.Cli.csproj
+++ b/src/Swashbuckle.AspNetCore.Cli/Swashbuckle.AspNetCore.Cli.csproj
@@ -4,10 +4,12 @@
 
   <PropertyGroup>
     <Description>Swashbuckle (Swagger) Command Line Tools</Description>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <AssemblyName>dotnet-swagger</AssemblyName>
+    <AssemblyName>swagger</AssemblyName>
     <PackageId>Swashbuckle.AspNetCore.Cli</PackageId>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>swagger</ToolCommandName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Swashbuckle.AspNetCore.Cli/Swashbuckle.AspNetCore.Cli.csproj
+++ b/src/Swashbuckle.AspNetCore.Cli/Swashbuckle.AspNetCore.Cli.csproj
@@ -6,7 +6,7 @@
     <Description>Swashbuckle (Swagger) Command Line Tools</Description>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <AssemblyName>swagger</AssemblyName>
+    <AssemblyName>dotnet-swagger</AssemblyName>
     <PackageId>Swashbuckle.AspNetCore.Cli</PackageId>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>swagger</ToolCommandName>

--- a/test/Swashbuckle.AspNetCore.Cli.Test/Swashbuckle.AspNetCore.Cli.Test.csproj
+++ b/test/Swashbuckle.AspNetCore.Cli.Test/Swashbuckle.AspNetCore.Cli.Test.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/test/WebSites/CliExample/CliExample.csproj
+++ b/test/WebSites/CliExample/CliExample.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.10" />
   </ItemGroup>
 
   <ItemGroup>
@@ -25,6 +25,6 @@
   </ItemGroup>-->
 
   <Target Name="SwaggerToFile" AfterTargets="AfterBuild">
-    <Exec Command="dotnet ../../../src/Swashbuckle.AspNetCore.Cli/bin/$(Configuration)/netcoreapp2.0/dotnet-swagger.dll tofile --host http://example.com --output wwwroot/api-docs/v1/swagger.json $(OutputPath)$(AssemblyName).dll v1" />
+    <Exec Command="dotnet ../../../src/Swashbuckle.AspNetCore.Cli/bin/$(Configuration)/netcoreapp2.1/dotnet-swagger.dll tofile --host http://example.com --output wwwroot/api-docs/v1/swagger.json $(OutputPath)$(AssemblyName).dll v1" />
   </Target>
 </Project>


### PR DESCRIPTION
- Bump to netcoreapp2.1, since this is minimal version supported by .NET Tools
- Name command as swagger (just so package could be used both ways hopefully)

Building and packaging
```
dotnet pack -c release -o ../artifacts /p:VersionSuffix=dev
```
Not sure how to propely integrate into existing build

Testing locally.
```
dotnet tool install --add-source <path-to-artifacts>artifacts\  Swashbuckle.AspNetCore.Cli
```

Closes #761

More information:
- https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-create
- https://github.com/dotnet/core/tree/master/samples/dotnetsay