### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ services.AddSwaggerGen(c =>
 {
     c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
 });
-services.AddSwaggerGenNewtonsoftSupport() // explicit opt-in
+services.AddSwaggerGenNewtonsoftSupport() // explicit opt-in - needs to be placed after AddSwaggerGen()
 ```
 
 # Swashbuckle, ApiExplorer, and Routing #


### PR DESCRIPTION
Added comment to be more explicit that AddSwaggerGenNewtonsoftSupport() needs to be placed after AddSwaggerGen() otherwise ISchemaGenerator wont be replaced. Learn't the hard way :(