### PR TITLE
fix: Microsoft.OpenAPI package reference conflict

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/Swashbuckle.AspNetCore.Swagger.csproj
+++ b/src/Swashbuckle.AspNetCore.Swagger/Swashbuckle.AspNetCore.Swagger.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi" Version="[1.1.4,1.2.0)" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.2.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/Swashbuckle.AspNetCore.Swagger/Swashbuckle.AspNetCore.Swagger.csproj
+++ b/src/Swashbuckle.AspNetCore.Swagger/Swashbuckle.AspNetCore.Swagger.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi" Version="1.1.4" />
+    <PackageReference Include="Microsoft.OpenApi" Version="[1.1.4,1.2.0)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">


### PR DESCRIPTION
Add upper bound to Miicrosoft.OpenAPI package reference to Swashbuckle.AspNetCore.Swagger project to be less than 1.2.0 as it breaks contains breaking changes for  Swashbuckle.AspNetCore.Swagger project

fixes #1717