### PR TITLE
Fix: Newtonsoft Handle Properties without DeclaringType

### DIFF
--- a/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/JsonPropertyExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/JsonPropertyExtensions.cs
@@ -9,7 +9,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft
     {
         public static bool TryGetMemberInfo(this JsonProperty jsonProperty, out MemberInfo memberInfo)
         {
-            memberInfo = jsonProperty.DeclaringType.GetMember(jsonProperty.UnderlyingName)
+            memberInfo = jsonProperty.DeclaringType?.GetMember(jsonProperty.UnderlyingName)
                 .FirstOrDefault();
 
             return (memberInfo != null);

--- a/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/NewtonsoftDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/NewtonsoftDataContractResolver.cs
@@ -176,7 +176,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft
                     ? jsonProperty.Required
                     : jsonObjectContract.ItemRequired ?? Required.Default;
 
-                var isSetViaConstructor = jsonProperty.DeclaringType.GetConstructors()
+                var isSetViaConstructor = jsonProperty.DeclaringType != null && jsonProperty.DeclaringType.GetConstructors()
                     .SelectMany(c => c.GetParameters())
                     .Any(p => string.Equals(p.Name, jsonProperty.PropertyName, StringComparison.OrdinalIgnoreCase));
 

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/AdditionalPropertyJsonContractResolver.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/AdditionalPropertyJsonContractResolver.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Swashbuckle.AspNetCore.Newtonsoft.Test
+{
+    public class AdditionalPropertyJsonContractResolver : DefaultContractResolver
+    {
+        public const string AdditionalPropertyName = "AdditionalPropertyFromContractResolver";
+
+        private sealed class ConstantValueProvider : IValueProvider
+        {
+            private readonly object _value;
+            public ConstantValueProvider(object value) => _value = value;
+            public void SetValue(object target, object value) => throw new NotImplementedException();
+            public object GetValue(object target) => _value;
+        }
+
+        /// <inheritdoc />
+        protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
+        {
+            var result = base.CreateProperties(type, memberSerialization);
+
+            result.Add(new JsonProperty
+            {
+                PropertyName = AdditionalPropertyName,
+                Readable = true,
+                Writable = false,
+                ValueProvider = new ConstantValueProvider("MyValue"),
+                PropertyType = typeof(string),
+            });
+
+            return result;
+        }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -693,6 +693,24 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         }
 
         [Fact]
+        public void GenerateSchema_HonorsSerializeSetting_ContractResolver()
+        {
+            var subject = Subject(
+                configureSerializer: c =>
+                {
+                    c.ContractResolver = new AdditionalPropertyJsonContractResolver();
+                }
+            );
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = subject.GenerateSchema(typeof(BaseType), schemaRepository);
+
+            var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
+
+            Assert.True(schema.Properties.ContainsKey(AdditionalPropertyJsonContractResolver.AdditionalPropertyName));
+        }
+
+        [Fact]
         public void GenerateSchema_HonorsSerializerAttribute_StringEnumConverter()
         {
             var schemaRepository = new SchemaRepository();


### PR DESCRIPTION
Properties serialized with Newtonsoft do not have to have a declaring type, e.g. if they are provided by a custom contract resolver. This commit fixes NullReferenceException issues on the DeclaringType property (that is also marked as CanBeNull by Newtonsoft).