### PR TITLE
Restore SchemaRepository.TryGetIdFor

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SchemaRepository.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SchemaRepository.cs
@@ -32,6 +32,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             };
         }
 
+        public bool TryGetIdFor(Type type, out string schemaId)
+        {
+            return _reservedIds.TryGetValue(type, out schemaId);
+        }
+        
         private void ReserveIdFor(Type type, string schemaId)
         {
             if (_reservedIds.ContainsValue(schemaId))


### PR DESCRIPTION
Some manipulation requires us to have access to a mapping from Type to SchemaID/Schema.
Unless there is a better way to find the SchemaID associated to a Type, it would be much helpful to restore `SchemaRepository.TryGetIdFor`.

For example, we use this to implement discriminator for Polymorphic schema.