### PR TITLE
fix typo in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,7 +837,7 @@ public class TagDescriptionsDocumentFilter : IDocumentFilter
 }
 ```
 
-_NOTE: If you're using the `SwaggerUI` middleware, the `TagDescriptionsDocumentFilter` demonstratd above could be used to display additional descriptions beside each group of Operations._
+_NOTE: If you're using the `SwaggerUI` middleware, the `TagDescriptionsDocumentFilter` demonstrated above could be used to display additional descriptions beside each group of Operations._
 
 ### Add Security Definitions and Requirements ###
 


### PR DESCRIPTION
Fixes  a tiny typo (demonstratd instead of demonstrated)