### PR TITLE
fix: decode xml comments

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Net;
 using System.Text.RegularExpressions;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
@@ -15,11 +16,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             if (text == null)
                 throw new ArgumentNullException("text");
 
+            //Call DecodeXml at last to avoid entities like &lt and &gt to break valid xml          
+
             return text
                 .NormalizeIndentation()
                 .HumanizeRefTags()
                 .HumanizeCodeTags()
-                .HumanizeParaTags();
+                .HumanizeParaTags()
+                .DecodeXml();
         }
 
         private static string NormalizeIndentation(this string text)
@@ -36,7 +40,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
                 if (padLen != 0 && line.Length >= padLen && line.Substring(0, padLen) == padding)
                     line = line.Substring(padLen);
-                              
+
                 lines[i] = line;
             }
 
@@ -93,7 +97,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private static string HumanizeParaTags(this string text)
         {
-            return ParaTagPattern.Replace(text, (match)=> "<br>" + match.Groups["display"].Value);
+            return ParaTagPattern.Replace(text, (match) => "<br>" + match.Groups["display"].Value);
+        }
+
+        private static string DecodeXml(this string text)
+        {
+            return WebUtility.HtmlDecode(text);
         }
 
     }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
@@ -128,6 +128,7 @@ A line of text",
         [InlineData(@"<paramref name=""param1"" /> does something", "param1 does something")]
         [InlineData(@"<c>DoWork</c> is a method in <c>TestClass</c>.", "{DoWork} is a method in {TestClass}.")]
         [InlineData(@"<para>This is a paragraph</para>.", "<br>This is a paragraph.")]
+        [InlineData(@"GET /Todo?iscomplete=true&amp;owner=mike", "GET /Todo?iscomplete=true&owner=mike")]
         public void Humanize_HumanizesInlineTags(
             string input,
             string expectedOutput)


### PR DESCRIPTION
Changes on XmlCommentsTextHelper and XmlCommentsTextHelperTests. Related issues : #1151, #1265 and, possibly, #1026.

Decode itself is done by System.Net.WebUtility.HtmlDecode() method. Calling it after NormalizeIndentation and Humanize functions seems interesting to avoid entities like `&lt;` and `&gt; `to break valid xml before calling Humanize(..).