### PR TITLE
add repo to Annotations project nuspec

### DIFF
--- a/src/Swashbuckle.AspNetCore.Annotations/Swashbuckle.AspNetCore.Annotations.csproj
+++ b/src/Swashbuckle.AspNetCore.Annotations/Swashbuckle.AspNetCore.Annotations.csproj
@@ -14,6 +14,8 @@
     <PackageTags>swagger;documentation;discovery;help;webapi;aspnet;aspnetcore;annotations</PackageTags>
     <PackageProjectUrl>https://github.com/domaindrivendev/Swashbuckle.AspNetCore</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE</PackageLicenseUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/domaindrivendev/Swashbuckle.AspNetCore.git</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The `...Annotations` project is currently being published to NuGet without a repository link.
* https://www.nuget.org/packages/Swashbuckle.AspNetCore.Annotations/

My team makes use of [renovate-bot](https://github.com/renovatebot/renovate) for automated dependency updates, which has configuration to group monorepo dependencies into single update requests. For Swashbuckle, this is currently relying on the [source URL prefix](https://github.com/renovatebot/presets/blob/master/packages/renovate-config-monorepo/package.json#L15).