### PR TITLE
Infer and assign server metadata base on common reverse proxy request…

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
@@ -1,10 +1,12 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Template;
+using Microsoft.Extensions.Primitives;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Writers;
 
@@ -33,13 +35,12 @@ namespace Swashbuckle.AspNetCore.Swagger
                 return;
             }
 
-            var basePath = !string.IsNullOrEmpty(httpContext.Request.PathBase)
-                ? httpContext.Request.PathBase.ToString()
-                : null;
-
             try
             {
-                var swagger = swaggerProvider.GetSwagger(documentName, null, basePath);
+                var swagger = swaggerProvider.GetSwagger(
+                    documentName: documentName,
+                    host: GetHostOrNullFromRequest(httpContext.Request),
+                    basePath: GetBasePathOrNullFromRequest(httpContext.Request));
 
                 // One last opportunity to modify the Swagger Document - this time with request context
                 foreach (var filter in _options.PreSerializeFilters)
@@ -53,6 +54,45 @@ namespace Swashbuckle.AspNetCore.Swagger
             {
                 RespondWithNotFound(httpContext.Response);
             }
+        }
+
+        private string GetHostOrNullFromRequest(HttpRequest request)
+        {
+            // Honor common reverse proxy headers if present ...
+
+            UriBuilder hostBuilder = null;
+
+            if (request.Headers.TryGetValue("X-Forwarded-For", out StringValues forwardedFor))
+                hostBuilder = new UriBuilder($"http://{forwardedFor[0]}");
+
+            if (request.Headers.TryGetValue("X-Forwarded-Host", out StringValues forwardedHost))
+                hostBuilder = new UriBuilder($"http://{forwardedHost[0]}");
+
+            if (hostBuilder == null)
+                return null;
+
+            if (request.Headers.TryGetValue("X-Forwarded-Proto", out StringValues forwardedProto))
+                hostBuilder.Scheme = forwardedProto[0];
+
+            if (request.Headers.TryGetValue("X-Forwarded-Port", out StringValues forwardedPort))
+                hostBuilder.Port = int.Parse(forwardedPort[0]);
+
+            return hostBuilder.Uri.ToString().Trim('/');
+        }
+
+        private string GetBasePathOrNullFromRequest(HttpRequest request)
+        {
+            var pathBuilder = new StringBuilder();
+
+            if (request.Headers.TryGetValue("X-Forwarded-Prefix", out StringValues forwardedPrefix))
+                pathBuilder.Append(forwardedPrefix[0].TrimEnd('/'));
+
+            if (request.PathBase.HasValue)
+                pathBuilder.Append(request.PathBase.Value.TrimEnd('/'));
+
+            return (pathBuilder.Length > 0)
+                ? pathBuilder.ToString()
+                : null;
         }
 
         private bool RequestingSwaggerDocument(HttpRequest request, out string documentName)


### PR DESCRIPTION
Wraps up #1298 by automatically honoring the following, relatively common, reverse proxy request headers:

- X-Forwarded-Host
- X-Forwarded-For
- X-Forwarded-Proto
- X-Forwarded-Port
- X-Forwarded-Prefix