### PR TITLE
Fix/enum underlying type casting

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/OpenApiAnyFactory.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/OpenApiAnyFactory.cs
@@ -12,6 +12,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             if (schema.Type == "boolean" && TryCast(value, out bool boolValue))
                 openApiAny = new OpenApiBoolean(boolValue);
+            
+            else if (schema.Type == "integer" && schema.Format == "int32" && TryCast(value, out byte byteValue))
+				openApiAny = new OpenApiInteger(byteValue);
 
             else if (schema.Type == "integer" && schema.Format == "int32" && TryCast(value, out short shortValue))
                 openApiAny = new OpenApiInteger(shortValue); // preliminary unboxing is required; simply casting to int won't suffice

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Types/Enums.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Types/Enums.cs
@@ -2,6 +2,13 @@
 
 namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
+    public enum ByteEnum:byte
+    {
+        Value2 = 2,
+        Value4 = 4,
+        Value8 = 8,
+    }
+
     public enum ShortEnum:short
     {
         Value2 = 2,

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/OpenApiAnyFactoryTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Generator/OpenApiAnyFactoryTests.cs
@@ -9,6 +9,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
     {
         [Theory]
         [InlineData("boolean", null, true, typeof(OpenApiBoolean))]
+        [InlineData("integer", "int32", (byte)10, typeof(OpenApiInteger))]
+        [InlineData("integer", "int32", ByteEnum.Value2, typeof(OpenApiInteger))]
         [InlineData("integer", "int32", (short)10, typeof(OpenApiInteger))]
         [InlineData("integer", "int32", ShortEnum.Value2, typeof(OpenApiInteger))]
         [InlineData("integer", "int32", 10, typeof(OpenApiInteger))]


### PR DESCRIPTION
Previously, this enum would be converted as null values
```
[Flags]
public enum Gender : byte
{
	None = 0,
	Male = 1,
	Female = 2,
	Both = Male | Female
}
```

```
"Gender": {
	"enum": [
		null,
		null,
		null,
		null
	],
	"type": "integer",
	"format": "int32"
}
```

This is because we are missing the casting to a byte