### PR TITLE
Improve error feedback regarding the use of empty enums

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonEnumHandler.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonEnumHandler.cs
@@ -2,54 +2,58 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+
 using Microsoft.OpenApi.Models;
 
-namespace Swashbuckle.AspNetCore.SwaggerGen
-{
-    public class JsonEnumHandler : SchemaGeneratorHandler
-    {
+namespace Swashbuckle.AspNetCore.SwaggerGen {
+
+    public class EmptyEnumException : Exception {
+
+        public EmptyEnumException(Type type) : base($"The enum type {type.FullName} has no values!") {
+
+        }
+    }
+
+    public class JsonEnumHandler : SchemaGeneratorHandler {
         private readonly SchemaGeneratorOptions _generatorOptions;
         private readonly JsonSerializerOptions _serializerOptions;
 
-        public JsonEnumHandler(SchemaGeneratorOptions generatorOptions, JsonSerializerOptions serializerOptions)
-        {
+        public JsonEnumHandler(SchemaGeneratorOptions generatorOptions, JsonSerializerOptions serializerOptions) {
             _generatorOptions = generatorOptions;
             _serializerOptions = serializerOptions;
         }
 
-        public override bool CanCreateSchemaFor(Type type, out bool shouldBeReferenced)
-        {
-            if (type.IsEnum)
-            {
+        public override bool CanCreateSchemaFor(Type type, out bool shouldBeReferenced) {
+            if (type.IsEnum) {
                 shouldBeReferenced = !_generatorOptions.UseInlineDefinitionsForEnums;
                 return true;
             }
 
-            shouldBeReferenced = false; return false;
+            shouldBeReferenced = false;
+            return false;
         }
 
-        public override OpenApiSchema CreateSchema(Type type, SchemaRepository schemaRepository)
-        {
+        public override OpenApiSchema CreateSchema(Type type, SchemaRepository schemaRepository) {
+            var enumValues = type.GetEnumValues();
+            if (enumValues.Length == 0) {
+                throw new EmptyEnumException(type);
+            }
             //Test to determine if the serializer will treat as string or not
-            var describeAsString = JsonSerializer.Serialize(type.GetEnumValues().GetValue(0), _serializerOptions).StartsWith("\"");
+            var describeAsString = JsonSerializer.Serialize(enumValues.GetValue(0), _serializerOptions).StartsWith("\"");
 
-            var schema = describeAsString
-                ? EnumTypeMap[typeof(string)]()
-                : EnumTypeMap[type.GetEnumUnderlyingType()]();
+            var schema = describeAsString ?
+                EnumTypeMap[typeof(string)]() :
+                EnumTypeMap[type.GetEnumUnderlyingType()]();
 
-            if (describeAsString)
-            {
+            if (describeAsString) {
                 schema.Enum = type.GetEnumValues()
                     .Cast<object>()
-                    .Select(value =>
-                    {
+                    .Select(value => {
                         var stringValue = JsonSerializer.Serialize(value, _serializerOptions).Replace("\"", string.Empty);
                         return OpenApiAnyFactory.CreateFor(schema, stringValue);
                     })
                     .ToList();
-            }
-            else
-            {
+            } else {
                 schema.Enum = type.GetEnumValues()
                     .Cast<object>()
                     .Select(value => OpenApiAnyFactory.CreateFor(schema, value))
@@ -59,17 +63,16 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             return schema;
         }
 
-        private static readonly Dictionary<Type, Func<OpenApiSchema>> EnumTypeMap = new Dictionary<Type, Func<OpenApiSchema>>
-        {
-            [ typeof(byte) ] = () => new OpenApiSchema { Type = "integer", Format = "int32" },
-            [ typeof(sbyte) ] = () => new OpenApiSchema { Type = "integer", Format = "int32" },
-            [ typeof(short) ] = () => new OpenApiSchema { Type = "integer", Format = "int32" },
-            [ typeof(ushort) ] = () => new OpenApiSchema { Type = "integer", Format = "int32" },
-            [ typeof(int) ] = () => new OpenApiSchema { Type = "integer", Format = "int32" },
-            [ typeof(uint) ] = () => new OpenApiSchema { Type = "integer", Format = "int32" },
-            [ typeof(long) ] = () => new OpenApiSchema { Type = "integer", Format = "int64" },
-            [ typeof(ulong) ] = () => new OpenApiSchema { Type = "integer", Format = "int64" },
-            [ typeof(string) ] = () => new OpenApiSchema { Type = "string" }
+        private static readonly Dictionary<Type, Func<OpenApiSchema>> EnumTypeMap = new Dictionary<Type, Func<OpenApiSchema>> {
+            [typeof(byte)] = () => new OpenApiSchema { Type = "integer", Format = "int32" },
+            [typeof(sbyte)] = () => new OpenApiSchema { Type = "integer", Format = "int32" },
+            [typeof(short)] = () => new OpenApiSchema { Type = "integer", Format = "int32" },
+            [typeof(ushort)] = () => new OpenApiSchema { Type = "integer", Format = "int32" },
+            [typeof(int)] = () => new OpenApiSchema { Type = "integer", Format = "int32" },
+            [typeof(uint)] = () => new OpenApiSchema { Type = "integer", Format = "int32" },
+            [typeof(long)] = () => new OpenApiSchema { Type = "integer", Format = "int64" },
+            [typeof(ulong)] = () => new OpenApiSchema { Type = "integer", Format = "int64" },
+            [typeof(string)] = () => new OpenApiSchema { Type = "string" }
         };
     }
 }


### PR DESCRIPTION
I came across an unexpected issue when upgrading to the latest version of Swashbuckle.AspNetCore where I had unintentionally defined an empty enum which led to the triggering of a non-obvious error by the generator. I've included a proposed fix to make the exception meaningful.