### PR TITLE
SwaggerUIMiddleware - lock down Index page redirect to the exact conf…

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -57,7 +57,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
                 return;
             }
 
-            if (httpMethod == "GET" && Regex.IsMatch(path, $"/{_options.RoutePrefix}/?index.html"))
+            if (httpMethod == "GET" && Regex.IsMatch(path, $"^/{_options.RoutePrefix}/?index.html$"))
             {
                 await RespondWithIndexHtml(httpContext.Response);
                 return;


### PR DESCRIPTION
With default settings for RoutePrefix, SwaggerUIMiddleware responds to any path that contains /swagger/index.html within the path (e.g. http://www.example.com/aaa/swagger/index.html , http://www.example.com/swagger/index.html/aaa) with a generated index.html page. The result is a broken index.html page, where the links within return 404.

The reason this happens is the regex (`/{_options.RoutePrefix}/?index.html`) that determines whether to respond with the index page isn't specific enough. This is different to the regex (`^/{_options.RoutePrefix}/?$`) which which determines whether to redirect to the index.html page.

Is there a good reason for this?
I think the two regex conditions should be similar.
