### PR TITLE
Update swagger-ui-dist to 3.25.0

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/package.json
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "swagger-ui-dist": "3.24.3"
+    "swagger-ui-dist": "3.25.0"
   }
 }


### PR DESCRIPTION
Fixes #1128

Swagger-UI was updated to 3.25.0 to support using `x-tokenName` in OpenAPI 3.0 OAuth security schemes in order to select a different field from the token JSON for use as the bearer token.

Our team uses this and so currently authenticating in the Swagger UI isn't usable.

Here's the release for that change: https://github.com/swagger-api/swagger-ui/releases/tag/v3.25.0

Thanks! 😃