### PR TITLE
Ability to specify a configuration file when using the CLI tool

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/PrimitiveSchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGen/PrimitiveSchemaGenerator.cs
@@ -32,11 +32,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             var jsonPrimitiveContract = (JsonPrimitiveContract)ContractResolver.ResolveContract(type);
 
-            var schema = jsonPrimitiveContract.UnderlyingType.IsEnum
-                ? GenerateEnumSchema(jsonPrimitiveContract)
-                : FactoryMethodMap[jsonPrimitiveContract.UnderlyingType]();
+            if (jsonPrimitiveContract.UnderlyingType.IsEnum)
+                return GenerateEnumSchema(jsonPrimitiveContract);
 
-            return schema;
+            if (FactoryMethodMap.ContainsKey(jsonPrimitiveContract.UnderlyingType))
+                return FactoryMethodMap[jsonPrimitiveContract.UnderlyingType]();
+
+            return new OpenApiSchema { Type = "string" };
         }
 
         private OpenApiSchema GenerateEnumSchema(JsonPrimitiveContract jsonPrimitiveContract)


### PR DESCRIPTION
Our application uses the Options pattern for configuration. On startup we validate our options class to avoid runtime errors. However, we're unable to use the CLI tools because the configuration file is defaulted to empty.

These changes will allow users to specify a specific host configuration when using the `dotnet swagger` tool. The value passed into the `--config` flag should be a relative path that points to a valid JSON configuration file, which will be loaded up when the host is built.