### PR TITLE
Provide capability to ignore existing SwaggerOptions/SwaggerUiOptions

### DIFF
--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocBuilderExtensions.cs
@@ -11,8 +11,16 @@ namespace Microsoft.AspNetCore.Builder
             this IApplicationBuilder app,
             Action<ReDocOptions> setupAction = null)
         {
-            var options = app.ApplicationServices.GetService<IOptions<ReDocOptions>>()?.Value ?? new ReDocOptions();
-            setupAction?.Invoke(options);
+            var options = new ReDocOptions();
+            if (setupAction != null)
+            {
+                setupAction(options);
+            }
+            else
+            {
+                options = app.ApplicationServices.GetRequiredService<IOptions<ReDocOptions>>().Value;
+            }
+
             app.UseMiddleware<ReDocMiddleware>(options);
 
             return app;

--- a/src/Swashbuckle.AspNetCore.Swagger/DependencyInjection/SwaggerBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/DependencyInjection/SwaggerBuilderExtensions.cs
@@ -9,9 +9,17 @@ namespace Microsoft.AspNetCore.Builder
     {
         public static IApplicationBuilder UseSwagger(
             this IApplicationBuilder app,
-            Action<SwaggerOptions> setupAction = null)
+            Action<SwaggerOptions> setupAction = null,
+            bool ignoreExistingOptions = false)
         {
-            var options = app.ApplicationServices.GetService<IOptions<SwaggerOptions>>()?.Value ?? new SwaggerOptions();
+            SwaggerOptions options = new SwaggerOptions();
+
+            var existingSwaggerOptions = app.ApplicationServices.GetService<IOptions<SwaggerOptions>>();
+            if (ignoreExistingOptions == false && existingSwaggerOptions?.Value != null)
+            {
+                options = existingSwaggerOptions.Value;
+            }
+
             setupAction?.Invoke(options);
             app.UseMiddleware<SwaggerMiddleware>(options);
 

--- a/src/Swashbuckle.AspNetCore.Swagger/DependencyInjection/SwaggerBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/DependencyInjection/SwaggerBuilderExtensions.cs
@@ -9,18 +9,18 @@ namespace Microsoft.AspNetCore.Builder
     {
         public static IApplicationBuilder UseSwagger(
             this IApplicationBuilder app,
-            Action<SwaggerOptions> setupAction = null,
-            bool ignoreExistingOptions = false)
+            Action<SwaggerOptions> setupAction = null)
         {
             SwaggerOptions options = new SwaggerOptions();
-
-            var existingSwaggerOptions = app.ApplicationServices.GetService<IOptions<SwaggerOptions>>();
-            if (ignoreExistingOptions == false && existingSwaggerOptions?.Value != null)
+            if (setupAction != null)
             {
-                options = existingSwaggerOptions.Value;
+                setupAction(options);
+            }
+            else
+            {
+                options = app.ApplicationServices.GetRequiredService<IOptions<SwaggerOptions>>().Value;
             }
 
-            setupAction?.Invoke(options);
             app.UseMiddleware<SwaggerMiddleware>(options);
 
             return app;

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
@@ -9,18 +9,18 @@ namespace Microsoft.AspNetCore.Builder
     {
         public static IApplicationBuilder UseSwaggerUI(
             this IApplicationBuilder app,
-            Action<SwaggerUIOptions> setupAction = null,
-            bool ignoreExistingOptions = false)
+            Action<SwaggerUIOptions> setupAction = null)
         {
-            SwaggerUIOptions options = new SwaggerUIOptions();
-
-            var existingSwaggerOptions = app.ApplicationServices.GetService<IOptions<SwaggerUIOptions>>();
-            if (ignoreExistingOptions == false && existingSwaggerOptions?.Value != null)
+            var options = new SwaggerUIOptions();
+            if (setupAction != null)
             {
-                options = existingSwaggerOptions.Value;
+                setupAction(options);
             }
-            
-            setupAction?.Invoke(options);
+            else
+            {
+                options = app.ApplicationServices.GetRequiredService<IOptions<SwaggerUIOptions>>().Value;
+            }
+
             app.UseMiddleware<SwaggerUIMiddleware>(options);
 
             return app;

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
@@ -9,9 +9,17 @@ namespace Microsoft.AspNetCore.Builder
     {
         public static IApplicationBuilder UseSwaggerUI(
             this IApplicationBuilder app,
-            Action<SwaggerUIOptions> setupAction = null)
+            Action<SwaggerUIOptions> setupAction = null,
+            bool ignoreExistingOptions = false)
         {
-            var options = app.ApplicationServices.GetService<IOptions<SwaggerUIOptions>>()?.Value ?? new SwaggerUIOptions();
+            SwaggerUIOptions options = new SwaggerUIOptions();
+
+            var existingSwaggerOptions = app.ApplicationServices.GetService<IOptions<SwaggerUIOptions>>();
+            if (ignoreExistingOptions == false && existingSwaggerOptions?.Value != null)
+            {
+                options = existingSwaggerOptions.Value;
+            }
+            
             setupAction?.Invoke(options);
             app.UseMiddleware<SwaggerUIMiddleware>(options);
 


### PR DESCRIPTION
Provide capability to ignore existing SwaggerOptions/SwaggerUiOptions which would allow you to expose different Swagger endpoints & UI URLs.

## Usecase

I've added OpenAPI 3.0 support to https://github.com/tomkerkhove/promitor but still support the old Swagger 2.0 approach.

With this approach, we have:
- Swagger UI 2.0 on `/swagger/index.html` which serves these Swagger doc endpoints
  - Swagger 2.0 on `/swagger/v1/swagger.json` (serialized as v2)
  - OpenAPI 3.0 on `/api/v1/docs.json`
- OpenAPI UI 3.0 on `/api/docs/index.html` which serves these OpenAPI doc endpoints
  - OpenAPI 3.0 on `/api/v1/docs.json`

This allows me to have the new approach side-by-side with the deprecated approach.

## Issue

When we're doing this:
```csharp
app.UseOpenApi(setupAction => setupAction.RouteTemplate = "api/{documentName}/docs.json");
app.UseOpenApi(setupAction => setupAction.SerializeAsV2 = true);
```

Our second call will use the configuration from the first call and the end result would be API docs being served on `api/{documentName}/docs.json` serialized as V2 instead of seperate endpoints.

With the introduction of `ignoreExistingOptions` we could explicitly say we don't want that. (but I'm open for better names) Same issue with respect to `UseSwaggerUI`.

## More information

- I've forked the bootstrapping extensions in my PR to fix this for my scenario, this might help explain why this is important. https://github.com/tomkerkhove/promitor/pull/841
- This might be in conflict/related to https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/1463