### PR TITLE
add support for discriminator mappings

### DIFF
--- a/src/Swashbuckle.AspNetCore.Annotations/SwaggerKnownSubTypeAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.Annotations/SwaggerKnownSubTypeAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Swashbuckle.AspNetCore.Annotations
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, AllowMultiple = true)]
+    public class SwaggerKnownSubTypeAttribute : Attribute
+    {
+        public SwaggerKnownSubTypeAttribute(Type subType, string discriminatorValue)
+        {
+            SubType = subType;
+            DiscriminatorValue = discriminatorValue;
+        }
+
+        public Type SubType { get; }
+
+        public string DiscriminatorValue { get; }
+    }
+}

--- a/src/Swashbuckle.AspNetCore.Annotations/SwaggerSubTypesAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.Annotations/SwaggerSubTypesAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 
 namespace Swashbuckle.AspNetCore.Annotations

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Xml.XPath;
 using Microsoft.OpenApi.Models;
@@ -258,9 +259,27 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="resolver"></param>
         public static void DetectSubTypesUsing(
             this SwaggerGenOptions swaggerGenOptions,
-            Func<Type, IEnumerable<Type>> resolver)
+            Func<Type, IDictionary<Type, string>> resolver)
         {
             swaggerGenOptions.SchemaGeneratorOptions.SubTypesResolver = resolver;
+        }
+
+        /// <summary>
+        /// To support polymorphism and inheritance behavior, Swashbuckle needs to detect the "known" sub types for a given base type.
+        /// That is, the sub types explicitly exposed by your API. By default, this will be any sub types in the same assembly as the base type.
+        /// To override this, you can provide a custom resolver function. This setting is only applicable when used in conjunction with
+        /// the UseOneOfForPolymorphism or UseAllOfForInheritance settings.
+        /// </summary>
+        /// <param name="swaggerGenOptions"></param>
+        /// <param name="resolver"></param>
+        [Obsolete("Use new overload using IDictionary instead.")]
+        public static void DetectSubTypesUsing(
+            this SwaggerGenOptions swaggerGenOptions,
+            Func<Type, IEnumerable<Type>> resolver)
+        {
+            DetectSubTypesUsing(
+                swaggerGenOptions,
+                (Type type) => resolver(type).ToDictionary<Type, Type, string>(st => st, st => null));
         }
 
         /// <summary>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
@@ -28,7 +28,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public bool UseOneOfForPolymorphism { get; set; }
 
-        public Func<Type, IEnumerable<Type>> SubTypesResolver { get; set; }
+        public Func<Type, IDictionary<Type, string>> SubTypesResolver { get; set; }
 
         public Func<Type, string> DiscriminatorSelector { get; set; }
 
@@ -54,12 +54,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             return prefix + modelType.Name.Split('`').First();
         }
 
-        private IEnumerable<Type> DefaultSubTypesResolver(Type baseType)
+        private IDictionary<Type, string> DefaultSubTypesResolver(Type baseType)
         {
             if (baseType == typeof(object))
-                return Enumerable.Empty<Type>();
+                return new Dictionary<Type, string>();
 
-            return baseType.Assembly.GetTypes().Where(type => type.IsSubclassOf(baseType));
+            return baseType.Assembly.GetTypes()
+                .Where(type => type.IsSubclassOf(baseType))
+                .ToDictionary<Type, Type, string>(type => type, type => null);
         }
 
         private string DefaultDiscriminatorSelector(Type baseType)

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -5,6 +5,7 @@ using System.Dynamic;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
@@ -12,6 +13,7 @@ using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using Xunit;
+using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Swashbuckle.AspNetCore.TestSupport;
 
@@ -725,7 +727,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             var serializerSettings = new JsonSerializerSettings();
             configureSerializer?.Invoke(serializerSettings);
 
-            return new SchemaGenerator(generatorOptions, new NewtonsoftDataContractResolver(generatorOptions, serializerSettings));
+            return new SchemaGenerator(generatorOptions, Options.Create(new SwaggerOptions()), new NewtonsoftDataContractResolver(generatorOptions, serializerSettings));
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -3,9 +3,10 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
-using Microsoft.OpenApi.Models;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
 using Xunit;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.TestSupport;
@@ -846,7 +847,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             return new SwaggerGenerator(
                 options ?? DefaultOptions,
                 new FakeApiDescriptionGroupCollectionProvider(apiDescriptions),
-                new SchemaGenerator(new SchemaGeneratorOptions(), new JsonSerializerDataContractResolver(new JsonSerializerOptions()))
+                new SchemaGenerator(new SchemaGeneratorOptions(), Options.Create(new SwaggerOptions()), new JsonSerializerDataContractResolver(new JsonSerializerOptions()))
             );
         }
 

--- a/test/WebSites/NswagClientExample/Controllers/AnimalsController.cs
+++ b/test/WebSites/NswagClientExample/Controllers/AnimalsController.cs
@@ -17,7 +17,9 @@ namespace NSwagClientExample.Controllers
         }
     }
 
-    [SwaggerSubTypes(typeof(Cat), typeof(Dog), Discriminator = "type")]
+    [SwaggerSubTypes(Discriminator = "type")]
+    [SwaggerKnownSubType(typeof(Cat), "IsCat")]
+    [SwaggerKnownSubType(typeof(Dog), "IsDog")]
     public abstract class Animal
     {
         public AnimalType Type { get; set; }
@@ -26,8 +28,8 @@ namespace NSwagClientExample.Controllers
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public enum AnimalType
     {
-        Cat,
-        Dog
+        IsCat,
+        IsDog
     }
 
     public class Cat : Animal

--- a/test/WebSites/NswagClientExample/swagger.json
+++ b/test/WebSites/NswagClientExample/swagger.json
@@ -31,7 +31,11 @@
                   }
                 ],
                 "discriminator": {
-                  "propertyName": "type"
+                  "propertyName": "type",
+                  "mapping": {
+                    "IsCat": "#/components/schemas/Cat",
+                    "IsDog": "#/components/schemas/Dog"
+                  }
                 }
               }
             },
@@ -49,7 +53,11 @@
                   }
                 ],
                 "discriminator": {
-                  "propertyName": "type"
+                  "propertyName": "type",
+                  "mapping": {
+                    "IsCat": "#/components/schemas/Cat",
+                    "IsDog": "#/components/schemas/Dog"
+                  }
                 }
               }
             },
@@ -67,7 +75,11 @@
                   }
                 ],
                 "discriminator": {
-                  "propertyName": "type"
+                  "propertyName": "type",
+                  "mapping": {
+                    "IsCat": "#/components/schemas/Cat",
+                    "IsDog": "#/components/schemas/Dog"
+                  }
                 }
               }
             }
@@ -116,8 +128,8 @@
       },
       "AnimalType": {
         "enum": [
-          "Cat",
-          "Dog"
+          "IsCat",
+          "IsDog"
         ],
         "type": "string"
       },


### PR DESCRIPTION
This PR adds support for discriminator mappings via attributes if the discriminator values differ from the type names.
For an example how to use it I adapted the `NswagClientExample` including the output `swagger.json`.

This essentially provides the Swashbuckle equivalent to https://github.com/manuc66/JsonSubTypes.

Please let me know if there's anything that I should change.

Relevant OpenAPI spec:
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#discriminatorObject

--
At the moment only strings are supported for discriminator values. I'd like to add support for referencing enums and respecting the conversion options of `Newtonsoft.Json` & `System.Text.Json` including support for `StringEnumConverter` later on. Though I'm not yet sure how to implement it. I'll probably create a separate PR for it later on.