### PR TITLE
Removed duplicate constructors where one of them used 'IOptions'

### DIFF
--- a/src/Swashbuckle.AspNetCore.Newtonsoft/DependencyInjection/NewtonsoftServiceCollectionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Newtonsoft/DependencyInjection/NewtonsoftServiceCollectionExtensions.cs
@@ -1,4 +1,8 @@
-﻿using Swashbuckle.AspNetCore.SwaggerGen;
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Swashbuckle.AspNetCore.SwaggerGen;
 using Swashbuckle.AspNetCore.Newtonsoft;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -7,7 +11,22 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         public static IServiceCollection AddSwaggerGenNewtonsoftSupport(this IServiceCollection services)
         {
-            return services.AddTransient<IApiModelResolver, NewtonsoftApiModelResolver>();
+            return services.AddTransient<IApiModelResolver>(s =>
+            {
+                var jsonSerializerSettings = s.GetJsonSerializerSettings() ?? new JsonSerializerSettings();
+                var options = s.GetRequiredService<IOptions<SchemaGeneratorOptions>>().Value;
+
+                return new NewtonsoftApiModelResolver(jsonSerializerSettings, options);
+            });
+        }
+
+        private static JsonSerializerSettings GetJsonSerializerSettings(this IServiceProvider serviceProvider)
+        {
+#if NETCOREAPP3_0
+            return serviceProvider.GetRequiredService<IOptions<MvcNewtonsoftJsonOptions>>().Value?.SerializerSettings;
+#else
+            return serviceProvider.GetRequiredService<IOptions<MvcJsonOptions>>().Value?.SerializerSettings;
+#endif
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.Newtonsoft/NewtonsoftApiModelResolver.cs
+++ b/src/Swashbuckle.AspNetCore.Newtonsoft/NewtonsoftApiModelResolver.cs
@@ -17,24 +17,6 @@ namespace Swashbuckle.AspNetCore.Newtonsoft
         private readonly IContractResolver _jsonContractResolver;
         private readonly SchemaGeneratorOptions _options;
 
-#if NETCOREAPP3_0
-        public NewtonsoftApiModelResolver(
-            IOptions<MvcNewtonsoftJsonOptions> jsonOptionsAccessor,
-            IOptions<SchemaGeneratorOptions> optionsAccessor)
-            : this(
-                jsonOptionsAccessor.Value?.SerializerSettings ?? new JsonSerializerSettings(),
-                optionsAccessor.Value ?? new SchemaGeneratorOptions())
-        { }
-#else
-        public NewtonsoftApiModelResolver(
-            IOptions<MvcJsonOptions> jsonOptionsAccessor,
-            IOptions<SchemaGeneratorOptions> optionsAccessor)
-            : this(
-                jsonOptionsAccessor.Value?.SerializerSettings ?? new JsonSerializerSettings(),
-                optionsAccessor.Value ?? new SchemaGeneratorOptions())
-        { }
-#endif
-
         public NewtonsoftApiModelResolver(JsonSerializerSettings jsonSerializerSettings, SchemaGeneratorOptions options)
         {
             _jsonSerializerSettings = jsonSerializerSettings;

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocBuilderExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.ReDoc;
 
 namespace Microsoft.AspNetCore.Builder
@@ -9,19 +11,9 @@ namespace Microsoft.AspNetCore.Builder
             this IApplicationBuilder app,
             Action<ReDocOptions> setupAction = null)
         {
-            if (setupAction == null)
-            {
-                // Don't pass options so it can be configured/injected via DI container instead
-                app.UseMiddleware<ReDocMiddleware>();
-            }
-            else
-            {
-                // Configure an options instance here and pass directly to the middleware
-                var options = new ReDocOptions();
-                setupAction.Invoke(options);
-
-                app.UseMiddleware<ReDocMiddleware>(options);
-            }
+            var options = app.ApplicationServices.GetService<IOptions<ReDocOptions>>()?.Value ?? new ReDocOptions();
+            setupAction?.Invoke(options);
+            app.UseMiddleware<ReDocMiddleware>(options);
 
             return app;
         }

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
@@ -34,14 +34,6 @@ namespace Swashbuckle.AspNetCore.ReDoc
             RequestDelegate next,
             IHostingEnvironment hostingEnv,
             ILoggerFactory loggerFactory,
-            IOptions<ReDocOptions> optionsAccessor)
-            : this(next, hostingEnv, loggerFactory, optionsAccessor.Value)
-        { }
-
-        public ReDocMiddleware(
-            RequestDelegate next,
-            IHostingEnvironment hostingEnv,
-            ILoggerFactory loggerFactory,
             ReDocOptions options)
         {
             _options = options ?? new ReDocOptions();

--- a/src/Swashbuckle.AspNetCore.Swagger/DependencyInjection/SwaggerBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/DependencyInjection/SwaggerBuilderExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Swagger;
 
 namespace Microsoft.AspNetCore.Builder
@@ -9,19 +11,9 @@ namespace Microsoft.AspNetCore.Builder
             this IApplicationBuilder app,
             Action<SwaggerOptions> setupAction = null)
         {
-            if (setupAction == null)
-            {
-                // Don't pass options so it can be configured/injected via DI container instead
-                app.UseMiddleware<SwaggerMiddleware>();
-            }
-            else
-            {
-                // Configure an options instance here and pass directly to the middleware
-                var options = new SwaggerOptions();
-                setupAction.Invoke(options);
-
-                app.UseMiddleware<SwaggerMiddleware>(options);
-            }
+            var options = app.ApplicationServices.GetService<IOptions<SwaggerOptions>>()?.Value ?? new SwaggerOptions();
+            setupAction?.Invoke(options);
+            app.UseMiddleware<SwaggerMiddleware>(options);
 
             return app;
         }

--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
@@ -18,12 +18,6 @@ namespace Swashbuckle.AspNetCore.Swagger
 
         public SwaggerMiddleware(
             RequestDelegate next,
-            IOptions<SwaggerOptions> optionsAccessor)
-            : this(next, optionsAccessor.Value)
-        { }
-
-        public SwaggerMiddleware(
-            RequestDelegate next,
             SwaggerOptions options)
         {
             _next = next;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonApiModelResolver.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonApiModelResolver.cs
@@ -13,17 +13,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     {
         private readonly JsonSerializerOptions _jsonSerializerOptions;
 
-#if NETCOREAPP3_0
-
-        public JsonApiModelResolver(IOptions<JsonOptions> jsonOptionsAccessor)
-            : this(jsonOptionsAccessor.Value?.JsonSerializerOptions ?? new JsonSerializerOptions())
-        { }
-#else
-        public JsonApiModelResolver()
-            : this(new JsonSerializerOptions())
-        { }
-#endif
-
         public JsonApiModelResolver(JsonSerializerOptions jsonSerializerOptions)
         {
             _jsonSerializerOptions = jsonSerializerOptions;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -10,12 +10,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private readonly SchemaGeneratorOptions _options;
         private readonly ApiModelHandler _chainOfHandlers;
 
-        public SchemaGenerator(IApiModelResolver apiModelResolver, IOptions<SchemaGeneratorOptions> optionsAccessor)
-            : this(
-                apiModelResolver,
-                optionsAccessor.Value ?? new SchemaGeneratorOptions())
-        { }
-
         public SchemaGenerator(IApiModelResolver apiModelResolver, SchemaGeneratorOptions options)
         {
             _apiModelResolver = apiModelResolver;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -24,13 +24,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         public SwaggerGenerator(
             IApiDescriptionGroupCollectionProvider apiDescriptionsProvider,
             ISchemaGenerator schemaGenerator,
-            IOptions<SwaggerGeneratorOptions> optionsAccessor)
-            : this(apiDescriptionsProvider, schemaGenerator, optionsAccessor.Value)
-        { }
-
-        public SwaggerGenerator(
-            IApiDescriptionGroupCollectionProvider apiDescriptionsProvider,
-            ISchemaGenerator schemaGenerator,
             SwaggerGeneratorOptions options)
         {
             _apiDescriptionsProvider = apiDescriptionsProvider;

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.SwaggerUI;
 
 namespace Microsoft.AspNetCore.Builder
@@ -9,19 +11,9 @@ namespace Microsoft.AspNetCore.Builder
             this IApplicationBuilder app,
             Action<SwaggerUIOptions> setupAction = null)
         {
-            if (setupAction == null)
-            {
-                // Don't pass options so it can be configured/injected via DI container instead
-                app.UseMiddleware<SwaggerUIMiddleware>();
-            }
-            else
-            {
-                // Configure an options instance here and pass directly to the middleware
-                var options = new SwaggerUIOptions();
-                setupAction.Invoke(options);
-
-                app.UseMiddleware<SwaggerUIMiddleware>(options);
-            }
+            var options = app.ApplicationServices.GetService<IOptions<SwaggerUIOptions>>()?.Value ?? new SwaggerUIOptions();
+            setupAction?.Invoke(options);
+            app.UseMiddleware<SwaggerUIMiddleware>(options);
 
             return app;
         }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -33,14 +33,6 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
             RequestDelegate next,
             IHostingEnvironment hostingEnv,
             ILoggerFactory loggerFactory,
-            IOptions<SwaggerUIOptions> optionsAccessor)
-            : this(next, hostingEnv, loggerFactory, optionsAccessor.Value)
-        { }
-
-        public SwaggerUIMiddleware(
-            RequestDelegate next,
-            IHostingEnvironment hostingEnv,
-            ILoggerFactory loggerFactory,
             SwaggerUIOptions options)
         {
             _options = options ?? new SwaggerUIOptions();


### PR DESCRIPTION
Removed duplicate constructors where one of them used 'IOptions' and one did not.

Having duplicate constructors creates ambiguities for some IoC containers which can result in them not being able to resolve some Swashbuckle services. Furthermore, this change helps decouple these classes from configuration infrastructure and moves it closer to where it belongs.