### PR TITLE
Do not duplicate parameter's description when there is an example, and inline the example.

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/OpenApiAnyHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/OpenApiAnyHelper.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen
+{
+    internal static class OpenApiAnyHelper
+    {
+        public static IOpenApiAny ConvertToOpenApiType(Type memberType, OpenApiSchema schema, string stringValue)
+        {
+            object typedValue;
+
+            try
+            {
+                typedValue = TypeDescriptor.GetConverter(memberType).ConvertFrom(
+                    context: null,
+                    culture: CultureInfo.InvariantCulture,
+                    stringValue);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+
+            return OpenApiAnyFactory.CreateFor(schema, typedValue);
+        }
+    }
+}

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.ComponentModel;
-using System.Globalization;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Xml.XPath;
-using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
@@ -60,28 +56,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 var example = paramNode.GetAttribute("example", string.Empty);
                 if (!string.IsNullOrEmpty(example))
                 {
-                    parameter.Example = ConvertToOpenApiType(parameterInfo.ParameterType, parameter.Schema, example);
+                    parameter.Example = OpenApiAnyHelper.ConvertToOpenApiType(parameterInfo.ParameterType, parameter.Schema, example);
                 }
             }
         }
 
-        private static IOpenApiAny ConvertToOpenApiType(Type memberType, OpenApiSchema schema, string stringValue)
-        {
-            object typedValue;
-
-            try
-            {
-                typedValue = TypeDescriptor.GetConverter(memberType).ConvertFrom(
-                    context: null,
-                    culture: CultureInfo.InvariantCulture,
-                    stringValue);
-            }
-            catch (Exception)
-            {
-                return null;
-            }
-
-            return OpenApiAnyFactory.CreateFor(schema, typedValue);
-        }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.ComponentModel;
-using System.Globalization;
-using System.Xml.XPath;
 using System.Reflection;
-using Microsoft.OpenApi.Any;
+using System.Xml.XPath;
 using Microsoft.OpenApi.Models;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
@@ -56,32 +53,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
                 if (fieldOrPropertyInfo is FieldInfo fieldInfo)
                 {
-                    schema.Example = ConvertToOpenApiType(fieldInfo.FieldType, schema, exampleString);
+                    schema.Example = OpenApiAnyHelper.ConvertToOpenApiType(fieldInfo.FieldType, schema, exampleString);
                 }
                 else if (fieldOrPropertyInfo is PropertyInfo propertyInfo)
                 {
-                    schema.Example = ConvertToOpenApiType(propertyInfo.PropertyType, schema, exampleString);
+                    schema.Example = OpenApiAnyHelper.ConvertToOpenApiType(propertyInfo.PropertyType, schema, exampleString);
                 }
             }
         }
 
-        private static IOpenApiAny ConvertToOpenApiType(Type memberType, OpenApiSchema schema, string stringValue)
-        {
-            object typedValue;
-
-            try
-            {
-                typedValue = TypeDescriptor.GetConverter(memberType).ConvertFrom(
-                    context: null,
-                    culture: CultureInfo.InvariantCulture,
-                    stringValue);
-            }
-            catch (Exception)
-            {
-                return null;
-            }
-
-            return OpenApiAnyFactory.CreateFor(schema, typedValue);
-        }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
@@ -25,10 +25,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             {
                 ApplyFieldOrPropertyTags(schema, context.MemberInfo);
             }
-            else if (context.ParameterInfo != null)
-            {
-                ApplyParamTags(schema, context.ParameterInfo);
-            }
         }
 
         private void ApplyTypeTags(OpenApiSchema schema, Type type)
@@ -65,24 +61,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 else if (fieldOrPropertyInfo is PropertyInfo propertyInfo)
                 {
                     schema.Example = ConvertToOpenApiType(propertyInfo.PropertyType, schema, exampleString);
-                }
-            }
-        }
-
-        private void ApplyParamTags(OpenApiSchema schema, ParameterInfo parameterInfo)
-        {
-            if (!(parameterInfo.Member is MethodInfo methodInfo)) return;
-
-            var methodMemberName = XmlCommentsNodeNameHelper.GetMemberNameForMethod(methodInfo);
-            var paramNode = _xmlNavigator.SelectSingleNode(
-                $"/doc/members/member[@name='{methodMemberName}']/param[@name='{parameterInfo.Name}']");
-
-            if (paramNode != null)
-            {
-                var example = paramNode.GetAttribute("example", "");
-                if (!string.IsNullOrEmpty(example))
-                {
-                    schema.Example = ConvertToOpenApiType(parameterInfo.ParameterType, schema, example);
                 }
             }
         }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
@@ -79,8 +79,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             if (paramNode != null)
             {
-                schema.Description = XmlCommentsTextHelper.Humanize(paramNode.InnerXml);
-
                 var example = paramNode.GetAttribute("example", "");
                 if (!string.IsNullOrEmpty(example))
                 {

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
@@ -55,20 +55,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal(expectedDescription, schema.Description);
         }
 
-        [Fact]
-        public void Apply_SetsDescription_FromActionParamTag()
-        {
-            var schema = new OpenApiSchema();
-            var parameterInfo = typeof(FakeControllerWithXmlComments)
-                .GetMethod(nameof(FakeControllerWithXmlComments.ActionWithParamTags))
-                .GetParameters()[0];
-            var filterContext = new SchemaFilterContext(parameterInfo.ParameterType, null, null, parameterInfo: parameterInfo);
-
-            Subject().Apply(schema, filterContext);
-
-            Assert.Equal("Description for param1", schema.Description);
-        }
-
         [Theory]
         [InlineData(0, "boolean", null, true)]
         [InlineData(1, "integer", "int32", 27)]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
@@ -56,42 +56,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
-        [InlineData(0, "boolean", null, true)]
-        [InlineData(1, "integer", "int32", 27)]
-        [InlineData(2, "integer", "int64", 4294967296L)]
-        [InlineData(3, "number", "float", 1.23F)]
-        [InlineData(4, "number", "double", 1.25D)]
-        [InlineData(5, "integer", "int32", 2)]
-        [InlineData(6, "string", "uuid", "1edab3d2-311a-4782-9ec9-a70d0478b82f")]
-        [InlineData(7, "string", null, "Example for StringProperty")]
-        [InlineData(8, "integer", "int32", null)]
-        public void Apply_SetsExample_FromActionParamTag(
-            int parameterIndex,
-            string schemaType,
-            string schemaFormat,
-            object expectedValue)
-        {
-            var schema = new OpenApiSchema { Type = schemaType, Format = schemaFormat };
-
-            var parameterInfo = typeof(FakeControllerWithXmlComments)
-                .GetMethod(nameof(FakeControllerWithXmlComments.ActionWithExampleParams))
-                .GetParameters()[parameterIndex];
-            var filterContext = new SchemaFilterContext(parameterInfo.ParameterType, null, null, parameterInfo: parameterInfo);
-
-            Subject().Apply(schema, filterContext);
-
-            if (expectedValue != null)
-            {
-                Assert.NotNull(schema.Example);
-                Assert.Equal(expectedValue, schema.Example.GetType().GetProperty("Value").GetValue(schema.Example));
-            }
-            else
-            {
-                Assert.Null(schema.Example);
-            }
-        }
-
-        [Theory]
         [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.BoolProperty), "boolean", null, true)]
         [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.IntProperty), "integer", "int32", 10)]
         [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.LongProperty), "integer", "int64", 4294967295L)]


### PR DESCRIPTION
Previous PRs: #1552, #1629

```csharp
<param name="foo" example="baz">foo parameter</param>
public void Get(string foo) {}
```
Before:
```json
          {
            "name": "foo",
            "in": "path",
            "description": "foo parameter",
            "schema": {
              "type": "string",
              "description": "foo parameter",
              "example": "baz"
            }
          }
```

After removing duplication:
```json
          {
            "name": "foo",
            "in": "path",
            "description": "foo parameter",
            "schema": {
              "type": "string",
              "example": "baz"
            }
          }
```

After moving examples under its parameters:
```json
          {
            "name": "foo",
            "in": "path",
            "description": "foo parameter",
            "example": "baz",
            "schema": {
              "type": "string"
            }
          }
```
