### PR TITLE
Improve polymorphism & inheritance behavior incl. more flexible config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ artifacts/
 Thumbs.db
 test/WebSites/CliExample/wwwroot/api-docs/v1/*.json
 test/WebSites/CliExampleWithFactory/wwwroot/api-docs/v1/*.json
+test/WebSites/NswagClientExample/NSwagClient/
 *ncrunch*

--- a/Swashbuckle.AspNetCore.sln
+++ b/Swashbuckle.AspNetCore.sln
@@ -89,6 +89,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CliExampleWithFactory", "te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Swashbuckle.AspNetCore.TestSupport", "test\Swashbuckle.AspNetCore.TestSupport\Swashbuckle.AspNetCore.TestSupport.csproj", "{6E3C0128-931F-4438-AEDD-984E0E2B2C7B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NSwagClientExample", "test\WebSites\NswagClientExample\NSwagClientExample.csproj", "{9840E751-5845-431C-943B-C75CAE596A45}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -459,6 +461,18 @@ Global
 		{6E3C0128-931F-4438-AEDD-984E0E2B2C7B}.Release|x64.Build.0 = Release|Any CPU
 		{6E3C0128-931F-4438-AEDD-984E0E2B2C7B}.Release|x86.ActiveCfg = Release|Any CPU
 		{6E3C0128-931F-4438-AEDD-984E0E2B2C7B}.Release|x86.Build.0 = Release|Any CPU
+		{9840E751-5845-431C-943B-C75CAE596A45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9840E751-5845-431C-943B-C75CAE596A45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9840E751-5845-431C-943B-C75CAE596A45}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9840E751-5845-431C-943B-C75CAE596A45}.Debug|x64.Build.0 = Debug|Any CPU
+		{9840E751-5845-431C-943B-C75CAE596A45}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9840E751-5845-431C-943B-C75CAE596A45}.Debug|x86.Build.0 = Debug|Any CPU
+		{9840E751-5845-431C-943B-C75CAE596A45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9840E751-5845-431C-943B-C75CAE596A45}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9840E751-5845-431C-943B-C75CAE596A45}.Release|x64.ActiveCfg = Release|Any CPU
+		{9840E751-5845-431C-943B-C75CAE596A45}.Release|x64.Build.0 = Release|Any CPU
+		{9840E751-5845-431C-943B-C75CAE596A45}.Release|x86.ActiveCfg = Release|Any CPU
+		{9840E751-5845-431C-943B-C75CAE596A45}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -495,6 +509,7 @@ Global
 		{605AA0D3-2AA7-46B4-811B-85DC1B1A3901} = {1669F896-133C-4996-B58C-E7CDA299ADFF}
 		{322813C4-0458-4F98-965D-568AD2C819CE} = {245144DE-BC89-4822-B044-020458BFECC0}
 		{6E3C0128-931F-4438-AEDD-984E0E2B2C7B} = {1669F896-133C-4996-B58C-E7CDA299ADFF}
+		{9840E751-5845-431C-943B-C75CAE596A45} = {245144DE-BC89-4822-B044-020458BFECC0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {36FC6A67-247D-4149-8EDD-79FFD1A75F51}

--- a/src/Swashbuckle.AspNetCore.Annotations/AnnotationsSwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Annotations/AnnotationsSwaggerGenOptionsExtensions.cs
@@ -22,7 +22,11 @@ namespace Microsoft.Extensions.DependencyInjection
             options.DocumentFilter<AnnotationsDocumentFilter>();
 
             if (enableSubTypeAnnotations)
-                options.GeneratePolymorphicSchemas(AnnotationsSubTypeResolver, AnnotationsDiscriminatorSelector);
+            {
+                options.UseOneOfForPolymorphism(AnnotationsDiscriminatorSelector);
+                options.DetectSubTypesUsing(AnnotationsSubTypeResolver);
+                options.UseAllOfForInheritance();
+            }
         }
 
         private static IEnumerable<Type> AnnotationsSubTypeResolver(Type type)
@@ -42,7 +46,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             return type.GetCustomAttributes(false)
                 .OfType<SwaggerSubTypesAttribute>()
-                .FirstOrDefault()?.Discriminator ?? "$type";
+                .FirstOrDefault()?.Discriminator;
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
@@ -33,7 +33,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             target.CustomTypeMappings = new Dictionary<Type, Func<OpenApiSchema>>(source.CustomTypeMappings);
             target.SchemaIdSelector = source.SchemaIdSelector;
             target.IgnoreObsoleteProperties = source.IgnoreObsoleteProperties;
-            target.GeneratePolymorphicSchemas = source.GeneratePolymorphicSchemas;
+            target.UseOneOfForPolymorphism = source.UseOneOfForPolymorphism;
+            target.UseAllOfForInheritance = source.UseAllOfForInheritance;
             target.SubTypesResolver = source.SubTypesResolver;
             target.DiscriminatorSelector = source.DiscriminatorSelector;
             target.UseAllOfToExtendReferenceSchemas = source.UseAllOfToExtendReferenceSchemas;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/IDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/IDataContractResolver.cs
@@ -11,42 +11,89 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
     public class DataContract
     {
-        public DataContract(
-            DataType dataType,
-            Type underlyingType,
-            string format = null,
-            IEnumerable<object> enumValues = null,
-            IEnumerable<DataProperty> properties = null,
-            Type additionalPropertiesType = null,
-            Type arrayItemType = null)
+        public static DataContract ForPrimitive(Type underlyingType, DataType dataType, string dataFormat, IEnumerable<object> enumValues = null)
         {
-            DataType = dataType;
-            Format = format;
-            EnumValues = enumValues;
-            Properties = properties;
-            UnderlyingType = underlyingType;
-            AdditionalPropertiesType = additionalPropertiesType;
-            ArrayItemType = arrayItemType;
+            return new DataContract(
+                underlyingType: underlyingType,
+                dataType: dataType,
+                dataFormat: dataFormat,
+                enumValues: enumValues);
         }
 
-        public DataType DataType { get; }
-        public string Format { get; }
-        public IEnumerable<object> EnumValues { get; }
-        public IEnumerable<DataProperty> Properties { get; }
+        public static DataContract ForArray(Type underlyingType, Type itemType)
+        {
+            return new DataContract(
+                underlyingType: underlyingType,
+                dataType: DataType.Array,
+                arrayItemType: itemType);
+        }
+
+        public static DataContract ForDictionary(Type underlyingType, Type valueType, IEnumerable<string> keys = null)
+        {
+            return new DataContract(
+                underlyingType: underlyingType,
+                dataType: DataType.Dictionary,
+                dictionaryValueType: valueType,
+                dictionaryKeys: keys);
+        }
+
+        public static DataContract ForObject(Type underlyingType, IEnumerable<DataProperty> properties, Type extensionDataType = null)
+        {
+            return new DataContract(
+                underlyingType: underlyingType,
+                dataType: DataType.Object,
+                objectProperties: properties,
+                objectExtensionDataType: extensionDataType);
+        }
+
+        public static DataContract ForDynamic(Type underlyingType)
+        {
+            return new DataContract(underlyingType: underlyingType, dataType: DataType.Unknown);
+        }
+
+        private DataContract(
+            Type underlyingType,
+            DataType dataType,
+            string dataFormat = null,
+            IEnumerable<object> enumValues = null,
+            Type arrayItemType = null,
+            Type dictionaryValueType = null,
+            IEnumerable<string> dictionaryKeys = null,
+            IEnumerable<DataProperty> objectProperties = null,
+            Type objectExtensionDataType = null)
+        {
+            UnderlyingType = underlyingType;
+            DataType = dataType;
+            DataFormat = dataFormat;
+            EnumValues = enumValues;
+            ArrayItemType = arrayItemType;
+            DictionaryValueType = dictionaryValueType;
+            DictionaryKeys = dictionaryKeys;
+            ObjectProperties = objectProperties;
+            ObjectExtensionDataType = objectExtensionDataType;
+        }
+
         public Type UnderlyingType { get; }
-        public Type AdditionalPropertiesType { get; }
+        public DataType DataType { get; }
+        public string DataFormat { get; }
+        public IEnumerable<object> EnumValues { get; }
         public Type ArrayItemType { get; }
+        public Type DictionaryValueType { get; }
+        public IEnumerable<string> DictionaryKeys { get; }
+        public IEnumerable<DataProperty> ObjectProperties { get; }
+        public Type ObjectExtensionDataType { get; }
     }
 
     public enum DataType
     {
-        Unknown,
         Boolean,
         Integer,
         Number,
         String,
+        Array,
+        Dictionary,
         Object,
-        Array
+        Unknown
     }
 
     public class DataProperty
@@ -70,17 +117,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         }
 
         public string Name { get; } 
-
         public bool IsRequired { get; }
-
         public bool IsNullable { get; }
-
         public bool IsReadOnly { get; }
-
         public bool IsWriteOnly { get; }
-
         public Type MemberType { get; }
-
         public MemberInfo MemberInfo { get; }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -18,65 +19,54 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public DataContract GetDataContractForType(Type type)
         {
-            var underlyingType = type.IsNullable(out Type innerType) ? innerType : type;
-
-            if (PrimitiveTypesAndFormats.ContainsKey(underlyingType))
+            if (type.IsOneOf(typeof(JsonDocument), typeof(JsonElement)))
             {
-                var primitiveTypeAndFormat = PrimitiveTypesAndFormats[underlyingType];
-
-                return new DataContract(
-                    dataType: primitiveTypeAndFormat.Item1,
-                    format: primitiveTypeAndFormat.Item2,
-                    underlyingType: underlyingType);
+                return DataContract.ForDynamic(underlyingType: type);
             }
 
-            if (underlyingType.IsEnum)
+            if (PrimitiveTypesAndFormats.ContainsKey(type))
             {
-                var enumValues = GetSerializedEnumValuesFor(underlyingType);
+                var primitiveTypeAndFormat = PrimitiveTypesAndFormats[type];
+
+                return DataContract.ForPrimitive(
+                    underlyingType: type,
+                    dataType: primitiveTypeAndFormat.Item1,
+                    dataFormat: primitiveTypeAndFormat.Item2);
+            }
+
+            if (type.IsEnum)
+            {
+                var enumValues = GetSerializedEnumValuesFor(type);
 
                 var primitiveTypeAndFormat = (enumValues.Any(value => value is string))
                     ? PrimitiveTypesAndFormats[typeof(string)]
-                    : PrimitiveTypesAndFormats[underlyingType.GetEnumUnderlyingType()];
+                    : PrimitiveTypesAndFormats[type.GetEnumUnderlyingType()];
 
-                return new DataContract(
+                return DataContract.ForPrimitive(
+                    underlyingType: type,
                     dataType: primitiveTypeAndFormat.Item1,
-                    format: primitiveTypeAndFormat.Item2,
-                    underlyingType: underlyingType,
+                    dataFormat: primitiveTypeAndFormat.Item2,
                     enumValues: enumValues);
             }
 
-            if (underlyingType.IsDictionary(out Type keyType, out Type valueType))
+            if (IsSupportedDictionary(type, out Type keyType, out Type valueType))
             {
-                if (keyType.IsEnum)
-                    throw new NotSupportedException(
-                        $"Schema cannot be generated for type {underlyingType} as it's not supported by the System.Text.Json serializer");
-
-                return new DataContract(
-                    dataType: DataType.Object,
-                    underlyingType: underlyingType,
-                    additionalPropertiesType: valueType);
+                return DataContract.ForDictionary(
+                    underlyingType: type,
+                    valueType: valueType);
             }
 
-            if (underlyingType.IsEnumerable(out Type itemType))
+            if (IsSupportedCollection(type, out Type itemType))
             {
-                return new DataContract(
-                    dataType: DataType.Array,
-                    underlyingType: underlyingType,
-                    arrayItemType: itemType);
+                return DataContract.ForArray(
+                    underlyingType: type,
+                    itemType: itemType);
             }
 
-            if (underlyingType.IsOneOf(typeof(JsonDocument), typeof(JsonElement)))
-            {
-                return new DataContract(
-                    dataType: DataType.Unknown,
-                    underlyingType: underlyingType);
-            }
-
-            return new DataContract(
-                dataType: DataType.Object,
-                underlyingType: underlyingType,
-                properties: GetDataPropertiesFor(underlyingType, out Type extensionDataValueType),
-                additionalPropertiesType: extensionDataValueType);
+            return DataContract.ForObject(
+                underlyingType: type,
+                properties: GetDataPropertiesFor(type, out Type extensionDataType),
+                extensionDataType: extensionDataType);
         }
 
         private IEnumerable<object> GetSerializedEnumValuesFor(Type enumType)
@@ -92,14 +82,55 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 : underlyingValues;
         }
 
-        private IEnumerable<DataProperty> GetDataPropertiesFor(Type objectType, out Type extensionDataValueType)
+        public bool IsSupportedDictionary(Type type, out Type keyType, out Type valueType)
         {
-            extensionDataValueType = null;
-
-            if (objectType == typeof(object))
+            if (type.IsConstructedFrom(typeof(IDictionary<,>), out Type constructedType)
+                || type.IsConstructedFrom(typeof(IReadOnlyDictionary<,>), out constructedType))
             {
-                return null;
+                keyType = constructedType.GenericTypeArguments[0];
+                valueType = constructedType.GenericTypeArguments[1];
+                return true;
             }
+
+            if (typeof(IDictionary).IsAssignableFrom(type))
+            {
+                keyType = valueType = typeof(object);
+                return true;
+            }
+
+            keyType = valueType = null;
+            return false;
+        }
+
+        public bool IsSupportedCollection(Type type, out Type itemType)
+        {
+            if (type.IsConstructedFrom(typeof(IEnumerable<>), out Type constructedType))
+            {
+                itemType = constructedType.GenericTypeArguments[0];
+                return true;
+            }
+
+#if NETCOREAPP3_0
+            if (type.IsConstructedFrom(typeof(IAsyncEnumerable<>), out constructedType))
+            {
+                itemType = constructedType.GenericTypeArguments[0];
+                return true;
+            }
+#endif
+
+            if (typeof(IEnumerable).IsAssignableFrom(type))
+            {
+                itemType = typeof(object);
+                return true;
+            }
+
+            itemType = null;
+            return false;
+        }
+
+        private IEnumerable<DataProperty> GetDataPropertiesFor(Type objectType, out Type extensionDataType)
+        {
+            extensionDataType = null;
 
             var applicableProperties = objectType.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
                 .Where(property =>
@@ -115,9 +146,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             foreach (var propertyInfo in applicableProperties)
             {
-                if (propertyInfo.HasAttribute<JsonExtensionDataAttribute>() && propertyInfo.PropertyType.IsDictionary(out Type _, out Type valueType))
+                if (propertyInfo.HasAttribute<JsonExtensionDataAttribute>()
+                    && propertyInfo.PropertyType.IsConstructedFrom(typeof(IDictionary<,>), out Type constructedDictionary))
                 {
-                    extensionDataValueType = valueType;
+                    extensionDataType = constructedDictionary.GenericTypeArguments[1];
                     continue;
                 }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
@@ -18,19 +18,22 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public IDictionary<Type, Func<OpenApiSchema>> CustomTypeMappings { get; set; }
 
+        public bool UseInlineDefinitionsForEnums { get; set; }
+
         public Func<Type, string> SchemaIdSelector { get; set; }
 
         public bool IgnoreObsoleteProperties { get; set; }
 
-        public bool GeneratePolymorphicSchemas { get; set; }
+        public bool UseAllOfToExtendReferenceSchemas { get; set; }
+
+        public bool UseOneOfForPolymorphism { get; set; }
 
         public Func<Type, IEnumerable<Type>> SubTypesResolver { get; set; }
 
         public Func<Type, string> DiscriminatorSelector { get; set; }
 
-        public bool UseAllOfToExtendReferenceSchemas { get; set; }
+        public bool UseAllOfForInheritance { get; set; }
 
-        public bool UseInlineDefinitionsForEnums { get; set; }
 
         public IList<ISchemaFilter> SchemaFilters { get; set; }
 
@@ -61,7 +64,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private string DefaultDiscriminatorSelector(Type baseType)
         {
-            return "$type";
+            return null;
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SchemaRepository.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SchemaRepository.cs
@@ -11,44 +11,43 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public Dictionary<string, OpenApiSchema> Schemas { get; private set; } = new Dictionary<string, OpenApiSchema>();
 
-        public OpenApiSchema GetOrAdd(Type type, string schemaId, Func<OpenApiSchema> factoryMethod)
-        {
-            if (!_reservedIds.TryGetValue(type, out string reservedId))
-            {
-                // First invocation of the factoryMethod for this type - reserve the provided schemaId first, and then invoke the factory method.
-                // Reserving the id first ensures that the factoryMethod will only be invoked once for a given type, even in recurrsive scenarios.
-                // If subsequent calls are made for the same type, a simple reference will be created instead.
-                ReserveIdFor(type, schemaId);
-                Schemas.Add(schemaId, factoryMethod());
-            }
-            else
-            {
-                schemaId = reservedId;
-            }
-
-            return new OpenApiSchema
-            {
-                Reference = new OpenApiReference { Id = schemaId, Type = ReferenceType.Schema }
-            };
-        }
-
-        public bool TryGetIdFor(Type type, out string schemaId)
-        {
-            return _reservedIds.TryGetValue(type, out schemaId);
-        }
-        
-        public void ReserveIdFor(Type type, string schemaId)
+        public void RegisterType(Type type, string schemaId)
         {
             if (_reservedIds.ContainsValue(schemaId))
             {
-                var reservedForType = _reservedIds.First(entry => entry.Value == schemaId).Key;
+                var conflictingType = _reservedIds.First(entry => entry.Value == schemaId).Key;
 
                 throw new InvalidOperationException(
                     $"Can't use schemaId \"${schemaId}\" for type \"${type}\". " +
-                    $"The same schemaId is already used for type \"${reservedForType}\"");
+                    $"The same schemaId is already used for type \"${conflictingType}\"");
             }
 
             _reservedIds.Add(type, schemaId);
+        }
+
+        public bool TryLookupByType(Type type, out OpenApiSchema referenceSchema)
+        {
+            if (_reservedIds.TryGetValue(type, out string schemaId))
+            {
+                referenceSchema = new OpenApiSchema
+                {
+                    Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = schemaId }
+                };
+                return true;
+            }
+
+            referenceSchema = null;
+            return false;
+        }
+
+        public OpenApiSchema AddDefinition(string schemaId, OpenApiSchema schema)
+        {
+            Schemas.Add(schemaId, schema);
+
+            return new OpenApiSchema
+            {
+                Reference = new OpenApiReference { Type = ReferenceType.Schema, Id = schemaId }
+            };
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/NewtonsoftSerializerTesting.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/NewtonsoftSerializerTesting.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Swashbuckle.AspNetCore.TestSupport;
 using Xunit;
@@ -13,15 +14,9 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         [Fact]
         public void Serialize()
         {
-            var dto = new Dictionary<IntEnum, string>
-            {
-                [IntEnum.Value2] = "foo",
-                [IntEnum.Value4] = "bar",
-                [IntEnum.Value8] = "blah",
-            };
+            var dto = new Version(1, 1, 1);
 
             var jsonString = JsonConvert.SerializeObject(dto);
-            Assert.Equal("{\"Value2\":\"foo\",\"Value4\":\"bar\",\"Value8\":\"blah\"}", jsonString);
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -178,7 +178,6 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 
             Assert.Equal("object", schema.Type);
             Assert.Empty(schema.Properties);
-            Assert.False(schema.AdditionalPropertiesAllowed);
         }
 
         [Theory]
@@ -393,10 +392,10 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         }
 
         [Fact]
-        public void GenerateSchema_SupportsOption_GeneratePolymorphicSchemas()
+        public void GenerateSchema_SupportsOption_UseOneOfForPolymorphism()
         {
             var subject = Subject(
-                configureGenerator: c => c.GeneratePolymorphicSchemas = true
+                configureGenerator: c => c.UseOneOfForPolymorphism = true
             );
             var schemaRepository = new SchemaRepository();
 
@@ -404,25 +403,94 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 
             // The polymorphic schema
             Assert.NotNull(schema.OneOf);
-            Assert.Equal(2, schema.OneOf.Count);
+            Assert.Equal(3, schema.OneOf.Count);
             Assert.NotNull(schema.OneOf[0].Reference);
-            // The first sub schema
-            var subSchema1 = schemaRepository.Schemas[schema.OneOf[0].Reference.Id];
-            Assert.NotNull(subSchema1.AllOf);
-            Assert.Equal(2, subSchema1.AllOf.Count);
-            Assert.Equal("PolymorphicType", subSchema1.AllOf[0].Reference.Id);
-            Assert.Equal(new[] { "Property1" }, subSchema1.AllOf[1].Properties.Keys);
-            // The second sub schema
-            var subSchema2 = schemaRepository.Schemas[schema.OneOf[1].Reference.Id];
-            Assert.NotNull(subSchema2.AllOf);
-            Assert.Equal(2, subSchema2.AllOf.Count);
-            Assert.Equal("PolymorphicType", subSchema2.AllOf[0].Reference.Id);
-            Assert.Equal(new[] { "Property2" }, subSchema2.AllOf[1].Properties.Keys);
-            // The base schema
-            var baseSchema = schemaRepository.Schemas[subSchema1.AllOf[0].Reference.Id];
-            Assert.Equal(new[] { "$type", "BaseProperty" }, baseSchema.Properties.Keys);
-            Assert.Equal(new[] { "$type" }, baseSchema.Required);
-            Assert.Equal("$type", baseSchema.Discriminator.PropertyName);
+            Assert.NotNull(schema.OneOf[1].Reference);
+            Assert.NotNull(schema.OneOf[2].Reference);
+            // The base type schema
+            var baseSchema = schemaRepository.Schemas[schema.OneOf[0].Reference.Id];
+            Assert.Equal("object", baseSchema.Type);
+            Assert.Equal(new[] { "BaseProperty"}, baseSchema.Properties.Keys);
+            // The first sub type schema
+            var subType1Schema = schemaRepository.Schemas[schema.OneOf[1].Reference.Id];
+            Assert.Equal("object", subType1Schema.Type);
+            Assert.Equal(new[] { "Property1", "BaseProperty" }, subType1Schema.Properties.Keys);
+            // The second sub type schema
+            var subType2Schema = schemaRepository.Schemas[schema.OneOf[2].Reference.Id];
+            Assert.Equal("object", subType2Schema.Type);
+            Assert.Equal(new[] { "Property2", "BaseProperty" }, subType2Schema.Properties.Keys);
+        }
+
+        [Fact]
+        public void GenerateSchema_SupportsOption_UseAllOfForInheritance()
+        {
+            var subject = Subject(
+                configureGenerator: c => c.UseAllOfForInheritance = true
+            );
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = subject.GenerateSchema(typeof(PolymorphicType), schemaRepository);
+
+            // The base type schema
+            var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
+            Assert.Equal("object", schema.Type);
+            Assert.Equal(new[] { "BaseProperty" }, schema.Properties.Keys);
+            // The first sub type schema
+            var subType1Schema = schemaRepository.Schemas["SubType1"];
+            Assert.Equal("object", subType1Schema.Type);
+            Assert.NotNull(subType1Schema.AllOf);
+            Assert.Equal(1, subType1Schema.AllOf.Count);
+            Assert.NotNull(subType1Schema.AllOf[0].Reference);
+            Assert.Equal(referenceSchema.Reference.Id, subType1Schema.AllOf[0].Reference.Id);
+            Assert.Equal(new[] { "Property1" }, subType1Schema.Properties.Keys);
+            // The second sub type schema
+            var subType2Schema = schemaRepository.Schemas["SubType2"];
+            Assert.Equal("object", subType2Schema.Type);
+            Assert.NotNull(subType2Schema.AllOf);
+            Assert.Equal(1, subType2Schema.AllOf.Count);
+            Assert.NotNull(subType2Schema.AllOf[0].Reference);
+            Assert.Equal(referenceSchema.Reference.Id, subType2Schema.AllOf[0].Reference.Id);
+            Assert.Equal(new[] { "Property2" }, subType2Schema.Properties.Keys);
+        }
+
+        [Fact]
+        public void GenerateSchema_SupportsOption_UseOneOfForPolymorphism_CombinedWith_UseAllOfForInheritance()
+        {
+            var subject = Subject(configureGenerator: c =>
+            {
+                c.UseOneOfForPolymorphism = true;
+                c.UseAllOfForInheritance = true;
+            });
+            var schemaRepository = new SchemaRepository();
+
+            var schema = subject.GenerateSchema(typeof(PolymorphicType), schemaRepository);
+
+            // The polymorphic schema
+            Assert.NotNull(schema.OneOf);
+            Assert.Equal(3, schema.OneOf.Count);
+            Assert.NotNull(schema.OneOf[0].Reference);
+            Assert.NotNull(schema.OneOf[1].Reference);
+            Assert.NotNull(schema.OneOf[2].Reference);
+            // The base type schema
+            var baseSchema = schemaRepository.Schemas[schema.OneOf[0].Reference.Id];
+            Assert.Equal("object", baseSchema.Type);
+            Assert.Equal(new[] { "BaseProperty"}, baseSchema.Properties.Keys);
+            // The first sub type schema
+            var subType1Schema = schemaRepository.Schemas[schema.OneOf[1].Reference.Id];
+            Assert.Equal("object", subType1Schema.Type);
+            Assert.NotNull(subType1Schema.AllOf);
+            Assert.Equal(1, subType1Schema.AllOf.Count);
+            Assert.NotNull(subType1Schema.AllOf[0].Reference);
+            Assert.Equal(schema.OneOf[0].Reference.Id, subType1Schema.AllOf[0].Reference.Id);
+            Assert.Equal(new[] { "Property1" }, subType1Schema.Properties.Keys);
+            // The second sub type schema
+            var subType2Schema = schemaRepository.Schemas[schema.OneOf[2].Reference.Id];
+            Assert.Equal("object", subType2Schema.Type);
+            Assert.NotNull(subType2Schema.AllOf);
+            Assert.Equal(1, subType2Schema.AllOf.Count);
+            Assert.NotNull(subType2Schema.AllOf[0].Reference);
+            Assert.Equal(schema.OneOf[0].Reference.Id, subType2Schema.AllOf[0].Reference.Id);
+            Assert.Equal(new[] { "Property2" }, subType2Schema.Properties.Keys);
         }
 
         [Fact]
@@ -635,33 +703,16 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Assert.Equal("object", schema.AdditionalProperties.Type);
         }
 
-        [Fact]
-        public void GenerateSchema_GeneratesEmptySchema_IfJToken()
+        [Theory]
+        [InlineData(typeof(JToken))]
+        [InlineData(typeof(JObject))]
+        [InlineData(typeof(JArray))]
+        public void GenerateSchema_GeneratesEmptySchema_IfDynamicJsonType(Type type)
         {
-            var schema = Subject().GenerateSchema(typeof(JToken), new SchemaRepository());
+            var schema = Subject().GenerateSchema(type, new SchemaRepository());
 
             Assert.Null(schema.Reference);
             Assert.Null(schema.Type);
-        }
-
-        [Fact]
-        public void GenerateSchema_GeneratesArraySchema_IfJArray()
-
-        {
-            var schema = Subject().GenerateSchema(typeof(JArray), new SchemaRepository());
-
-            Assert.Equal("array", schema.Type);
-            Assert.NotNull(schema.Items);
-            Assert.Null(schema.Items.Type);
-        }
-
-        [Fact]
-        public void GenerateSchema_GeneratesObjectSchema_IfJObject()
-        {
-            var schema = Subject().GenerateSchema(typeof(JObject), new SchemaRepository());
-
-            Assert.Equal("object", schema.Type);
-            Assert.Empty(schema.Properties);
         }
 
         private SchemaGenerator Subject(

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeController.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeController.cs
@@ -34,10 +34,19 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void ActionWithParameterWithBindRequiredAttribute([BindRequired]string param)
         { }
 
-        public void ActionWithOptionalParameter(string param = "someDefaultValue")
+        public void ActionWithIntParameter(int param)
         { }
 
-        public void ActionWithParameterWithDefaultValueAttribute([DefaultValue("someDefaultValue")]string param)
+        public void ActionWithIntParameterWithRangeAttribute([Range(1, 12)]int param)
+        { }
+
+        public void ActionWithIntParameterWithDefaultValue(int param = 1)
+        { }
+
+        public void ActionWithIntParameterWithDefaultValueAttribute([DefaultValue(3)]int param)
+        { }
+
+        public void ActionWithIntParameterWithRequiredAttribute([Required]int param)
         { }
 
         [Consumes("application/someMediaType")]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/JsonSerializerTesting.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/JsonSerializerTesting.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text.Json;
+﻿using System.Text.Json;
 using Xunit;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen.Test
@@ -13,27 +11,23 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [Fact]
         public void Serialize()
         {
-            var dto = new Dictionary<JsonConverterAnnotatedEnum, string>
-            {
-                [JsonConverterAnnotatedEnum.Value1] = "foo",
-                [JsonConverterAnnotatedEnum.Value2] = "bar",
-                [JsonConverterAnnotatedEnum.X] = "blah",
-            };
+            var dto = new TestDto();
 
-            Assert.Throws<NotSupportedException>(() =>
-            {
-                JsonSerializer.Serialize(dto);
-            });
+            var json = JsonSerializer.Serialize(dto);
+
+            //Assert.Equal("{\"Prop1\":null}", json);
         }
 
         [Fact]
         public void Deserialize()
         {
-            Assert.Throws<NotSupportedException>(() =>
-            {
-                var dto = JsonSerializer.Deserialize<Dictionary<JsonConverterAnnotatedEnum, string>>(
-                    "{ \"value1\": \"foo\", \"value2\": \"bar\" }");
-            });
+            var dto = JsonSerializer.Deserialize<TestDto>(
+                "{ \"Prop1\": 123 }");
         }
+    }
+
+    public class TestDto
+    {
+        public int Prop1 { get; set; }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -248,38 +248,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal("string", operation.Parameters.First().Schema.Type);
         }
 
-        [Theory]
-        [InlineData(nameof(FakeController.ActionWithOptionalParameter))]
-        [InlineData(nameof(FakeController.ActionWithParameterWithDefaultValueAttribute))]
-        public void GetSwagger_SetsParameterDefault_IfActionParameterIsOptionalOrHasDefaultValueAttribute(
-            string actionName)
-        {
-            var subject = Subject(
-                apiDescriptions: new[]
-                {
-                    ApiDescriptionFactory.Create(
-                        methodInfo: typeof(FakeController).GetMethod(actionName),
-                        groupName: "v1",
-                        httpMethod: "POST",
-                        relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
-                            new ApiParameterDescription
-                            {
-                                Name = "param",
-                                Source = BindingSource.Query
-                            }
-                        })
-                }
-            );
-
-            var document = subject.GetSwagger("v1");
-
-            var operation = document.Paths["/resource"].Operations[OperationType.Post];
-            Assert.Equal(1, operation.Parameters.Count);
-            Assert.Equal("someDefaultValue", ((OpenApiString)operation.Parameters.First().Schema.Default).Value);
-        }
-
         [Fact]
         public void GetSwagger_GeneratesRequestBody_ForFirstApiParameterThatIsBoundToBody()
         {

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/ComplexType2.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/ComplexType2.cs
@@ -1,0 +1,11 @@
+﻿namespace Swashbuckle.AspNetCore.TestSupport
+{
+    public class ComplexType2
+    {
+        public int IntProperty { get; set; }
+
+        public string StringProperty { get; set; }
+
+        public int? NullableIntProperty { get; set; }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/ComplexTypeWithRestrictedProperties.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/ComplexTypeWithRestrictedProperties.cs
@@ -1,0 +1,9 @@
+﻿namespace Swashbuckle.AspNetCore.TestSupport
+{
+    public class ComplexTypeWithRestrictedProperties
+    {
+        public int ReadWriteProperty { get; set; }
+        public int ReadOnlyProperty { get; }
+        public int WriteOnlyProperty { set { } }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/DataAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/DataAnnotatedType.cs
@@ -16,6 +16,9 @@ namespace Swashbuckle.AspNetCore.TestSupport
         [Range(1, 12)]
         public int IntWithRange { get; set; }
 
+        [DefaultValue(3)]
+        public int IntWithDefaultValue { get; set; }
+
         [RegularExpression("^[3-6]?\\d{12,15}$")]
         public string StringWithRegularExpression { get; set; }
 

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/DataAnnotatedViaMetadataType.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/DataAnnotatedViaMetadataType.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Swashbuckle.AspNetCore.TestSupport
@@ -13,6 +14,8 @@ namespace Swashbuckle.AspNetCore.TestSupport
         public int IntWithRange { get; set; }
 
         public string StringWithRegularExpression { get; set; }
+
+        public string StringWithMinMaxLength { get; set; }
     }
 
     public class MetadataType
@@ -28,5 +31,8 @@ namespace Swashbuckle.AspNetCore.TestSupport
 
         [RegularExpression("^[3-6]?\\d{12,15}$")]
         public string StringWithRegularExpression { get; set; }
+
+        [MinLength(1), MaxLength(3)]
+        public string StringWithMinMaxLength { get; set; }
     }
 }

--- a/test/WebSites/CliExample/CliExample.csproj
+++ b/test/WebSites/CliExample/CliExample.csproj
@@ -8,7 +8,6 @@
     <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerGen\Swashbuckle.AspNetCore.SwaggerGen.csproj" />
     <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerUI\Swashbuckle.AspNetCore.SwaggerUI.csproj" />
     <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.Swagger\Swashbuckle.AspNetCore.Swagger.csproj" />
-    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.Cli\Swashbuckle.AspNetCore.Cli.csproj" />
   </ItemGroup>
 
   <!--

--- a/test/WebSites/NswagClientExample/Controllers/AnimalsController.cs
+++ b/test/WebSites/NswagClientExample/Controllers/AnimalsController.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace NSwagClientExample.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class AnimalsController : ControllerBase
+    {
+        [HttpPost]
+        public void CreateAnimal([Required]Animal animal)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    [SwaggerSubTypes(typeof(Cat), typeof(Dog), Discriminator = "type")]
+    public abstract class Animal
+    {
+        public AnimalType Type { get; set; }
+    }
+
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum AnimalType
+    {
+        Cat,
+        Dog
+    }
+
+    public class Cat : Animal
+    {
+        public string CatSpecificProperty { get; set; }
+    }
+
+    public class Dog : Animal
+    {
+        public string DogSpecificProperty { get; set; }
+    }
+}

--- a/test/WebSites/NswagClientExample/NswagClientExample.csproj
+++ b/test/WebSites/NswagClientExample/NswagClientExample.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Nswag.MSbuild" Version="13.6.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerGen\Swashbuckle.AspNetCore.SwaggerGen.csproj" />
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerUI\Swashbuckle.AspNetCore.SwaggerUI.csproj" />
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.Swagger\Swashbuckle.AspNetCore.Swagger.csproj" />
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.Annotations\Swashbuckle.AspNetCore.Annotations.csproj" />
+  </ItemGroup>
+
+  <Target Name="SwaggerToFile" AfterTargets="AfterBuild">
+    <Exec Command="dotnet $(SolutionDir)/src/Swashbuckle.AspNetCore.Cli/bin/$(Configuration)/$(TargetFramework)/dotnet-swagger.dll tofile --host http://example.com --output swagger.json $(OutputPath)$(AssemblyName).dll v1" />
+  </Target>
+
+  <Target Name="NSwag" AfterTargets="SwaggerToFile">
+    <Exec Command="$(NSwagExe) openapi2csclient /input:swagger.json /namespace:NSwagClient /output:NSwagClient/Client.cs" />
+  </Target>
+
+</Project>

--- a/test/WebSites/NswagClientExample/Program.cs
+++ b/test/WebSites/NswagClientExample/Program.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace NSwagClientExample
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/test/WebSites/NswagClientExample/Properties/launchSettings.json
+++ b/test/WebSites/NswagClientExample/Properties/launchSettings.json
@@ -1,0 +1,30 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:59598",
+      "sslPort": 0
+    }
+  },
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger/v1/swagger.json",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "NswagClientExample": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "weatherforecast",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:5000"
+    }
+  }
+}

--- a/test/WebSites/NswagClientExample/Startup.cs
+++ b/test/WebSites/NswagClientExample/Startup.cs
@@ -1,0 +1,54 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace NSwagClientExample
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers();
+
+            services.AddSwaggerGen(c =>
+            {
+                c.EnableAnnotations(enableSubTypeAnnotations: true);
+            });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+
+            app.UseSwagger();
+
+            app.UseSwaggerUI(c =>
+            {
+                c.SwaggerEndpoint("v1/swagger.json", "V1 Docs");
+            });
+        }
+    }
+}

--- a/test/WebSites/NswagClientExample/appsettings.Development.json
+++ b/test/WebSites/NswagClientExample/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/test/WebSites/NswagClientExample/appsettings.json
+++ b/test/WebSites/NswagClientExample/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/test/WebSites/NswagClientExample/swagger.json
+++ b/test/WebSites/NswagClientExample/swagger.json
@@ -1,0 +1,135 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "NSwagClientExample",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "http://example.com"
+    }
+  ],
+  "paths": {
+    "/Animals": {
+      "post": {
+        "tags": [
+          "Animals"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/Animal"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Cat"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Dog"
+                  }
+                ],
+                "discriminator": {
+                  "propertyName": "type"
+                }
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/Animal"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Cat"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Dog"
+                  }
+                ],
+                "discriminator": {
+                  "propertyName": "type"
+                }
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/Animal"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Cat"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Dog"
+                  }
+                ],
+                "discriminator": {
+                  "propertyName": "type"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Cat": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Animal"
+          }
+        ],
+        "properties": {
+          "catSpecificProperty": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Dog": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Animal"
+          }
+        ],
+        "properties": {
+          "dogSpecificProperty": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AnimalType": {
+        "enum": [
+          "Cat",
+          "Dog"
+        ],
+        "type": "string"
+      },
+      "Animal": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/AnimalType"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/version.props
+++ b/version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>5.5.1</VersionPrefix>
+    <VersionPrefix>5.6.0</VersionPrefix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes #1564 
Fixes #1643 
Fixes #1662

__Overview__
With the existing support for polymorphism/inheritance (enabled with the `GeneratePolymorphicSchemas` setting), Swashbuckle will implicitly use the `oneOf` keyword in base type schemas (see "Polymorphism" in the [Swagger docs](https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/)) AND the `allOf` keyword in sub type schemas (see "Model Composition" in the [Swagger docs](https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/)).

However, it turns out there's many use cases where these two keywords might be used independently. For example, `oneOf` is particularly useful for documenting the various acceptable structures for payloads that are bound to an abstract/base class. But `allOf` on the other hand is more useful for client code generators when you want to maintain an inheritance structure in the generated client models.

This PR splits the setting into two separate settings that can be enabled independently or together:

```csharp
services.AddSwagger(c =>
{
    ...
    c.UseOneOfForPolymorphism();
    c.UseAllOfForInheritance();
}
```

Additionnally, the existing implementation of "Polymorphic" schemas (i.e. schemas that include the `oneOf` keyword) didn't include the abstract/base class itself in the list which is technically incorrect. This PR also addresses this issue by including the abstract/base class in the list.