### PR TITLE
escape swaggerui route prefix when used in regexes

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -50,7 +50,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
             var path = httpContext.Request.Path.Value;
 
             // If the RoutePrefix is requested (with or without trailing slash), redirect to index URL
-            if (httpMethod == "GET" && Regex.IsMatch(path, $"^/{_options.RoutePrefix}/?$"))
+            if (httpMethod == "GET" && Regex.IsMatch(path, $"^/{Regex.Escape(_options.RoutePrefix)}/?$"))
             {
                 // Use relative redirect to support proxy environments
                 var relativeRedirectPath = path.EndsWith("/")
@@ -61,7 +61,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
                 return;
             }
 
-            if (httpMethod == "GET" && Regex.IsMatch(path, $"^/{_options.RoutePrefix}/?index.html$"))
+            if (httpMethod == "GET" && Regex.IsMatch(path, $"^/{Regex.Escape(_options.RoutePrefix)}/?index.html$"))
             {
                 await RespondWithIndexHtml(httpContext.Response);
                 return;


### PR DESCRIPTION
Using a route prefix including special characters leads the swagger link to use the wrong index.html.

Instead of using the index.html from the swaggerui project, it uses the index.html from the swagger-ui-dist package (https://github.com/swagger-api/swagger-ui/blob/master/dist/index.html), and so usually opens the pet store sample.

This is due to the raw route prefix being passed in as regex-pattern, without being escaped properly.

The app config I've tried to use:

```c#
app.UseSwagger(c => { c.RouteTemplate = "$/swagger/{documentName}/swagger.json"; });
app.UseSwaggerUI(c =>
{
    c.RoutePrefix = "$/swagger";
    c.SwaggerEndpoint("/$/swagger/v1/swagger.json", "pineapple api v1");
});
```