### PR TITLE
Restore support for multiple SwaggerUI and ReDoc urls

### DIFF
--- a/Swashbuckle.AspNetCore.sln
+++ b/Swashbuckle.AspNetCore.sln
@@ -82,7 +82,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetCore21", "test\WebSites\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Swashbuckle.AspNetCore.Newtonsoft", "src\Swashbuckle.AspNetCore.Newtonsoft\Swashbuckle.AspNetCore.Newtonsoft.csproj", "{0783E72E-3483-43AF-AE4B-2A6CFAFD3DD3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Swashbuckle.AspNetCore.Newtonsoft.Test", "test\Swashbuckle.AspNetCore.Newtonsoft.Test\Swashbuckle.AspNetCore.Newtonsoft.Test.csproj", "{605AA0D3-2AA7-46B4-811B-85DC1B1A3901}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Swashbuckle.AspNetCore.Newtonsoft.Test", "test\Swashbuckle.AspNetCore.Newtonsoft.Test\Swashbuckle.AspNetCore.Newtonsoft.Test.csproj", "{605AA0D3-2AA7-46B4-811B-85DC1B1A3901}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MultipleUrls", "test\WebSites\MultipleUrls\MultipleUrls.csproj", "{1EBEDFFF-8685-4AAD-B4CD-D8B7AEC4701A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -430,6 +432,18 @@ Global
 		{605AA0D3-2AA7-46B4-811B-85DC1B1A3901}.Release|x64.Build.0 = Release|Any CPU
 		{605AA0D3-2AA7-46B4-811B-85DC1B1A3901}.Release|x86.ActiveCfg = Release|Any CPU
 		{605AA0D3-2AA7-46B4-811B-85DC1B1A3901}.Release|x86.Build.0 = Release|Any CPU
+		{1EBEDFFF-8685-4AAD-B4CD-D8B7AEC4701A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1EBEDFFF-8685-4AAD-B4CD-D8B7AEC4701A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1EBEDFFF-8685-4AAD-B4CD-D8B7AEC4701A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1EBEDFFF-8685-4AAD-B4CD-D8B7AEC4701A}.Debug|x64.Build.0 = Debug|Any CPU
+		{1EBEDFFF-8685-4AAD-B4CD-D8B7AEC4701A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1EBEDFFF-8685-4AAD-B4CD-D8B7AEC4701A}.Debug|x86.Build.0 = Debug|Any CPU
+		{1EBEDFFF-8685-4AAD-B4CD-D8B7AEC4701A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1EBEDFFF-8685-4AAD-B4CD-D8B7AEC4701A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1EBEDFFF-8685-4AAD-B4CD-D8B7AEC4701A}.Release|x64.ActiveCfg = Release|Any CPU
+		{1EBEDFFF-8685-4AAD-B4CD-D8B7AEC4701A}.Release|x64.Build.0 = Release|Any CPU
+		{1EBEDFFF-8685-4AAD-B4CD-D8B7AEC4701A}.Release|x86.ActiveCfg = Release|Any CPU
+		{1EBEDFFF-8685-4AAD-B4CD-D8B7AEC4701A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -464,6 +478,7 @@ Global
 		{BB570B42-0F2F-4B59-BEAE-5F1B43856ACA} = {245144DE-BC89-4822-B044-020458BFECC0}
 		{0783E72E-3483-43AF-AE4B-2A6CFAFD3DD3} = {15A55F4A-FC33-4D96-BAAD-FBDCDD96D5F5}
 		{605AA0D3-2AA7-46B4-811B-85DC1B1A3901} = {1669F896-133C-4996-B58C-E7CDA299ADFF}
+		{1EBEDFFF-8685-4AAD-B4CD-D8B7AEC4701A} = {245144DE-BC89-4822-B044-020458BFECC0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {36FC6A67-247D-4149-8EDD-79FFD1A75F51}

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocBuilderExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.ReDoc;
 
 namespace Microsoft.AspNetCore.Builder
@@ -9,19 +11,9 @@ namespace Microsoft.AspNetCore.Builder
             this IApplicationBuilder app,
             Action<ReDocOptions> setupAction = null)
         {
-            if (setupAction == null)
-            {
-                // Don't pass options so it can be configured/injected via DI container instead
-                app.UseMiddleware<ReDocMiddleware>();
-            }
-            else
-            {
-                // Configure an options instance here and pass directly to the middleware
-                var options = new ReDocOptions();
-                setupAction.Invoke(options);
-
-                app.UseMiddleware<ReDocMiddleware>(options);
-            }
+            var options = setupAction == null ? app.ApplicationServices.GetService<IOptions<ReDocOptions>>()?.Value ?? new ReDocOptions() : new ReDocOptions();
+            setupAction?.Invoke(options);
+            app.UseMiddleware<ReDocMiddleware>(options);
 
             return app;
         }

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocBuilderExtensions.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.ReDoc;
 
 namespace Microsoft.AspNetCore.Builder
@@ -11,9 +9,19 @@ namespace Microsoft.AspNetCore.Builder
             this IApplicationBuilder app,
             Action<ReDocOptions> setupAction = null)
         {
-            var options = app.ApplicationServices.GetService<IOptions<ReDocOptions>>()?.Value ?? new ReDocOptions();
-            setupAction?.Invoke(options);
-            app.UseMiddleware<ReDocMiddleware>(options);
+            if (setupAction == null)
+            {
+                // Don't pass options so it can be configured/injected via DI container instead
+                app.UseMiddleware<ReDocMiddleware>();
+            }
+            else
+            {
+                // Configure an options instance here and pass directly to the middleware
+                var options = new ReDocOptions();
+                setupAction.Invoke(options);
+
+                app.UseMiddleware<ReDocMiddleware>(options);
+            }
 
             return app;
         }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.SwaggerUI;
 
 namespace Microsoft.AspNetCore.Builder
@@ -11,9 +9,19 @@ namespace Microsoft.AspNetCore.Builder
             this IApplicationBuilder app,
             Action<SwaggerUIOptions> setupAction = null)
         {
-            var options = app.ApplicationServices.GetService<IOptions<SwaggerUIOptions>>()?.Value ?? new SwaggerUIOptions();
-            setupAction?.Invoke(options);
-            app.UseMiddleware<SwaggerUIMiddleware>(options);
+            if (setupAction == null)
+            {
+                // Don't pass options so it can be configured/injected via DI container instead
+                app.UseMiddleware<SwaggerUIMiddleware>();
+            }
+            else
+            {
+                // Configure an options instance here and pass directly to the middleware
+                var options = new SwaggerUIOptions();
+                setupAction.Invoke(options);
+
+                app.UseMiddleware<SwaggerUIMiddleware>(options);
+            }
 
             return app;
         }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.SwaggerUI;
 
 namespace Microsoft.AspNetCore.Builder
@@ -9,19 +11,9 @@ namespace Microsoft.AspNetCore.Builder
             this IApplicationBuilder app,
             Action<SwaggerUIOptions> setupAction = null)
         {
-            if (setupAction == null)
-            {
-                // Don't pass options so it can be configured/injected via DI container instead
-                app.UseMiddleware<SwaggerUIMiddleware>();
-            }
-            else
-            {
-                // Configure an options instance here and pass directly to the middleware
-                var options = new SwaggerUIOptions();
-                setupAction.Invoke(options);
-
-                app.UseMiddleware<SwaggerUIMiddleware>(options);
-            }
+            var options = setupAction == null ? app.ApplicationServices.GetService<IOptions<SwaggerUIOptions>>()?.Value ?? new SwaggerUIOptions() : new SwaggerUIOptions();
+            setupAction?.Invoke(options);
+            app.UseMiddleware<SwaggerUIMiddleware>(options);
 
             return app;
         }

--- a/test/WebSites/MultipleUrls/ConfigureSwaggerGenOptions.cs
+++ b/test/WebSites/MultipleUrls/ConfigureSwaggerGenOptions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace MultipleUrls
+{
+    public class ConfigureSwaggerOptions : IConfigureOptions<SwaggerGenOptions>
+    {
+        readonly IApiVersionDescriptionProvider provider;
+
+        public ConfigureSwaggerOptions(IApiVersionDescriptionProvider provider) =>
+            this.provider = provider;
+
+        public void Configure(SwaggerGenOptions options)
+        {
+            foreach (var description in provider.ApiVersionDescriptions)
+            {
+                options.SwaggerDoc(
+                    description.GroupName,
+                    new OpenApiInfo()
+                    {
+                        Title = $"Sample API {description.ApiVersion}",
+                        Version = description.ApiVersion.ToString(),
+                    });
+            }
+        }
+    }
+}

--- a/test/WebSites/MultipleUrls/MultipleUrls.csproj
+++ b/test/WebSites/MultipleUrls/MultipleUrls.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.0.0-preview8.19405.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.0.0-preview8.19405.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.Swagger\Swashbuckle.AspNetCore.Swagger.csproj" />
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerGen\Swashbuckle.AspNetCore.SwaggerGen.csproj" />
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerUI\Swashbuckle.AspNetCore.SwaggerUI.csproj" />
+    <ProjectReference Include="..\ReDoc\ReDoc.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/WebSites/MultipleUrls/Program.cs
+++ b/test/WebSites/MultipleUrls/Program.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MultipleUrls
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/test/WebSites/MultipleUrls/Properties/launchSettings.json
+++ b/test/WebSites/MultipleUrls/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:63013/",
+      "sslPort": 44341
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "MultipleUrls": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    }
+  }
+}

--- a/test/WebSites/MultipleUrls/Startup.cs
+++ b/test/WebSites/MultipleUrls/Startup.cs
@@ -1,0 +1,75 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace MultipleUrls
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers();
+
+            services.AddApiVersioning();
+            services.AddVersionedApiExplorer();
+
+            services.AddSwaggerGen();
+            services.AddTransient<IConfigureOptions<SwaggerGenOptions>, ConfigureSwaggerOptions>();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IApiVersionDescriptionProvider provider)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+
+            app.UseSwagger();
+
+            foreach (var description in provider.ApiVersionDescriptions) {
+                app.UseSwaggerUI(c =>
+                {
+                    c.RoutePrefix = $"api-docs/{description.GroupName}";
+                    c.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.json", description.GroupName.ToUpperInvariant());
+
+                    foreach (var innerDescription in provider.ApiVersionDescriptions)
+                    {
+                        if (description == innerDescription)
+                            continue;
+
+                        c.SwaggerEndpoint($"/swagger/{innerDescription.GroupName}/swagger.json", innerDescription.GroupName.ToUpperInvariant());
+                    }
+                });
+
+                app.UseReDoc(c =>
+                {
+                    c.RoutePrefix = $"api-docs/{description.GroupName}/redoc";
+                    c.SpecUrl = $"/swagger/{description.GroupName}/swagger.json";
+                });
+            }
+        }
+    }
+}

--- a/test/WebSites/MultipleUrls/V1/ProductsController.cs
+++ b/test/WebSites/MultipleUrls/V1/ProductsController.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MultipleUrls.V1
+{
+    [ApiVersion("1.0")]
+    [ApiVersion("2.0")]
+    [ApiController]
+    [Route("[controller]")]
+    public class ProductsController
+    {
+        [HttpGet]
+        public IEnumerable<Product> GetProducts()
+        {
+            return new[]
+            {
+                new Product { Id = 1, Description = "A product" },
+                new Product { Id = 2, Description = "Another product" },
+            };
+        }
+    }
+
+    public class Product
+    {
+        public int Id { get; set; }
+
+        public string Description { get; set; }
+    }
+}

--- a/test/WebSites/MultipleUrls/V2/ProductsController.cs
+++ b/test/WebSites/MultipleUrls/V2/ProductsController.cs
@@ -1,0 +1,28 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using MultipleUrls.V1;
+
+namespace MultipleUrls.V2
+{
+    [ApiVersion("2.0")]
+    [ApiController]
+    [Route("[controller]")]
+    public class ProductsController
+    {
+        [HttpPost]
+        public int CreateProduct([FromBody, Required]Product product)
+        {
+            return 1;
+        }
+
+        [HttpPut("{id}")]
+        public void UpdateProduct(int id, [FromBody, Required]Product product)
+        {
+        }
+
+        [HttpDelete("{id}")]
+        public void DeleteProduct(int id)
+        {
+        }
+    }
+}

--- a/test/WebSites/MultipleUrls/appsettings.Development.json
+++ b/test/WebSites/MultipleUrls/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/test/WebSites/MultipleUrls/appsettings.json
+++ b/test/WebSites/MultipleUrls/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
The changes to SwaggerUIBuilderExtensions.cs and ReDocBuilderExtensions.cs in #1386 made it impossible to register more than one endpoint from which to serve SwaggerUI and ReDoc. This PR undoes the changes and adds a test website to validate the functionality (and showcase the use case).

Fetching an IOptions<T> from the service provider would always return the same (initially default) instance of SwaggerUIOptions/ReDocOptions respectively, meaning every instance of middleware would operate on the same instance of the options object. As a result, subsequent setup actions would overwrite the options object from previous registrations.