### PR TITLE
Add an option to specify the serialize format version per document

### DIFF
--- a/src/Swashbuckle.AspNetCore.Cli/Program.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/Program.cs
@@ -91,9 +91,9 @@ namespace Swashbuckle.AspNetCore.Cli
                             writer = new OpenApiJsonWriter(streamWriter);
 
                         if (namedArgs.ContainsKey("--serializeasv2"))
-                            swagger.SerializeAsV2(writer);
+                            swagger.Item1.SerializeAsV2(writer);
                         else
-                            swagger.SerializeAsV3(writer);
+                            swagger.Item1.SerializeAsV3(writer);
 
                         if (outputPath != null)
                             Console.WriteLine($"Swagger JSON/YAML succesfully written to {outputPath}");

--- a/src/Swashbuckle.AspNetCore.Swagger/ISwaggerProvider.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/ISwaggerProvider.cs
@@ -7,7 +7,7 @@ namespace Swashbuckle.AspNetCore.Swagger
 {
     public interface ISwaggerProvider
     {
-        OpenApiDocument GetSwagger(
+        Tuple<OpenApiDocument, SerializeVersion> GetSwagger(
             string documentName,
             string host = null,
             string basePath = null);

--- a/src/Swashbuckle.AspNetCore.Swagger/SerializeVersion.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SerializeVersion.cs
@@ -1,0 +1,8 @@
+﻿namespace Swashbuckle.AspNetCore.Swagger
+{
+    public enum SerializeVersion
+    {
+        V2,
+        V3
+    }
+}

--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
@@ -44,10 +44,10 @@ namespace Swashbuckle.AspNetCore.Swagger
                 // One last opportunity to modify the Swagger Document - this time with request context
                 foreach (var filter in _options.PreSerializeFilters)
                 {
-                    filter(swagger, httpContext.Request);
+                    filter(swagger.Item1, httpContext.Request);
                 }
 
-                await RespondWithSwaggerJson(httpContext.Response, swagger);
+                await RespondWithSwaggerJson(httpContext.Response, swagger.Item1, swagger.Item2);
             }
             catch (UnknownSwaggerDocument)
             {
@@ -72,7 +72,7 @@ namespace Swashbuckle.AspNetCore.Swagger
             response.StatusCode = 404;
         }
 
-        private async Task RespondWithSwaggerJson(HttpResponse response, OpenApiDocument swagger)
+        private async Task RespondWithSwaggerJson(HttpResponse response, OpenApiDocument swagger, SerializeVersion serializeAs)
         {
             response.StatusCode = 200;
             response.ContentType = "application/json;charset=utf-8";
@@ -80,7 +80,7 @@ namespace Swashbuckle.AspNetCore.Swagger
             using (var textWriter = new StringWriter(CultureInfo.InvariantCulture))
             {
                 var jsonWriter = new OpenApiJsonWriter(textWriter);
-                if (_options.SerializeAsV2) swagger.SerializeAsV2(jsonWriter); else swagger.SerializeAsV3(jsonWriter);
+                if (serializeAs == SerializeVersion.V3) swagger.SerializeAsV3(jsonWriter); else swagger.SerializeAsV2(jsonWriter);
 
                 await response.WriteAsync(textWriter.ToString(), new UTF8Encoding(false));
             }

--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerOptions.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerOptions.cs
@@ -22,6 +22,7 @@ namespace Swashbuckle.AspNetCore.Swagger
         /// <summary>
         /// Return Swagger JSON in the V2 format rather than V3
         /// </summary>
+        [Obsolete("The format version is set when adding documents in SwaggerGen.")]
         public bool SerializeAsV2 { get; set; }
 
         /// <summary>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Application/ConfigureSwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Application/ConfigureSwaggerGeneratorOptions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
@@ -37,7 +38,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public void DeepCopy(SwaggerGeneratorOptions source, SwaggerGeneratorOptions target)
         {
-            target.SwaggerDocs = new Dictionary<string, OpenApiInfo>(source.SwaggerDocs);
+            target.SwaggerDocs = new Dictionary<string, Tuple<OpenApiInfo, SerializeVersion>>(source.SwaggerDocs);
             target.DocInclusionPredicate = source.DocInclusionPredicate;
             target.IgnoreObsoleteActions = source.IgnoreObsoleteActions;
             target.ConflictingActionsResolver = source.ConflictingActionsResolver;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Application/DocumentProvider.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Application/DocumentProvider.cs
@@ -45,13 +45,13 @@ namespace Microsoft.Extensions.ApiDescriptions
             // Let UnknownSwaggerDocument or other exception bubble up to caller.
             var swagger = _swaggerProvider.GetSwagger(documentName, host: null, basePath: null);
             var jsonWriter = new OpenApiJsonWriter(writer);
-            if (_options.SerializeAsV2)
+            if (swagger.Item2 == SerializeVersion.V3)
             {
-                swagger.SerializeAsV2(jsonWriter);
+                swagger.Item1.SerializeAsV3(jsonWriter);
             }
             else
             {
-                swagger.SerializeAsV3(jsonWriter);
+                swagger.Item1.SerializeAsV2(jsonWriter);
             }
 
             return Task.CompletedTask;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Application/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Application/SwaggerGenOptionsExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Xml.XPath;
 using Microsoft.OpenApi.Models;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -20,7 +21,23 @@ namespace Microsoft.Extensions.DependencyInjection
             string name,
             OpenApiInfo info)
         {
-            swaggerGenOptions.SwaggerGeneratorOptions.SwaggerDocs.Add(name, info);
+            SwaggerDoc(swaggerGenOptions, name, info, SerializeVersion.V3);
+        }
+
+        /// <summary>
+        /// Define one or more documents to be created by the Swagger generator
+        /// </summary>
+        /// <param name="swaggerGenOptions"></param>
+        /// <param name="name">A URI-friendly name that uniquely identifies the document</param>
+        /// <param name="info">Global metadata to be included in the Swagger output</param>
+        /// <param name="serializeAs">Format version to use in the JSON document</param>
+        public static void SwaggerDoc(
+            this SwaggerGenOptions swaggerGenOptions,
+            string name,
+            OpenApiInfo info,
+            SerializeVersion serializeAs)
+        {
+            swaggerGenOptions.SwaggerGeneratorOptions.SwaggerDocs.Add(name, new Tuple<OpenApiInfo, SerializeVersion>(info, serializeAs));
         }
 
         /// <summary>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -29,9 +29,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             _options = options ?? new SwaggerGeneratorOptions();
         }
 
-        public OpenApiDocument GetSwagger(string documentName, string host = null, string basePath = null)
+        public Tuple<OpenApiDocument, SerializeVersion> GetSwagger(string documentName, string host = null, string basePath = null)
         {
-            if (!_options.SwaggerDocs.TryGetValue(documentName, out OpenApiInfo info))
+            if (!_options.SwaggerDocs.TryGetValue(documentName, out Tuple<OpenApiInfo, SerializeVersion> info))
                 throw new UnknownSwaggerDocument(documentName, _options.SwaggerDocs.Select(d => d.Key));
 
             var applicableApiDescriptions = _apiDescriptionsProvider.ApiDescriptionGroups.Items
@@ -43,7 +43,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             var swaggerDoc = new OpenApiDocument
             {
-                Info = info,
+                Info = info.Item1,
                 Servers = GenerateServers(host, basePath),
                 Paths = GeneratePaths(applicableApiDescriptions, schemaRepository),
                 Components = new OpenApiComponents
@@ -60,7 +60,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 filter.Apply(swaggerDoc, filterContext);
             }
 
-            return swaggerDoc;
+            return new Tuple<OpenApiDocument, SerializeVersion>(swaggerDoc, info.Item2);
         }
 
         private IList<OpenApiServer> GenerateServers(string host, string basePath)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
@@ -11,7 +12,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     {
         public SwaggerGeneratorOptions()
         {
-            SwaggerDocs = new Dictionary<string, OpenApiInfo>();
+            SwaggerDocs = new Dictionary<string, Tuple<OpenApiInfo, SerializeVersion>>();
             DocInclusionPredicate = DefaultDocInclusionPredicate;
             OperationIdSelector = DefaultOperationIdSelector;
             TagsSelector = DefaultTagsSelector;
@@ -23,7 +24,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             DocumentFilters = new List<IDocumentFilter>();
         }
 
-        public IDictionary<string, OpenApiInfo> SwaggerDocs { get; set; }
+        public IDictionary<string, Tuple<OpenApiInfo, SerializeVersion>> SwaggerDocs { get; set; }
 
         public Func<string, ApiDescription, bool> DocInclusionPredicate { get; set; }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptionsExtensions.cs
@@ -261,6 +261,7 @@ namespace Microsoft.AspNetCore.Builder
         /// <summary>
         /// Only applies to authorizatonCode flows. Proof Key for Code Exchange brings enhanced security for OAuth public clients.
         /// The default is false
+        /// </summary>
         /// <param name="options"></param>
         public static void OAuthUsePkce(this SwaggerUIOptions options)
         {

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -30,14 +30,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 },
                 options: new SwaggerGeneratorOptions
                 {
-                    SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                    SwaggerDocs = new Dictionary<string, Tuple<OpenApiInfo, SerializeVersion>>
                     {
-                        [ "v1" ] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                        [ "v1" ] = new Tuple<OpenApiInfo, SerializeVersion>(new OpenApiInfo { Version = "V1", Title = "Test API" }, SerializeVersion.V3) 
                     }
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             Assert.Equal("V1", document.Info.Version);
             Assert.Equal("Test API", document.Info.Title);
@@ -56,7 +56,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             Assert.Null(document.Paths["/resource"].Operations[OperationType.Post].OperationId);
         }
@@ -72,7 +72,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             Assert.Equal("SomeRouteName", document.Paths["/resource"].Operations[OperationType.Post].OperationId);
         }
@@ -88,7 +88,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             Assert.True(document.Paths["/resource"].Operations[OperationType.Post].Deprecated);
         }
@@ -121,7 +121,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(1, operation.Parameters.Count);
@@ -150,7 +150,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(0, operation.Parameters.Count);
@@ -178,7 +178,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.True(operation.Parameters.First().Required);
@@ -211,7 +211,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(1, operation.Parameters.Count);
@@ -240,7 +240,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(1, operation.Parameters.Count);
@@ -272,7 +272,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(1, operation.Parameters.Count);
@@ -305,7 +305,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.NotNull(operation.RequestBody);
@@ -345,7 +345,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(expectedRequired, operation.RequestBody.Required);
@@ -380,7 +380,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.NotNull(operation.RequestBody);
@@ -416,7 +416,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(new[] { "application/someMediaType" }, operation.RequestBody.Content.Keys);
@@ -456,7 +456,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(new[] { "200", "400", "default" }, operation.Responses.Keys);
@@ -493,7 +493,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(new[] { "application/someMediaType" }, operation.Responses["200"].Content.Keys);
@@ -571,15 +571,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 },
                 options: new SwaggerGeneratorOptions
                 {
-                    SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                    SwaggerDocs = new Dictionary<string, Tuple<OpenApiInfo, SerializeVersion>>
                     {
-                        ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                        ["v1"] = new Tuple<OpenApiInfo, SerializeVersion>(new OpenApiInfo { Version = "V1", Title = "Test API" }, SerializeVersion.V3)
                     },
                     IgnoreObsoleteActions = true
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             Assert.Equal(new[] { "/resource" }, document.Paths.Keys.ToArray());
             Assert.Equal(new[] { OperationType.Post }, document.Paths["/resource"].Operations.Keys);
@@ -602,15 +602,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 },
                 options: new SwaggerGeneratorOptions
                 {
-                    SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                    SwaggerDocs = new Dictionary<string, Tuple<OpenApiInfo, SerializeVersion>>
                     {
-                        ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                        ["v1"] = new Tuple<OpenApiInfo, SerializeVersion>(new OpenApiInfo { Version = "V1", Title = "Test API" }, SerializeVersion.V3)
                     },
                     SortKeySelector = (apiDesc) => apiDesc.RelativePath
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             Assert.Equal(new[] { "/resource1", "/resource2", "/resource3" }, document.Paths.Keys.ToArray());
         }
@@ -626,15 +626,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 },
                 options: new SwaggerGeneratorOptions
                 {
-                    SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                    SwaggerDocs = new Dictionary<string, Tuple<OpenApiInfo, SerializeVersion>>
                     {
-                        ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                        ["v1"] = new Tuple<OpenApiInfo, SerializeVersion>(new OpenApiInfo { Version = "V1", Title = "Test API" }, SerializeVersion.V3)
                     },
                     TagsSelector = (apiDesc) => new[] { apiDesc.RelativePath }
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             Assert.Equal(new[] { "resource" }, document.Paths["/resource"].Operations[OperationType.Post].Tags.Select(t => t.Name));
         }
@@ -653,15 +653,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 },
                 options: new SwaggerGeneratorOptions
                 {
-                    SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                    SwaggerDocs = new Dictionary<string, Tuple<OpenApiInfo, SerializeVersion>>
                     {
-                        ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                        ["v1"] = new Tuple<OpenApiInfo, SerializeVersion>(new OpenApiInfo { Version = "V1", Title = "Test API" }, SerializeVersion.V3)
                     },
                     ConflictingActionsResolver = (apiDescriptions) => apiDescriptions.First()
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             Assert.Equal(new[] { "/resource" }, document.Paths.Keys.ToArray());
             Assert.Equal(new[] { OperationType.Post }, document.Paths["/resource"].Operations.Keys);
@@ -689,15 +689,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 },
                 options: new SwaggerGeneratorOptions
                 {
-                    SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                    SwaggerDocs = new Dictionary<string, Tuple<OpenApiInfo, SerializeVersion>>
                     {
-                        ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                        ["v1"] = new Tuple<OpenApiInfo, SerializeVersion>(new OpenApiInfo { Version = "V1", Title = "Test API" }, SerializeVersion.V3)
                     },
                     DescribeAllParametersInCamelCase = true
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(1, operation.Parameters.Count);
@@ -711,9 +711,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 apiDescriptions: new ApiDescription[] { },
                 options: new SwaggerGeneratorOptions
                 {
-                    SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                    SwaggerDocs = new Dictionary<string, Tuple<OpenApiInfo, SerializeVersion>>
                     {
-                        ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                        ["v1"] = new Tuple<OpenApiInfo, SerializeVersion>(new OpenApiInfo { Version = "V1", Title = "Test API" }, SerializeVersion.V3)
                     },
                     SecuritySchemes = new Dictionary<string, OpenApiSecurityScheme>
                     {
@@ -722,7 +722,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             Assert.Equal(new[] { "basic" }, document.Components.SecuritySchemes.Keys);
         }
@@ -738,9 +738,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 },
                 options: new SwaggerGeneratorOptions
                 {
-                    SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                    SwaggerDocs = new Dictionary<string, Tuple<OpenApiInfo, SerializeVersion>>
                     {
-                        ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                        ["v1"] = new Tuple<OpenApiInfo, SerializeVersion>(new OpenApiInfo { Version = "V1", Title = "Test API" }, SerializeVersion.V3)
                     },
                     OperationFilters = new List<IOperationFilter>
                     {
@@ -749,7 +749,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.NotEmpty(operation.Extensions);
@@ -762,9 +762,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 apiDescriptions: new ApiDescription[] { },
                 options: new SwaggerGeneratorOptions
                 {
-                    SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                    SwaggerDocs = new Dictionary<string, Tuple<OpenApiInfo, SerializeVersion>>
                     {
-                        ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                        ["v1"] = new Tuple<OpenApiInfo, SerializeVersion>(new OpenApiInfo { Version = "V1", Title = "Test API" }, SerializeVersion.V3)
                     },
                     DocumentFilters = new List<IDocumentFilter>
                     {
@@ -773,7 +773,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             );
 
-            var document = subject.GetSwagger("v1");
+            var document = subject.GetSwagger("v1").Item1;
 
             Assert.NotEmpty(document.Extensions);
         }
@@ -789,10 +789,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
         private static readonly SwaggerGeneratorOptions DefaultOptions = new SwaggerGeneratorOptions
         {
-            SwaggerDocs = new Dictionary<string, OpenApiInfo>
+            SwaggerDocs = new Dictionary<string, Tuple<OpenApiInfo, SerializeVersion>>
             {
-                ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
-            }
+                ["v1"] = new Tuple<OpenApiInfo, SerializeVersion>(new OpenApiInfo { Version = "V1", Title = "Test API" }, SerializeVersion.V3)
+            },
         };
     }
 }

--- a/test/WebSites/Basic/Startup.cs
+++ b/test/WebSites/Basic/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.OpenApi.Models;
 using Basic.Swagger;
 using Microsoft.AspNetCore.Localization;
 using System.IO;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace Basic
 {
@@ -36,7 +37,7 @@ namespace Basic
                         Version = "v1",
                         Description = "A sample API for testing Swashbuckle",
                         TermsOfService = new Uri("http://tempuri.org/terms")
-                    }
+                    }, SerializeVersion.V3
                 );
 
                 c.OperationFilter<AssignOperationVendorExtensions>();

--- a/test/WebSites/CliExample/Startup.cs
+++ b/test/WebSites/CliExample/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace CliExample
 {
@@ -23,7 +24,7 @@ namespace CliExample
 
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new OpenApiInfo { Title = "Test API", Version = "v1" });
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "Test API", Version = "v1" }, SerializeVersion.V3);
             });
         }
 

--- a/test/WebSites/CustomUIConfig/Startup.cs
+++ b/test/WebSites/CustomUIConfig/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerUI;
 
 namespace CustomUIConfig
@@ -24,7 +25,7 @@ namespace CustomUIConfig
 
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new OpenApiInfo { Title = "Test API", Version = "1" });
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "Test API", Version = "1" }, SerializeVersion.V3);
             });
         }
 

--- a/test/WebSites/CustomUIIndex/Startup.cs
+++ b/test/WebSites/CustomUIIndex/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace CustomUIIndex
 {
@@ -23,7 +24,7 @@ namespace CustomUIIndex
 
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new OpenApiInfo { Title = "Test API", Version = "1" });
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "Test API", Version = "1" }, SerializeVersion.V3);
             });
         }
 

--- a/test/WebSites/GenericControllers/Startup.cs
+++ b/test/WebSites/GenericControllers/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 using GenericControllers.Swagger;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace GenericControllers
 {
@@ -25,7 +26,7 @@ namespace GenericControllers
 
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new OpenApiInfo { Title = "Test API", Version = "1" });
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "Test API", Version = "1" }, SerializeVersion.V3);
 
                 var xmlCommentsPath = Path.Combine(System.AppContext.BaseDirectory, "GenericControllers.xml");
                 c.IncludeXmlComments(xmlCommentsPath);

--- a/test/WebSites/MultipleVersions/ConfigureSwaggerGenOptions.cs
+++ b/test/WebSites/MultipleVersions/ConfigureSwaggerGenOptions.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace MultipleVersions
@@ -23,7 +24,7 @@ namespace MultipleVersions
                     {
                         Title = $"Sample API {description.ApiVersion}",
                         Version = description.ApiVersion.ToString(),
-                    });
+                    }, SerializeVersion.V3);
             }
         }
     }

--- a/test/WebSites/NetCore21/Startup.cs
+++ b/test/WebSites/NetCore21/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace NetCore21
 {
@@ -31,7 +32,7 @@ namespace NetCore21
 
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new OpenApiInfo { Title = "Test API", Version = "1" });
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "Test API", Version = "1" }, SerializeVersion.V2);
                 c.UseInlineDefinitionsForEnums();
             });
             services.AddSwaggerGenNewtonsoftSupport();

--- a/test/WebSites/OAuth2Integration/Startup.cs
+++ b/test/WebSites/OAuth2Integration/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace OAuth2Integration
 {
@@ -52,7 +53,7 @@ namespace OAuth2Integration
 
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new OpenApiInfo { Version = "v1", Title = "Test API V1" });
+                c.SwaggerDoc("v1", new OpenApiInfo { Version = "v1", Title = "Test API V1" }, SerializeVersion.V3);
 
                 // Define the OAuth2.0 scheme that's in use (i.e. Implicit Flow)
                 c.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme

--- a/test/WebSites/ReDoc/Startup.cs
+++ b/test/WebSites/ReDoc/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.ReDoc;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace ReDoc
 {
@@ -24,7 +25,7 @@ namespace ReDoc
 
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc("v1", new OpenApiInfo { Title = "Test API", Version = "1" });
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "Test API", Version = "1" }, SerializeVersion.V2);
             });
         }
 


### PR DESCRIPTION
Added an overloaded method that specifies the serialize version when adding a document:
```services.AddSwaggerGen(c =>
{
    c.SwaggerDoc("v1", new OpenApiInfo { Title = "Test", Version = "1" }, SerializeVersion.V2);
});
```
The previous method serializes as V3 and the `SwaggerOptions.SerializeAsV2` has been marked as obsolete.
This change allows to have different versions of the documents that serialize in different formats.