### PR TITLE
Correct order of attribute inheritance when using model metadata and duplicate attributes

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
@@ -9,8 +10,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     {
         public static IEnumerable<object> GetInlineAndMetadataAttributes(this MemberInfo memberInfo)
         {
-            var attributes = memberInfo.GetCustomAttributes(true)
-                .ToList();
+            var attributes = memberInfo.GetCustomAttributes(true).ToList();
 
             var metadataTypeAttribute = memberInfo.DeclaringType.GetCustomAttributes(true)
                 .OfType<ModelMetadataTypeAttribute>()
@@ -21,7 +21,16 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             if (metadataMemberInfo != null)
             {
-                attributes.AddRange(metadataMemberInfo.GetCustomAttributes(true));
+                // if the same attribute (or a derived version) exists on both the model class and its metadata
+                // class, asp.net core uses the one on the model class - we need to conform with that behaviour
+                foreach (var metadataAttribute in metadataMemberInfo.GetCustomAttributes(true))
+                {
+                    if (!attributes.Any(a => a.GetType() == metadataAttribute.GetType()
+                                             || metadataAttribute.GetType().IsSubclassOf(a.GetType())))
+                    {
+                        attributes.Add(metadataAttribute);
+                    }
+                }
             }
 
             return attributes;

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -296,7 +296,13 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Assert.Equal(1, schema.Properties["IntWithRange"].Minimum);
             Assert.Equal(12, schema.Properties["IntWithRange"].Maximum);
             Assert.Equal("^[3-6]?\\d{12,15}$", schema.Properties["StringWithRegularExpression"].Pattern);
+            Assert.NotNull(schema.Properties["StringWithDefaultValue"].Default);
+            Assert.Equal("foobar", ((OpenApiString)schema.Properties["StringWithDefaultValue"].Default).Value);
             Assert.Equal(new[] { "IntWithRequired", "StringWithRequired" }, schema.Required.ToArray());
+            Assert.Equal(1, schema.Properties[nameof(DataAnnotatedViaMetadataType.IntWithTwoRanges)].Minimum);
+            Assert.Equal(20, schema.Properties[nameof(DataAnnotatedViaMetadataType.IntWithTwoRanges)].Maximum);
+            Assert.Equal(6, schema.Properties[nameof(DataAnnotatedViaMetadataType.IntWithRangeSubclass)].Minimum);
+            Assert.Equal(42, schema.Properties[nameof(DataAnnotatedViaMetadataType.IntWithRangeSubclass)].Maximum);
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -289,6 +289,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.NotNull(schema.Properties["StringWithDefaultValue"].Default);
             Assert.Equal("foobar", ((OpenApiString)schema.Properties["StringWithDefaultValue"].Default).Value);
             Assert.Equal(new[] { "IntWithRequired", "StringWithRequired" }, schema.Required.ToArray());
+            Assert.Equal(1, schema.Properties[nameof(DataAnnotatedViaMetadataType.IntWithTwoRanges)].Minimum);
+            Assert.Equal(20, schema.Properties[nameof(DataAnnotatedViaMetadataType.IntWithTwoRanges)].Maximum);
+            Assert.Equal(6, schema.Properties[nameof(DataAnnotatedViaMetadataType.IntWithRangeSubclass)].Minimum);
+            Assert.Equal(42, schema.Properties[nameof(DataAnnotatedViaMetadataType.IntWithRangeSubclass)].Maximum);
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/DataAnnotatedViaMetadataType.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/DataAnnotatedViaMetadataType.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.TestSupport.Fixtures;
 
 namespace Swashbuckle.AspNetCore.TestSupport
 {
@@ -17,6 +18,12 @@ namespace Swashbuckle.AspNetCore.TestSupport
 
         [DefaultValue("foobar")]
         public string StringWithDefaultValue { get; set; }
+
+        [Range(1, 20)]
+        public int IntWithTwoRanges { get; set; }
+
+        [Range(6, 42)]
+        public int IntWithRangeSubclass { get; set; }
     }
 
     public class MetadataType
@@ -33,7 +40,15 @@ namespace Swashbuckle.AspNetCore.TestSupport
         [RegularExpression("^[3-6]?\\d{12,15}$")]
         public string StringWithRegularExpression { get; set; }
 
-        // NOTE: Annotation for this one is in the actual class
+        // NOTE: Annotation for this one is on the actual model
         public string StringWithDefaultValue { get; set; }
+
+        // NOTE: Redeclared, but with different values - the model's version should win over this one
+        [Range(100, 2000)]
+        public int IntWithTwoRanges { get; set; }
+
+        // NOTE: A subclass of the model's attribute - the model's version should win over this one
+        [ExtendedRange(600, 4200)]
+        public int IntWithRangeSubclass { get; set; }
     }
 }

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/ExtendedRangeAttribute.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/ExtendedRangeAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Swashbuckle.AspNetCore.TestSupport.Fixtures
+{
+    public class ExtendedRangeAttribute : RangeAttribute
+    {
+        public ExtendedRangeAttribute(double minimum, double maximum) : base(minimum, maximum)
+        {
+        }
+
+        public ExtendedRangeAttribute(int minimum, int maximum) : base(minimum, maximum)
+        {
+        }
+
+        public ExtendedRangeAttribute(Type type, string minimum, string maximum) : base(type, minimum, maximum)
+        {
+        }
+    }
+}


### PR DESCRIPTION
If an attribute (or subclass) is defined on both a model and its metadata class, Swashbuckle will use the latter's definition. This differs from ASP.NET Core which takes the model as the source of truth. This commit makes Swashbuckle behave the same as ASP.NET Core.