### PR TITLE
Correct default value for camel-cased string enums

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/OpenApiAnyFactory.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/OpenApiAnyFactory.cs
@@ -32,7 +32,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             else if (schema.Type == "string" && value.GetType().IsEnum) {
                 if (schema.Enum != null)
                 {
-                    var loweredValue = Enum.GetName(value.GetType(), value)?.ToLowerInvariant();
+                    var name = Enum.GetName(value.GetType(), value);
+                    var mappedValue = schema.Enum.FirstOrDefault(e => string.Equals(name, ((OpenApiString)e)?.Value, StringComparison.OrdinalIgnoreCase));
+                    if (mappedValue != null) openApiAny = mappedValue;
                     var mappedValue = schema.Enum.Select(e => ((OpenApiString)e)?.Value).Where(v => v.ToLowerInvariant() == loweredValue).FirstOrDefault();
                     if (mappedValue != null) openApiAny = new OpenApiString(mappedValue);
                 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/OpenApiAnyFactory.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/OpenApiAnyFactory.cs
@@ -33,10 +33,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 if (schema.Enum != null)
                 {
                     var name = Enum.GetName(value.GetType(), value);
-                    var mappedValue = schema.Enum.FirstOrDefault(e => string.Equals(name, ((OpenApiString)e)?.Value, StringComparison.OrdinalIgnoreCase));
-                    if (mappedValue != null) openApiAny = mappedValue;
-                    var mappedValue = schema.Enum.Select(e => ((OpenApiString)e)?.Value).Where(v => v.ToLowerInvariant() == loweredValue).FirstOrDefault();
-                    if (mappedValue != null) openApiAny = new OpenApiString(mappedValue);
+                    openApiAny = schema.Enum.FirstOrDefault(e =>
+                        string.Equals(name, ((OpenApiString)e)?.Value, StringComparison.OrdinalIgnoreCase));
                 }
             }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/OpenApiAnyFactory.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/OpenApiAnyFactory.cs
@@ -32,7 +32,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             else if (schema.Type == "string" && value.GetType().IsEnum) {
                 if (schema.Enum != null)
                 {
-                    var loweredValue = Enum.GetName(value.GetType(), value).ToLowerInvariant();
+                    var loweredValue = Enum.GetName(value.GetType(), value)?.ToLowerInvariant();
                     var mappedValue = schema.Enum.Select(e => ((OpenApiString)e)?.Value).Where(v => v.ToLowerInvariant() == loweredValue).FirstOrDefault();
                     if (mappedValue != null) openApiAny = new OpenApiString(mappedValue);
                 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/OpenApiAnyFactory.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Generator/OpenApiAnyFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 
@@ -28,8 +29,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             else if (schema.Type == "number" && schema.Format == "double" && TryCast(value, out double doubleValue))
                 openApiAny = new OpenApiDouble(doubleValue);
 
-            else if (schema.Type == "string" && value.GetType().IsEnum)
-                openApiAny = new OpenApiString(Enum.GetName(value.GetType(), value));
+            else if (schema.Type == "string" && value.GetType().IsEnum) {
+                if (schema.Enum != null)
+                {
+                    var loweredValue = Enum.GetName(value.GetType(), value).ToLowerInvariant();
+                    var mappedValue = schema.Enum.Select(e => ((OpenApiString)e)?.Value).Where(v => v.ToLowerInvariant() == loweredValue).FirstOrDefault();
+                    if (mappedValue != null) openApiAny = new OpenApiString(mappedValue);
+                }
+            }
 
             else if (schema.Type == "string" && schema.Format == "date-time" && TryCast(value, out DateTime dateTimeValue))
                 openApiAny = new OpenApiDate(dateTimeValue);

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Types/DataAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/Types/DataAnnotatedType.cs
@@ -36,5 +36,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
         [DefaultValue("foobar")]
         public string StringWithDefaultValue { get; set; }
+
+        [DefaultValue(IntEnum.Value4)]
+        public IntEnum IntEnumWithDefaultValue { get; set; }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGen/SchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGen/SchemaGeneratorTests.cs
@@ -267,6 +267,26 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal("password", schema.Properties["StringWithDataTypePassword"].Format);
             Assert.IsType<OpenApiString>(schema.Properties["StringWithDefaultValue"].Default);
             Assert.Equal("foobar", ((OpenApiString)schema.Properties["StringWithDefaultValue"].Default).Value);
+            Assert.Equal(4, ((OpenApiInteger)schema.Properties["IntEnumWithDefaultValue"].Default).Value);
+        }
+
+        [Theory]
+        [InlineData(true, false, "Value4")]
+        [InlineData(true, true, "value4")]
+        public void GenerateSchema_SetsValidationProperties_ForEnumAsString(
+            bool describeAllEnumsAsStrings,
+            bool describeStringEnumsInCamelCase,
+            string expectedValue)
+        {
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = Subject(o => {
+                o.DescribeAllEnumsAsStrings = describeAllEnumsAsStrings;
+                o.DescribeStringEnumsInCamelCase = describeStringEnumsInCamelCase;
+            }).GenerateSchema(typeof(DataAnnotatedType), schemaRepository);
+
+            var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
+            Assert.Equal(expectedValue, ((OpenApiString)schema.Properties["IntEnumWithDefaultValue"].Default).Value);
         }
 
         [Fact]


### PR DESCRIPTION
Addresses the remaining issue of #1164 mentioned in the comments, i.e. "Default enum value ... not correctly camel-cased for enum serialized as string, when camel-casing is set in options or `StringEnumConverter`".

This is actually complete and correct (I hope!) as long as renaming enum members via `EnumMemberAttribute` is no longer supported, so that the only issue is camel-casing.

If arbitrary mapping/renaming of enum members is to be supported then for the reasons I mentioned in the issue - which I'm sure you're aware of! - I think there is no way to do a complete solution just within `TryCreateFor`, and - as far as I can work out - refactoring would be needed to change things so that default values (at least for enums) are calculated at the time when the `OpenApiSchema` is calculated (i.e. when the required mapping info is fully available). But if that's not to be supported then, as I say, I hope that this does the trick!