### PR TITLE
Add support to PKCE for SwaggerUI & update OAuth2Integration sample #999

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,3 @@
 {
-  "requires": true,
-  "lockfileVersion": 1,
-  "dependencies": {
-    "swashbuckle": {
-      "version": "file:src/Swashbuckle.AspNetCore.SwaggerUI",
-      "requires": {
-        "swagger-ui-dist": "3.19.5"
-      },
-      "dependencies": {
-        "swagger-ui-dist": {
-          "version": "3.19.5",
-          "bundled": true
-        }
-      }
-    }
-  }
+  "lockfileVersion": 1
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -203,5 +203,10 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// (Authorization header with Basic base64encode(client_id + client_secret))
         /// </summary>
         public bool UseBasicAuthenticationWithAccessCodeGrant { get; set; } = false;
+
+        /// <summary>
+        /// Enabled to use PKCE with the Autorization Code flow.
+        /// </summary>
+        public bool UsePkceWithAuthorizationCodeGrant { get; set; } = false;
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptionsExtensions.cs
@@ -258,5 +258,14 @@ namespace Microsoft.AspNetCore.Builder
         {
             options.OAuthConfigObject.UseBasicAuthenticationWithAccessCodeGrant = true;
         }
+
+        /// <summary>
+        /// Enabled to use PKCE with the Autorization Code flow.
+        /// </summary>
+        /// <param name="options"></param>
+        public static void OAuthUsePkce(this SwaggerUIOptions options)
+        {
+            options.OAuthConfigObject.UsePkceWithAuthorizationCodeGrant = true;
+        }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/package-lock.json
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "swagger-ui-dist": {
-      "version": "3.24.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.24.0.tgz",
-      "integrity": "sha512-5uAjeEqV+zbtalBDXAIrkqUZwsUHYwvBSeGYlFcLj1ERS3jfprL4OPLSSriDoeXCtNmWzpz5aooV2qJW+DqdUQ=="
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.24.3.tgz",
+      "integrity": "sha512-kB8qobP42Xazaym7sD9g5mZuRL4416VIIYZMqPEIskkzKqbPLQGEiHA3ga31bdzyzFLgr6Z797+6X1Am6zYpbg=="
     }
   }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/package.json
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "swagger-ui-dist": "3.24.0"
+    "swagger-ui-dist": "3.24.3"
   }
 }

--- a/test/WebSites/OAuth2Integration/AuthServer/Config.cs
+++ b/test/WebSites/OAuth2Integration/AuthServer/Config.cs
@@ -10,16 +10,38 @@ namespace OAuth2Integration.AuthServer
         {
             yield return new Client
             {
-                AllowAccessTokensViaBrowser = true,
-                AllowedGrantTypes = GrantTypes.Implicit,
-                AllowedScopes = new[] { "readAccess", "writeAccess" },
                 ClientId = "test-id",
-                ClientName = "test-app",
-                ClientSecrets = new[] { new Secret("test-secret".Sha256()) },
+                ClientName = "Interactive client (Code with PKCE)",
+
                 RedirectUris = new[] {
                     "http://localhost:55202/resource-server/swagger/oauth2-redirect.html", // IIS Express
                     "http://localhost:5000/resource-server/swagger/oauth2-redirect.html", // Kestrel
-                }
+                },
+
+                RequireClientSecret = false,
+                RequireConsent = true,
+
+                AllowedGrantTypes = GrantTypes.Code,
+                RequirePkce = true,
+                AllowedScopes = new[] { "readAccess", "writeAccess" },
+            };
+
+            yield return new Client
+            {
+                ClientId = "test-id.confidential",
+                ClientName = "Interactive client (Code with PKCE)",
+
+                RedirectUris = new[] {
+                    "http://localhost:55202/resource-server/swagger/oauth2-redirect.html", // IIS Express
+                    "http://localhost:5000/resource-server/swagger/oauth2-redirect.html", // Kestrel
+                },
+
+                ClientSecrets = { new Secret("test-secret".Sha256()) },
+                RequireConsent = true,
+
+                AllowedGrantTypes = GrantTypes.Code,
+                RequirePkce = true,
+                AllowedScopes = new[] { "readAccess", "writeAccess" },
             };
         }
 

--- a/test/WebSites/OAuth2Integration/Startup.cs
+++ b/test/WebSites/OAuth2Integration/Startup.cs
@@ -80,7 +80,7 @@ namespace OAuth2Integration
                         {
                             Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "oauth2" }
                         },
-                        new[] { "openid", "profile", "email", "api" }
+                        new[] { "readAccess", "writeAccess" }
                     }
                 });
 

--- a/test/WebSites/OAuth2Integration/Startup.cs
+++ b/test/WebSites/OAuth2Integration/Startup.cs
@@ -60,9 +60,10 @@ namespace OAuth2Integration
                     Type = SecuritySchemeType.OAuth2,
                     Flows = new OpenApiOAuthFlows
                     {
-                        Implicit = new OpenApiOAuthFlow
+                        AuthorizationCode = new OpenApiOAuthFlow
                         {
                             AuthorizationUrl = new Uri("/auth-server/connect/authorize", UriKind.Relative),
+                            TokenUrl = new Uri("/auth-server/connect/token", UriKind.Relative),
                             Scopes = new Dictionary<string, string>
                             {
                                 { "readAccess", "Access read operations" },
@@ -79,7 +80,7 @@ namespace OAuth2Integration
                         {
                             Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "oauth2" }
                         },
-                        new[] { "readAccess", "writeAccess" }
+                        new[] { "openid", "profile", "email", "api" }
                     }
                 });
 
@@ -128,15 +129,12 @@ namespace OAuth2Integration
                 resourceServer.UseSwaggerUI(c =>
                 {
                     c.SwaggerEndpoint("/resource-server/swagger/v1/swagger.json", "My API V1");
-
                     // Additional OAuth settings (See https://github.com/swagger-api/swagger-ui/blob/v3.10.0/docs/usage/oauth2.md)
-                    c.OAuthClientId("test-id");
+                    c.OAuthClientId("test-id.confidential");
                     c.OAuthClientSecret("test-secret");
-                    c.OAuthRealm("test-realm");
                     c.OAuthAppName("test-app");
                     c.OAuthScopeSeparator(" ");
-                    c.OAuthAdditionalQueryStringParams(new Dictionary<string, string> { { "foo", "bar" }});
-                    c.OAuthUseBasicAuthenticationWithAccessCodeGrant();
+                    c.OAuthUsePkce();
                     c.ConfigObject.DeepLinking = true;
                 });
             });


### PR DESCRIPTION
### Description
- Added support for [PKCE](https://tools.ietf.org/html/rfc7636) with the Autorization Code flow.

### Motivation and Context
- This makes the Authorization Code flow more secure because the code can only be used by the client that provided the code_challenge on the /authorize request. It's the recommended way for [Browser-Based Applications](https://www.identityserver.com/articles/change-in-recommendations-for-browser-based-applications)

Fixes #999 

### How Has This Been Tested?

- I've update the [OAuth2IntegrationSample](https://github.com/lurumad/Swashbuckle.AspNetCore/tree/feature/pkce/test/WebSites/OAuth2Integration) flow to use an interactive confidential client (Code with PKCE).

Regards!
