### PR TITLE
Configurable use of ref instead of oneOf for polymorphic types

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
@@ -37,6 +37,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             target.SubTypesResolver = source.SubTypesResolver;
             target.DiscriminatorSelector = source.DiscriminatorSelector;
             target.UseAllOfToExtendReferenceSchemas = source.UseAllOfToExtendReferenceSchemas;
+            target.UseRefInsteadOfOneOfForPolymorphicSchemas = source.UseRefInsteadOfOneOfForPolymorphicSchemas;
             target.UseInlineDefinitionsForEnums = source.UseInlineDefinitionsForEnums;
             target.SchemaFilters = new List<ISchemaFilter>(source.SchemaFilters);
             target.DescribeAllEnumsAsStrings = source.DescribeAllEnumsAsStrings;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -245,6 +245,15 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// User ref instead of oneOf for polymorphic schemas 
+        /// </summary>
+        /// <param name="swaggerGenOptions"></param>
+        public static void UseRefInsteadOfOneOfForPolymorphicSchemas(this SwaggerGenOptions swaggerGenOptions)
+        {
+            swaggerGenOptions.SchemaGeneratorOptions.UseRefInsteadOfOneOfForPolymorphicSchemas = true;
+        }
+
+        /// <summary>
         /// Generate inline schema definitions (as opposed to referencing a shared definition) for enum parameters and properties
         /// </summary>
         /// <param name="swaggerGenOptions"></param>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -60,8 +60,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             if (_generatorOptions.GeneratePolymorphicSchemas)
             {
-                var knownSubTypes = _generatorOptions.SubTypesResolver(type);
-                if (knownSubTypes.Any())
+                var knownSubTypes = _generatorOptions.SubTypesResolver(type).ToList();
+                if (_generatorOptions.UseRefInsteadOfOneOfForPolymorphicSchemas)
+                {
+                    knownSubTypes.Select(subType => GenerateSchema(subType, schemaRepository)).ToList();
+                }
+                else if (knownSubTypes.Any())
                 {
                     return GeneratePolymorphicSchema(knownSubTypes, schemaRepository);
                 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
@@ -30,6 +30,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public bool UseAllOfToExtendReferenceSchemas { get; set; }
 
+        public bool UseRefInsteadOfOneOfForPolymorphicSchemas { get; set; }
+
         public bool UseInlineDefinitionsForEnums { get; set; }
 
         public IList<ISchemaFilter> SchemaFilters { get; set; }


### PR DESCRIPTION
Added configuration to use `ref` intead of `oneOf`, for better support of code generation tools, that can not handle `oneOf` correct