### PR TITLE
improving data types

### DIFF
--- a/src/Swashbuckle.AspNetCore.ApiTesting/OpenApiSchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/OpenApiSchemaExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Text;
 using Microsoft.OpenApi.Models;
 
@@ -9,11 +10,22 @@ namespace Swashbuckle.AspNetCore.ApiTesting
         internal static bool TryParse(this OpenApiSchema schema, string stringValue, out object typedValue)
         {
             typedValue = null;
-
-            if (schema.Type == "boolean" && bool.TryParse(stringValue, out bool boolValue))
-                typedValue = boolValue;
+            if (schema.Type == "integer" && schema.Format == "int64" && long.TryParse(stringValue, out long longValue))
+                typedValue = longValue;
+            else if (schema.Type == "integer" && int.TryParse(stringValue, out int intValue))
+                typedValue = intValue;
+            else if (schema.Type == "number" && schema.Format == "double" && double.TryParse(stringValue, out double doubleValue))
+                typedValue = doubleValue;
             else if (schema.Type == "number" && float.TryParse(stringValue, out float floatValue))
                 typedValue = floatValue;
+            else if (schema.Type == "string" && schema.Format == "byte" && byte.TryParse(stringValue, out byte byteValue))
+                typedValue = byteValue;
+            else if (schema.Type == "string" && schema.Format == "date-time" && DateTime.TryParse(stringValue, out DateTime dateTimeValue))
+                typedValue = dateTimeValue;
+            else if (schema.Type == "string" && schema.Format == "uuid" && Guid.TryParse(stringValue, out Guid uuidValue))
+                typedValue = uuidValue;
+            else if (schema.Type == "boolean" && bool.TryParse(stringValue, out bool boolValue))
+                typedValue = boolValue;
             else if (schema.Type == "string")
                 typedValue = stringValue;
             else if (schema.Type == "array")


### PR DESCRIPTION
Improving data types on Swashbuckle.AspNetCore.ApiTesting to check and allow integer, datetime, byte, guid and double.

This change is based on:
![image](https://user-images.githubusercontent.com/7536544/81248563-fe540c00-8ff2-11ea-9bd7-0019343e24c0.png)
https://swagger.io/specification/