### PR TITLE
Fix dictionary key exception regarding GeneratePolymorphicSchemas

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -188,7 +188,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             if (_generatorOptions.GeneratePolymorphicSchemas && _generatorOptions.SubTypesResolver(serializerMetadata.Type).Any())
             {
                 var discriminatorName = _generatorOptions.DiscriminatorSelector(serializerMetadata.Type);
-                schema.Properties.Add(discriminatorName, new OpenApiSchema { Type = "string" });
+
+                if (!schema.Properties.ContainsKey(discriminatorName))
+                    schema.Properties.Add(discriminatorName, new OpenApiSchema { Type = "string" });
+
                 schema.Required.Add(discriminatorName);
                 schema.Discriminator = new OpenApiDiscriminator { PropertyName = discriminatorName };
             }


### PR DESCRIPTION
Motivation
------------
The properties dictionary is not being checked prior to adding a discriminator property, resulting in a key exception

Modification
-------------
 - Checked the properties dictionary keys before adding a new key