### PR TITLE
Add document name to document and operation filter contexts.

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/IDocumentFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/IDocumentFilter.cs
@@ -14,11 +14,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         public DocumentFilterContext(
             IEnumerable<ApiDescription> apiDescriptions,
             ISchemaGenerator schemaGenerator,
-            SchemaRepository schemaRepository)
+            SchemaRepository schemaRepository,
+            string documentName = null)
         {
             ApiDescriptions = apiDescriptions;
             SchemaGenerator = schemaGenerator;
             SchemaRepository = schemaRepository;
+            DocumentName = documentName;
         }
 
         public IEnumerable<ApiDescription> ApiDescriptions { get; }
@@ -26,5 +28,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         public ISchemaGenerator SchemaGenerator { get; }
 
         public SchemaRepository SchemaRepository { get; }
+
+        public string DocumentName { get; }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/IOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/IOperationFilter.cs
@@ -15,12 +15,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             ApiDescription apiDescription,
             ISchemaGenerator schemaRegistry,
             SchemaRepository schemaRepository,
-            MethodInfo methodInfo)
+            MethodInfo methodInfo,
+            string documentName = null)
         {
             ApiDescription = apiDescription;
             SchemaGenerator = schemaRegistry;
             SchemaRepository = schemaRepository;
             MethodInfo = methodInfo;
+            DocumentName = documentName;
         }
 
         public ApiDescription ApiDescription { get; }
@@ -30,5 +32,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         public SchemaRepository SchemaRepository { get; }
 
         public MethodInfo MethodInfo { get; }
+
+        public string DocumentName { get; }
     }
 }


### PR DESCRIPTION
We generate multiple swagger documents from a single service that are pre-filtered and formatted for specific consumers. Currently we do this with a (large) `PreSerializeFilters`, but document and operation filters would be much cleaner. We can exclude paths entirely with `DocInclusionPredicate`, but we can't change their shape.

In order to know which document we're processing for, `documentName` seems reasonable in the filter context(s).

Comments/suggestions welcome.