### PR TITLE
Enhancement - Support for paragraphs #1083

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
@@ -8,6 +8,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     {
         private static Regex RefTagPattern = new Regex(@"<(see|paramref) (name|cref)=""([TPF]{1}:)?(?<display>.+?)"" ?/>");
         private static Regex CodeTagPattern = new Regex(@"<c>(?<display>.+?)</c>");
+        private static Regex ParaTagPattern = new Regex(@"<para>(?<display>.+?)</para>", RegexOptions.Singleline);
 
         public static string Humanize(string text)
         {
@@ -17,7 +18,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             return text
                 .NormalizeIndentation()
                 .HumanizeRefTags()
-                .HumanizeCodeTags();
+                .HumanizeCodeTags()
+                .HumanizeParaTags();
         }
 
         private static string NormalizeIndentation(this string text)
@@ -34,7 +36,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
                 if (padLen != 0 && line.Length >= padLen && line.Substring(0, padLen) == padding)
                     line = line.Substring(padLen);
-
+                              
                 lines[i] = line;
             }
 
@@ -87,6 +89,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private static string HumanizeCodeTags(this string text)
         {
             return CodeTagPattern.Replace(text, (match) => "{" + match.Groups["display"].Value + "}");
+        }
+
+        private static string HumanizeParaTags(this string text)
+        {
+            return ParaTagPattern.Replace(text, (match)=> "<br>" + match.Groups["display"].Value);
         }
 
     }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
@@ -127,6 +127,7 @@ A line of text",
         [InlineData(@"Returns a <see cref=""T:Product""/>", "Returns a Product")]
         [InlineData(@"<paramref name=""param1"" /> does something", "param1 does something")]
         [InlineData(@"<c>DoWork</c> is a method in <c>TestClass</c>.", "{DoWork} is a method in {TestClass}.")]
+        [InlineData(@"<para>This is a paragraph</para>.", "<br>This is a paragraph.")]
         public void Humanize_HumanizesInlineTags(
             string input,
             string expectedOutput)


### PR DESCRIPTION
The change resides on the XmlCommentsTextHelper class. A new ParaTagPattern and HumanizeParaTags handle de Para tag in the same way Ref and Code tags are dealt with. The test class has new inline data in order to check this new behavior.