### PR TITLE
Adding support for yaml in ui

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
@@ -47,7 +47,14 @@ namespace Swashbuckle.AspNetCore.Swagger
                     filter(swagger, httpContext.Request);
                 }
 
-                await RespondWithSwaggerJson(httpContext.Response, swagger);
+                if (Path.GetExtension(httpContext.Request.Path.Value) == "yaml")
+                {
+                    await RespondWithSwaggerYaml(httpContext.Response, swagger);
+                }
+                else
+                {
+                    await RespondWithSwaggerJson(httpContext.Response, swagger);
+                }
             }
             catch (UnknownSwaggerDocument)
             {
@@ -81,6 +88,20 @@ namespace Swashbuckle.AspNetCore.Swagger
             {
                 var jsonWriter = new OpenApiJsonWriter(textWriter);
                 if (_options.SerializeAsV2) swagger.SerializeAsV2(jsonWriter); else swagger.SerializeAsV3(jsonWriter);
+
+                await response.WriteAsync(textWriter.ToString(), new UTF8Encoding(false));
+            }
+        }
+
+        private async Task RespondWithSwaggerYaml(HttpResponse response, OpenApiDocument swagger)
+        {
+            response.StatusCode = 200;
+            response.ContentType = "text/yaml;charset=utf-8";
+
+            using (var textWriter = new StringWriter(CultureInfo.InvariantCulture))
+            {
+                var yamlWriter = new OpenApiYamlWriter(textWriter);
+                if (_options.SerializeAsV2) swagger.SerializeAsV2(yamlWriter); else swagger.SerializeAsV3(yamlWriter);
 
                 await response.WriteAsync(textWriter.ToString(), new UTF8Encoding(false));
             }

--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerOptions.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerOptions.cs
@@ -16,7 +16,7 @@ namespace Swashbuckle.AspNetCore.Swagger
         /// <summary>
         /// Sets a custom route for the Swagger JSON endpoint(s). Must include the {documentName} parameter
         /// </summary>
-        public string RouteTemplate { get; set; } = "swagger/{documentName}/swagger.json";
+        public string RouteTemplate { get; set; } = "swagger/{documentName}/swagger.{json|yaml}";
 
         
         /// <summary>


### PR DESCRIPTION
This pull request let users use yaml in addition to json.

Simply replace json with yaml

here

`app.UseSwaggerUI(x =>
            {
                x.SwaggerEndpoint("/swagger/v1/swagger.yaml", "Zeipt Dashboard API");
            });`

And you're set. Requests to "/swagger/v1/swagger.json" will still return the json file, and requests to "/swagger/v1/swagger.yaml" will return the yaml file if you continue to use json.

I've made this change because a client I have use yaml for their API documentation and referring them to my Swashbuckle json file every time I made an API change was not satisfactory and the yaml file was to be preferred.