### PR TITLE
Fixed redirect when using empty RoutePrefix

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -51,7 +51,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
             var path = httpContext.Request.Path.Value;
 
             // If the RoutePrefix is requested (with or without trailing slash), redirect to index URL
-            if (httpMethod == "GET" && Regex.IsMatch(path, $"^/{Regex.Escape(_options.RoutePrefix)}/?$"))
+            if (httpMethod == "GET" && Regex.IsMatch(path, $"^/?{Regex.Escape(_options.RoutePrefix)}/?$"))
             {
                 // Use relative redirect to support proxy environments
                 var relativeRedirectPath = path.EndsWith("/")


### PR DESCRIPTION
Fixes https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/1688#issue-comment-box

If you want the swagger ui served from the root path, you can set de RoutePrefix to an empty string. However, behind a reverse proxy and a appbasepath set, the request path could be empty (instead of a /) 
This tiny fix solves these edge cases.