### PR TITLE
Added standard SwaggerUI route as default route.

### DIFF
--- a/Swashbuckle.AspNetCore.sln
+++ b/Swashbuckle.AspNetCore.sln
@@ -89,6 +89,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CliExampleWithFactory", "te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Swashbuckle.AspNetCore.TestSupport", "test\Swashbuckle.AspNetCore.TestSupport\Swashbuckle.AspNetCore.TestSupport.csproj", "{6E3C0128-931F-4438-AEDD-984E0E2B2C7B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DefaultRoute", "test\WebSites\DefaultRoute\DefaultRoute.csproj", "{B5448796-4165-4C2A-BA4E-C997FBD0005B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -459,6 +461,18 @@ Global
 		{6E3C0128-931F-4438-AEDD-984E0E2B2C7B}.Release|x64.Build.0 = Release|Any CPU
 		{6E3C0128-931F-4438-AEDD-984E0E2B2C7B}.Release|x86.ActiveCfg = Release|Any CPU
 		{6E3C0128-931F-4438-AEDD-984E0E2B2C7B}.Release|x86.Build.0 = Release|Any CPU
+		{B5448796-4165-4C2A-BA4E-C997FBD0005B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5448796-4165-4C2A-BA4E-C997FBD0005B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5448796-4165-4C2A-BA4E-C997FBD0005B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B5448796-4165-4C2A-BA4E-C997FBD0005B}.Debug|x64.Build.0 = Debug|Any CPU
+		{B5448796-4165-4C2A-BA4E-C997FBD0005B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B5448796-4165-4C2A-BA4E-C997FBD0005B}.Debug|x86.Build.0 = Debug|Any CPU
+		{B5448796-4165-4C2A-BA4E-C997FBD0005B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5448796-4165-4C2A-BA4E-C997FBD0005B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5448796-4165-4C2A-BA4E-C997FBD0005B}.Release|x64.ActiveCfg = Release|Any CPU
+		{B5448796-4165-4C2A-BA4E-C997FBD0005B}.Release|x64.Build.0 = Release|Any CPU
+		{B5448796-4165-4C2A-BA4E-C997FBD0005B}.Release|x86.ActiveCfg = Release|Any CPU
+		{B5448796-4165-4C2A-BA4E-C997FBD0005B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -495,6 +509,7 @@ Global
 		{605AA0D3-2AA7-46B4-811B-85DC1B1A3901} = {1669F896-133C-4996-B58C-E7CDA299ADFF}
 		{322813C4-0458-4F98-965D-568AD2C819CE} = {245144DE-BC89-4822-B044-020458BFECC0}
 		{6E3C0128-931F-4438-AEDD-984E0E2B2C7B} = {1669F896-133C-4996-B58C-E7CDA299ADFF}
+		{B5448796-4165-4C2A-BA4E-C997FBD0005B} = {245144DE-BC89-4822-B044-020458BFECC0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {36FC6A67-247D-4149-8EDD-79FFD1A75F51}

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -37,6 +37,9 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         {
             _options = options ?? new SwaggerUIOptions();
 
+            // use standard Swagger endpoint URL if no custom URLs provided
+            if (_options.ConfigObject.Urls == null) _options.ConfigObject.Urls = new[] { new UrlDescriptor { Url = "/swagger/v1/swagger.json", Name = "API Description" } };
+
             _staticFileMiddleware = CreateStaticFileMiddleware(next, hostingEnv, loggerFactory, options);
 
             _jsonSerializerOptions = new JsonSerializerOptions();

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -33,6 +33,17 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
         }
 
         [Fact]
+        public async Task DefaultRoute_RedirectsToRelativeIndexUrl()
+        {
+            var client = new TestSite(typeof(DefaultRoute.Startup)).BuildClient();
+
+            var response = await client.GetAsync("/");
+
+            Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
+            Assert.Equal("index.html", response.Headers.Location.ToString());
+        }
+
+        [Fact]
         public async Task IndexUrl_ReturnsCustomPageTitleAndStylesheets_IfConfigured()
         {
             var client = new TestSite(typeof(CustomUIConfig.Startup)).BuildClient();

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/Swashbuckle.AspNetCore.IntegrationTests.csproj
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/Swashbuckle.AspNetCore.IntegrationTests.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\WebSites\ConfigFromFile\ConfigFromFile.csproj" />
     <ProjectReference Include="..\WebSites\CustomUIConfig\CustomUIConfig.csproj" />
     <ProjectReference Include="..\WebSites\CustomUIIndex\CustomUIIndex.csproj" />
+    <ProjectReference Include="..\WebSites\DefaultRoute\DefaultRoute.csproj" />
     <ProjectReference Include="..\WebSites\GenericControllers\GenericControllers.csproj" />
     <ProjectReference Include="..\WebSites\MultipleVersions\MultipleVersions.csproj" />
     <ProjectReference Include="..\WebSites\NetCore21\NetCore21.csproj" />

--- a/test/WebSites/DefaultRoute/DefaultRoute.csproj
+++ b/test/WebSites/DefaultRoute/DefaultRoute.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.Swagger\Swashbuckle.AspNetCore.Swagger.csproj" />
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerGen\Swashbuckle.AspNetCore.SwaggerGen.csproj" />
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerUI\Swashbuckle.AspNetCore.SwaggerUI.csproj" />
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.Annotations\Swashbuckle.AspNetCore.Annotations.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/WebSites/DefaultRoute/Program.cs
+++ b/test/WebSites/DefaultRoute/Program.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace DefaultRoute
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/test/WebSites/DefaultRoute/Properties/launchSettings.json
+++ b/test/WebSites/DefaultRoute/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:53224"
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "DefaultRoute": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "",
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/test/WebSites/DefaultRoute/Startup.cs
+++ b/test/WebSites/DefaultRoute/Startup.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace DefaultRoute
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration) => Configuration = configuration;
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers();
+            services.AddSwaggerGen();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment()) app.UseDeveloperExceptionPage();
+
+            app.UseRouting()
+                .UseEndpoints(endpoints => endpoints.MapControllers())
+                .UseSwaggerUI(c => c.RoutePrefix = "")      // default route will be used here
+                ;
+        }
+    }
+}

--- a/test/WebSites/DefaultRoute/appsettings.Development.json
+++ b/test/WebSites/DefaultRoute/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/test/WebSites/DefaultRoute/appsettings.json
+++ b/test/WebSites/DefaultRoute/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Proposed solution for issue #1756:
<br/>

Previously, when no custom Swagger endpoint route was provided to SwaggerUI by client, an empty web page was displayed. No error message was shown.

Now, the well known standard route will be used if no custom route is provided.

[The change is a single code line](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/1d1e3ee0befeb5db171a95c820b8197657a516e3/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs#L40-L41) adding the default route to Swagger endpoint url if no route is provided in `Startup.cs`:

```c#
// use standard Swagger endpoint URL if no custom URLs provided
if (_options.ConfigObject.Urls == null) _options.ConfigObject.Urls = new[] { new UrlDescriptor { Url = "/swagger/v1/swagger.json", Name = "API Description" } };
```

I also added an integration test, conforming to contributing guidelines.