### PR TITLE
Fixed simple typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ services.AddSwaggerGen(c =>
 {
     c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API", Version = "v1" });
 });
-services.AddSwaggerGenNewtonsoftSupport() // explicit opt-in - needs to be placed after AddSwaggerGen()
+services.AddSwaggerGenNewtonsoftSupport(); // explicit opt-in - needs to be placed after AddSwaggerGen()
 ```
 
 # Swashbuckle, ApiExplorer, and Routing #


### PR DESCRIPTION
In a code example there was a missing semicolon from the end of one line.