### PR TITLE
Expose `--serializeasv2` command line parameter

### DIFF
--- a/README-v5.md
+++ b/README-v5.md
@@ -251,6 +251,12 @@ app.UseSwagger(c =>
 });
 ```
 
+Alternatively if you use Swagger CLI you could pass `--serializeasv2` command line parameter to `dotnet swagger` command.
+For example:
+```
+dotnet swagger tofile --output api.json --serializeasv2 "$(TargetPath)" v1
+```
+
 ## Swashbuckle.AspNetCore.SwaggerGen ##
 
 ### Assign Explicit OperationIds ###
@@ -1160,13 +1166,14 @@ dotnet tool run swagger tofile --help
 Before you invoke the `tofile` command, you need to ensure your application is configured to expose Swagger JSON, as described in [Getting Started](#getting-started). Once this is done, you can point to your startup assembly and generate a local Swagger JSON file with the following command:
 
 ```
-dotnet tool run swagger tofile --output [output] [startupassembly] [swaggerdoc]
+dotnet tool run swagger tofile --output [--serializeasv2] [output] [startupassembly] [swaggerdoc]
 ```
 
 Where ...
 * [output] is the relative path where the Swagger JSON will be output to
 * [startupassembly] is the relative path to your application's startup assembly
 * [swaggerdoc] is the name of the swagger document you want to retrieve, as configured in your startup class
+* `--serializeasv2` output Swagger in the V2 format rather than V3
 
 Checkout the [CliExample app](test/WebSites/CliExample) for more inspiration. It leverages the MSBuild Exec command to generate Swagger JSON at build-time.
 


### PR DESCRIPTION
This parameter often nescessary to use now, since Atuorest has a lot of issues with Open API 3.0