### PR TITLE
Add examples to XML params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ artifacts/
 Thumbs.db
 test/WebSites/CliExample/wwwroot/api-docs/v1/*.json
 test/WebSites/CliExampleWithFactory/wwwroot/api-docs/v1/*.json
+*ncrunch*

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ To enhance the generated docs with human-friendly descriptions, you can annotate
     /// <summary>
     /// Retrieves a specific product by unique id
     /// </summary>
-    /// <param name="id" example="123"></param>
+    /// <param name="id" example="123">The product id</param>
     /// <remarks>Awesomeness!</remarks>
     /// <response code="200">Product created</response>
     /// <response code="400">Product has missing/invalid values</response>

--- a/README.md
+++ b/README.md
@@ -460,14 +460,14 @@ To enhance the generated docs with human-friendly descriptions, you can annotate
     }
     ```
 
-3. Annotate your actions with summary, param, remarks and response tags:
+3. Annotate your actions with summary, remarks, param and response tags:
 
     ```csharp
     /// <summary>
     /// Retrieves a specific product by unique id
     /// </summary>
-    /// <param name="id" example="123">The product id</param>
     /// <remarks>Awesomeness!</remarks>
+    /// <param name="id" example="123">The product id</param>
     /// <response code="200">Product created</response>
     /// <response code="400">Product has missing/invalid values</response>
     /// <response code="500">Oops! Can't create your product right now</response>

--- a/README.md
+++ b/README.md
@@ -460,12 +460,13 @@ To enhance the generated docs with human-friendly descriptions, you can annotate
     }
     ```
 
-3. Annotate your actions with summary, remarks and response tags:
+3. Annotate your actions with summary, param, remarks and response tags:
 
     ```csharp
     /// <summary>
     /// Retrieves a specific product by unique id
     /// </summary>
+    /// <param name="id" example="123"></param>
     /// <remarks>Awesomeness!</remarks>
     /// <response code="200">Product created</response>
     /// <response code="400">Product has missing/invalid values</response>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
@@ -80,6 +80,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             if (paramNode != null)
             {
                 schema.Description = XmlCommentsTextHelper.Humanize(paramNode.InnerXml);
+
+                var example = paramNode.GetAttribute("example", "");
+                if (!string.IsNullOrEmpty(example))
+                {
+                    schema.Example = ConvertToOpenApiType(parameterInfo.ParameterType, schema, example);
+                }
             }
         }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithXmlComments.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithXmlComments.cs
@@ -1,4 +1,7 @@
-﻿namespace Swashbuckle.AspNetCore.SwaggerGen.Test
+﻿using Swashbuckle.AspNetCore.TestSupport;
+using System;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
     /// <summary>
     /// Summary for FakeControllerWithXmlComments
@@ -23,6 +26,27 @@
         /// <response code="200">Description for 200 response</response>
         /// <response code="400">Description for 400 response</response>
         public void ActionWithResponseTags()
+        { }
+
+        /// <param name="boolParam" example="true"></param>
+        /// <param name="intParam" example="27"></param>
+        /// <param name="longParam" example="4294967296"></param>
+        /// <param name="floatParam" example="1.23"></param>
+        /// <param name="doubleParam" example="1.25"></param>
+        /// <param name="enumParam" example="2"></param>
+        /// <param name="guidParam" example="1edab3d2-311a-4782-9ec9-a70d0478b82f"></param>
+        /// <param name="stringParam" example="Example for StringProperty"></param>
+        /// <param name="badExampleIntParam" example="goodbye"></param>
+        public void ActionWithExampleParams(
+            bool boolParam,
+            int intParam,
+            long longParam,
+            float floatParam,
+            double doubleParam,
+            IntEnum enumParam,
+            Guid guidParam,
+            string stringParam,
+            int badExampleIntParam)
         { }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.xml
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.xml
@@ -43,6 +43,17 @@
             <response code="200">Description for 200 response</response>
             <response code="400">Description for 400 response</response>
         </member>
+        <member name="M:Swashbuckle.AspNetCore.SwaggerGen.Test.FakeControllerWithXmlComments.ActionWithExampleParams(System.Boolean,System.Int32,System.Int64,System.Single,System.Double,Swashbuckle.AspNetCore.TestSupport.IntEnum,System.Guid,System.String,System.Int32)">
+            <param name="boolParam" example="true"></param>
+            <param name="intParam" example="27"></param>
+            <param name="longParam" example="4294967296"></param>
+            <param name="floatParam" example="1.23"></param>
+            <param name="doubleParam" example="1.25"></param>
+            <param name="enumParam" example="2"></param>
+            <param name="guidParam" example="1edab3d2-311a-4782-9ec9-a70d0478b82f"></param>
+            <param name="stringParam" example="Example for StringProperty"></param>
+            <param name="badExampleIntParam" example="goodbye"></param>
+        </member>
         <member name="T:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedGenericType`2">
             <summary>
             Summary for XmlAnnotatedGenericType

--- a/test/WebSites/Basic/Controllers/CrudActionsController.cs
+++ b/test/WebSites/Basic/Controllers/CrudActionsController.cs
@@ -50,7 +50,7 @@ namespace Basic.Controllers
         /// <summary>
         /// Returns a specific product
         /// </summary>
-        /// <param name="id" example="111"></param>
+        /// <param name="id" example="111">The product id</param>
         /// <returns></returns>
         [HttpGet("{id}", Name = "GetProduct")]
         public Product Get(int id)

--- a/test/WebSites/Basic/Controllers/CrudActionsController.cs
+++ b/test/WebSites/Basic/Controllers/CrudActionsController.cs
@@ -35,7 +35,7 @@ namespace Basic.Controllers
         /// <summary>
         /// Searches the collection of products by description key words
         /// </summary>
-        /// <param name="keywords">A list of search terms</param>
+        /// <param name="keywords" example="hello">A list of search terms</param>
         /// <returns></returns>
         [HttpGet(Name = "SearchProducts")]
         public IEnumerable<Product> Get([FromQuery(Name = "kw")]string keywords = "foobar")
@@ -48,9 +48,9 @@ namespace Basic.Controllers
         }
 
         /// <summary>
-        /// Returns a specific product 
+        /// Returns a specific product
         /// </summary>
-        /// <param name="id"></param>
+        /// <param name="id" example="111"></param>
         /// <returns></returns>
         [HttpGet("{id}", Name = "GetProduct")]
         public Product Get(int id)
@@ -61,7 +61,7 @@ namespace Basic.Controllers
         /// <summary>
         /// Updates all properties of a specific product
         /// </summary>
-        /// <param name="id"></param>
+        /// <param name="id" example="222"></param>
         /// <param name="product"></param>
         [HttpPut("{id}", Name = "UpdateProduct")]
         public void Update(int id, [FromBody, Required]Product product)
@@ -71,7 +71,7 @@ namespace Basic.Controllers
         /// <summary>
         /// Updates some properties of a specific product
         /// </summary>
-        /// <param name="id"></param>
+        /// <param name="id" example="333"></param>
         /// <param name="updates"></param>
         [HttpPatch("{id}", Name = "PatchProduct")]
         public void Patch(int id, [FromBody, Required]IDictionary<string, object> updates)
@@ -81,7 +81,7 @@ namespace Basic.Controllers
         /// <summary>
         /// Deletes a specific product
         /// </summary>
-        /// <param name="id"></param>
+        /// <param name="id" example="444"></param>
         [HttpDelete("{id}", Name = "DeleteProduct")]
         public void Delete(int id)
         {


### PR DESCRIPTION
Fixes #1628.
I ensure the example type is the correct type and not always a string.
Includes unit tests and updated Readme.