### PR TITLE
Add description for usage of global tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1082,24 +1082,35 @@ _NOTE:_ This feature is currently beta only. Please post feedback to the followi
 
 The Swashbuckle CLI tool can retrieve Swagger JSON directly from your application startup assembly, and write it to file. This can be useful if you want to incorporate Swagger generation into a CI/CD process, or if you want to serve it from static file at run-time.
 
-The tool can be installed as a [per-project, framework-dependent CLI extension](https://docs.microsoft.com/en-us/dotnet/core/tools/extensibility#per-project-based-extensibility) by adding the following reference to your .csproj file and running `dotnet restore`:
+The tool can be installed as a [.NET Core Global Tools](https://docs.microsoft.com/en-us/dotnet/core/tools/global-tools) either locally or globally by creation of `dotnet-tools.json` next to your .csproj file 
+or next to your solution file:
 
-```xml
-<ItemGroup>
-  <DotNetCliToolReference Include="Swashbuckle.AspNetCore.Cli" Version="2.1.0-beta1" />
-</ItemGroup>
+```json
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+  }
+}
 ```
+
+then to install tool locally, run following command
+```
+dotnet tool install swashbuckle.aspnetcore.cli
+```
+
+On clean machine to restore tool, please run `dotnet tool restore`
 
 Once this is done, you should be able to run the following command from your project root:
 
 ```
-dotnet swagger tofile --help
+dotnet tool run swagger tofile --help
 ```
 
 Before you invoke the `tofile` command, you need to ensure your application is configured to expose Swagger JSON, as described in [Getting Started](#getting-started). Once this is done, you can point to your startup assembly and generate a local Swagger JSON file with the following command:
 
 ```
-dotnet swagger tofile --output [output] [startupassembly] [swaggerdoc]
+dotnet tool run swagger tofile --output [output] [startupassembly] [swaggerdoc]
 ```
 
 Where ...

--- a/test/WebSites/CliExample/CliExample.csproj
+++ b/test/WebSites/CliExample/CliExample.csproj
@@ -5,6 +5,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Remove="dotnet-tools.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="dotnet-tools.json">
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.10" />
   </ItemGroup>
 
@@ -17,14 +27,25 @@
 
   <!--
     NOTE: In practice, you would uncomment the following snippet to install the dotnet-swagger tool via Nuget.
-    Then, the exec command below could be simplified to the following "dotnet swagger tofile ..."
+    Then, the exec command below could be simplified to the following "dotnet tool run swagger tofile ..."
   -->
 
-  <!--<ItemGroup>
-    <DotNetCliToolReference Include="Swashbuckle.AspNetCore.Cli" Version="1.2.0-beta1" />
-  </ItemGroup>-->
+  <!--
+  <Target Name="SwaggerToFile" AfterTargets="AfterBuild">
+    <Exec Command="dotnet tool run swagger tofile &#45;-host http://example.com &#45;-output wwwroot/api-docs/v1/swagger.json &quot;$(TargetPath)&quot; v1" />
+  </Target>
+  -->
+
+  <!--
+    NOTE: If you install swagger as global tool then you could run simply "swagger tofile ..."
+  -->
+  <!--
+  <Target Name="SwaggerToFile" AfterTargets="AfterBuild">
+    <Exec Command="swagger tofile &#45;-host http://example.com &#45;-output wwwroot/api-docs/v1/swagger.json &quot;$(TargetPath)&quot; v1" />
+  </Target>
+  -->
 
   <Target Name="SwaggerToFile" AfterTargets="AfterBuild">
-    <Exec Command="dotnet ../../../src/Swashbuckle.AspNetCore.Cli/bin/$(Configuration)/netcoreapp2.1/dotnet-swagger.dll tofile --host http://example.com --output wwwroot/api-docs/v1/swagger.json $(OutputPath)$(AssemblyName).dll v1" />
+    <Exec Command="dotnet ../../../src/Swashbuckle.AspNetCore.Cli/bin/$(Configuration)/netcoreapp2.1/dotnet-swagger.dll tofile --host http://example.com --output wwwroot/api-docs/v1/swagger.json &quot;$(TargetPath)&quot; v1" />
   </Target>
 </Project>

--- a/test/WebSites/CliExample/dotnet-tools.json
+++ b/test/WebSites/CliExample/dotnet-tools.json
@@ -1,0 +1,12 @@
+﻿{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "swashbuckle.aspnetcore.cli": {
+      "version": "5.0.0",
+      "commands": [
+        "swagger"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
As per @domaindrivendev description, created explanation for the usage of global tool.

I take liberation and place explicit version of 5.0.0 in the CliExample, since this is required to have proper tool configuration for restoring. So if you want to release 5.0.0-rc3 then that place should be changed.