### PR TITLE
Enhance SecurityRequirementOperationFilter

### DIFF
--- a/test/WebSites/OAuth2Integration/ResourceServer/Swagger/SecurityRequirementsOperationFilter.cs
+++ b/test/WebSites/OAuth2Integration/ResourceServer/Swagger/SecurityRequirementsOperationFilter.cs
@@ -1,6 +1,9 @@
 ﻿using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
+using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -8,14 +11,31 @@ namespace OAuth2Integration.ResourceServer.Swagger
 {
     public class SecurityRequirementsOperationFilter : IOperationFilter
     {
+        private readonly AuthorizationOptions _authorizationOptions;
+        
+        public SecurityRequirementsOperationFilter(IOptions<AuthorizationOptions> authorizationOptions)
+        {
+            // Beware: This might only part of the truth. If someone exchanges the IAuthorizationPolicyProvider and that loads
+            // policies and requirements from another source than the configured options, we might not get all requirements
+            // from here. But then we would have to make asynchronous calls from this synchronous interface.
+            _authorizationOptions = authorizationOptions?.Value ?? throw new ArgumentNullException(nameof(authorizationOptions));
+        }
+
         public void Apply(OpenApiOperation operation, OperationFilterContext context)
         {
-            // Policy names map to scopes
-            var requiredScopes = context.MethodInfo
+            var requiredPolicies = context.MethodInfo
                 .GetCustomAttributes(true)
+                .Concat(context.MethodInfo.DeclaringType.GetCustomAttributes(true))
                 .OfType<AuthorizeAttribute>()
                 .Select(attr => attr.Policy)
                 .Distinct();
+
+            var requiredScopes = requiredPolicies.Select(p => _authorizationOptions.GetPolicy(p))
+                .SelectMany(r => r.Requirements.OfType<ClaimsAuthorizationRequirement>())
+                .Where(cr => cr.ClaimType == "scope")
+                .SelectMany(r => r.AllowedValues)
+                .Distinct()
+                .ToList();
 
             if (requiredScopes.Any())
             {
@@ -31,7 +51,7 @@ namespace OAuth2Integration.ResourceServer.Swagger
                 {
                     new OpenApiSecurityRequirement
                     {
-                        [ oAuthScheme ] = requiredScopes.ToList()
+                        [ oAuthScheme ] = requiredScopes
                     }
                 };
             }

--- a/test/WebSites/OAuth2Integration/ResourceServer/Swagger/SecurityRequirementsOperationFilter.cs
+++ b/test/WebSites/OAuth2Integration/ResourceServer/Swagger/SecurityRequirementsOperationFilter.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Authorization;


### PR DESCRIPTION
`SecurityRequirementOperationFilter` should not only respect `AuthorizeAttribute` on the method, but also on the class, so additionally read the attributes from the declaring type.

Then use the configured `AuthorizationOptions` to retrieve the actual Policy that is named in the `AuthorizeAttribute`.
Then analyze the policy and find all scope requirements to figure out the actual required scopes.
