### PR TITLE
Readme apimodel

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,7 +789,7 @@ public class AutoRestSchemaFilter : ISchemaFilter
 {
     public void Apply(OpenApiSchema schema, SchemaFilterContext context)
     {
-		var type = context.ApiModel.Type;
+	var type = context.Type;
         if (type.IsEnum)
         {
             schema.Extensions.Add(

--- a/README.md
+++ b/README.md
@@ -789,7 +789,7 @@ public class AutoRestSchemaFilter : ISchemaFilter
 {
     public void Apply(OpenApiSchema schema, SchemaFilterContext context)
     {
-	var type = context.Type;
+        var type = context.Type;
         if (type.IsEnum)
         {
             schema.Extensions.Add(


### PR DESCRIPTION
`ApiModel` was removed from `SchemaFilterContext` by https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/1411.

This PR updates README.md to reflect this change.