### PR TITLE
Fix possible NullReferenceException

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
@@ -28,7 +28,7 @@ namespace Swashbuckle.AspNetCore.Swagger
         {
             _next = next;
             _options = options ?? new SwaggerOptions();
-            _requestMatcher = new TemplateMatcher(TemplateParser.Parse(options.RouteTemplate), new RouteValueDictionary());
+            _requestMatcher = new TemplateMatcher(TemplateParser.Parse(_options.RouteTemplate), new RouteValueDictionary());
         }
 
         public async Task Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)


### PR DESCRIPTION
Use _options instead of options in order to get rid of possible nullref.