### PR TITLE
Update README.md example for setting custom swagger path

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ app.UseSwaggerUI(c =>
 })
 ```
 
+_NOTE: If you also need to update the relative path that the UI itself is available on, you'll need to follow the instructions found in [Change Relative Path to the UI](#change-relative-path-to-the-ui)._
+
 ### Modify Swagger with Request Context ###
 
 If you need to set some Swagger metadata based on the current request, you can configure a filter that's executed prior to serializing the document.


### PR DESCRIPTION
Thanks for your project!  When using the example in the README to set a custom swagger path for the UI, I found that it didn't work.  I found that an extra line of config was necessary to get it working.

This is a one-line PR to add in the missing line I needed to get custom paths working.