### PR TITLE
Consolidate usage of version using Directory.Build.props

### DIFF
--- a/Swashbuckle.AspNetCore.sln
+++ b/Swashbuckle.AspNetCore.sln
@@ -3,6 +3,9 @@
 VisualStudioVersion = 15.0.27004.2006
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{15A55F4A-FC33-4D96-BAAD-FBDCDD96D5F5}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FA1B4021-0A97-4F68-B966-148191F6AAA8}"
 	ProjectSection(SolutionItems) = preProject

--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -39,7 +39,7 @@ function dotnet-build {
 }
 
 function dotnet-pack {
-    Get-ChildItem -Path src/** | ForEach-Object {
+    Get-ChildItem -Path src/** -Directory | ForEach-Object {
         if ($VersionSuffix.Length -gt 0) {
             dotnet pack $_ -c Release --no-build -o $ArtifactsPath --version-suffix $VersionSuffix
         }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\version.props" />
+</Project>

--- a/src/Swashbuckle.AspNetCore.Annotations/Swashbuckle.AspNetCore.Annotations.csproj
+++ b/src/Swashbuckle.AspNetCore.Annotations/Swashbuckle.AspNetCore.Annotations.csproj
@@ -1,6 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="..\..\version.props" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>

--- a/src/Swashbuckle.AspNetCore.ApiTesting.Xunit/Swashbuckle.AspNetCore.ApiTesting.Xunit.csproj
+++ b/src/Swashbuckle.AspNetCore.ApiTesting.Xunit/Swashbuckle.AspNetCore.ApiTesting.Xunit.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\version.props" />
-
   <PropertyGroup>
     <Description>Xunit add-on for Swagger/OpenAPI-driven integration testing API's built on ASP.NET Core</Description>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/src/Swashbuckle.AspNetCore.ApiTesting/Swashbuckle.AspNetCore.ApiTesting.csproj
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/Swashbuckle.AspNetCore.ApiTesting.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\version.props" />
-
   <PropertyGroup>
     <Description>Core components for Swagger/OpenAPI-driven integration testing API's built on ASP.NET Core</Description>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/src/Swashbuckle.AspNetCore.Cli/Swashbuckle.AspNetCore.Cli.csproj
+++ b/src/Swashbuckle.AspNetCore.Cli/Swashbuckle.AspNetCore.Cli.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\version.props" />
-
   <PropertyGroup>
     <Description>Swashbuckle (Swagger) Command Line Tools</Description>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>

--- a/src/Swashbuckle.AspNetCore.ReDoc/Swashbuckle.AspNetCore.ReDoc.csproj
+++ b/src/Swashbuckle.AspNetCore.ReDoc/Swashbuckle.AspNetCore.ReDoc.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\version.props" />
-
   <PropertyGroup>
     <Description>Middleware to expose an embedded version of ReDoc from an ASP.NET Core application</Description>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>

--- a/src/Swashbuckle.AspNetCore.Swagger/Swashbuckle.AspNetCore.Swagger.csproj
+++ b/src/Swashbuckle.AspNetCore.Swagger/Swashbuckle.AspNetCore.Swagger.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\version.props" />
-
   <PropertyGroup>
     <Description>Middleware to expose Swagger JSON endpoints from API's built on ASP.NET Core</Description>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Swashbuckle.AspNetCore.SwaggerGen.csproj
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Swashbuckle.AspNetCore.SwaggerGen.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\version.props" />
-
   <PropertyGroup>
     <Description>Swagger Generator for API's built on ASP.NET Core</Description>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\version.props" />
-
   <PropertyGroup>
     <Description>Middleware to expose an embedded version of the swagger-ui from an ASP.NET Core application</Description>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>

--- a/src/Swashbuckle.AspNetCore/Swashbuckle.AspNetCore.csproj
+++ b/src/Swashbuckle.AspNetCore/Swashbuckle.AspNetCore.csproj
@@ -1,6 +1,5 @@
 ﻿<Project>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-  <Import Project="..\..\version.props" />
 
   <PropertyGroup>
     <Description>Swagger tools for documenting APIs built on ASP.NET Core</Description>


### PR DESCRIPTION
This change make any project in the `src/` folder to import `version.props` file
See https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019#directorybuildprops-and-directorybuildtargets
`build.ps1` modified to pack only folders in `src\` directory.
