### PR TITLE
Added possibility to define client-side interceptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1108,6 +1108,8 @@ app.UseSwaggerUI(c =>
     c.ShowCommonExtensions();
     c.EnableValidator();
     c.SupportedSubmitMethods(SubmitMethod.Get, SubmitMethod.Head);
+    c.UseRequestInterceptor("(request) => { return request; }");
+    c.UseResponseInterceptor("(response) => { return response; }");
 });
 ```
 
@@ -1159,6 +1161,31 @@ app.UseSwaggerUI(c =>
     c.OAuthScopeSeparator(" ");
     c.OAuthAdditionalQueryStringParams(new Dictionary<string, string> { { "foo", "bar" }}); 
     c.OAuthUseBasicAuthenticationWithAccessCodeGrant();
+});
+```
+
+### Use client-side request and response interceptors ###
+
+To use custom interceptors on requests and responses going through swagger-ui you can define them as javascript functions in the configuration:
+
+```csharp
+app.UseSwaggerUI(c =>
+{
+    ...
+
+    c.UseRequestInterceptor("(req) => { req.headers['x-my-custom-header'] = 'MyCustomValue'; return req; }");
+    c.UseResponseInterceptor("(res) => { console.log('Custom interceptor intercepted response from:', res.url); return res; }");
+});
+```
+
+This can be useful in a range of scenarios where you might want to append local xsrf tokens to all requests for example:
+
+```csharp
+app.UseSwaggerUI(c =>
+{
+    ...
+
+    c.UseRequestInterceptor("(req) => { req.headers['X-XSRF-Token'] = localStorage.getItem('xsrf-token'); return req; }");
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ The steps described above will get you up and running with minimal setup. Howeve
     * [Inject Custom CSS](#inject-custom-css)
     * [Customize index.html](#customize-indexhtml)
     * [Enable OAuth2.0 Flows](#enable-oauth20-flows)
+    * [Use client-side request and response interceptors](#use-client-side-request-and-response-interceptors)
 
 * [Swashbuckle.AspNetCore.Annotations](#swashbuckleaspnetcoreannotations)
     * [Install and Enable Annotations](#install-and-enable-annotations)

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -118,7 +118,8 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
                 { "%(DocumentTitle)", _options.DocumentTitle },
                 { "%(HeadContent)", _options.HeadContent },
                 { "%(ConfigObject)", JsonSerializer.Serialize(_options.ConfigObject, _jsonSerializerOptions) },
-                { "%(OAuthConfigObject)", JsonSerializer.Serialize(_options.OAuthConfigObject, _jsonSerializerOptions) }
+                { "%(OAuthConfigObject)", JsonSerializer.Serialize(_options.OAuthConfigObject, _jsonSerializerOptions) },
+                { "%(Interceptors)", JsonSerializer.Serialize(_options.Interceptors) },
             };
         }
     }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -39,6 +39,11 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// Gets the JavaScript config object, represented as JSON, that will be passed to the initOAuth method
         /// </summary>
         public OAuthConfigObject OAuthConfigObject { get; set; } = new OAuthConfigObject();
+
+        /// <summary>
+        /// Gets the interceptor functions that define client-side request/response interceptors
+        /// </summary>
+        public InterceptorFunctions Interceptors { get; set; } = new InterceptorFunctions();
     }
 
     public class ConfigObject
@@ -206,5 +211,24 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// The default is false
         /// </summary>
         public bool UsePkceWithAuthorizationCodeGrant { get; set; } = false;
+    }
+
+    public class InterceptorFunctions
+    {
+        /// <summary>
+        /// MUST be a valid Javascript function.
+        /// Function to intercept remote definition, "Try it out", and OAuth 2.0 requests.
+        /// Accepts one argument requestInterceptor(request) and must return the modified request, or a Promise that resolves to the modified request.
+        /// Ex: "req => { req.headers['MyCustomHeader'] = 'CustomValue'; return req; }"
+        /// </summary>
+        public string RequestInterceptorFunction { get; set; }
+
+        /// <summary>
+        /// MUST be a valid Javascript function.
+        /// Function to intercept remote definition, "Try it out", and OAuth 2.0 responses.
+        /// Accepts one argument responseInterceptor(response) and must return the modified response, or a Promise that resolves to the modified response.
+        /// Ex: "res => { console.log(res); return res; }"
+        /// </summary>
+        public string ResponseInterceptorFunction { get; set; }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptionsExtensions.cs
@@ -276,5 +276,25 @@ namespace Microsoft.AspNetCore.Builder
         {
             options.OAuthConfigObject.UsePkceWithAuthorizationCodeGrant = true;
         }
+
+        /// <summary>
+        /// Function to intercept remote definition, "Try it out", and OAuth 2.0 requests.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="value">MUST be a valid Javascript function: (request: SwaggerRequest) => SwaggerRequest</param>
+        public static void UseRequestInterceptor(this SwaggerUIOptions options, string value)
+        {
+            options.Interceptors.RequestInterceptorFunction = value;
+        }
+
+        /// <summary>
+        /// Function to intercept remote definition, "Try it out", and OAuth 2.0 responses.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="value">MUST be a valid Javascript function: (response: SwaggerResponse ) => SwaggerResponse </param>
+        public static void UseResponseInterceptor(this SwaggerUIOptions options, string value)
+        {
+            options.Interceptors.ResponseInterceptorFunction = value;
+        }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
@@ -43,6 +43,35 @@
     <script src="./swagger-ui-bundle.js"></script>
     <script src="./swagger-ui-standalone-preset.js"></script>
     <script>
+        /* Source: https://gist.github.com/lamberta/3768814
+         * Parse a string function definition and return a function object. Does not use eval.
+         * @param {string} str
+         * @return {function}
+         *
+         * Example:
+         *  var f = function (x, y) { return x * y; };
+         *  var g = parseFunction(f.toString());
+         *  g(33, 3); //=> 99
+         */
+        function parseFunction(str) {
+            if (!str) return void (0);
+
+            var fn_body_idx = str.indexOf('{'),
+                fn_body = str.substring(fn_body_idx + 1, str.lastIndexOf('}')),
+                fn_declare = str.substring(0, fn_body_idx),
+                fn_params = fn_declare.substring(fn_declare.indexOf('(') + 1, fn_declare.lastIndexOf(')')),
+                args = fn_params.split(',');
+
+            args.push(fn_body);
+
+            function Fn() {
+                return Function.apply(this, args);
+            }
+            Fn.prototype = Function.prototype;
+
+            return new Fn();
+        }
+
         window.onload = function () {
             var configObject = JSON.parse('%(ConfigObject)');
             var oauthConfigObject = JSON.parse('%(OAuthConfigObject)');
@@ -65,6 +94,13 @@
             configObject.dom_id = "#swagger-ui";
             configObject.presets = [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset];
             configObject.layout = "StandaloneLayout";
+
+            // Parse and add interceptor functions
+            var interceptors = JSON.parse('%(Interceptors)');
+            if (interceptors.RequestInterceptorFunction)
+                configObject.requestInterceptor = parseFunction(interceptors.RequestInterceptorFunction);
+            if (interceptors.ResponseInterceptorFunction)
+                configObject.responseInterceptor = parseFunction(interceptors.ResponseInterceptorFunction);
 
             // Begin Swagger UI call region
 

--- a/test/WebSites/CustomUIConfig/Startup.cs
+++ b/test/WebSites/CustomUIConfig/Startup.cs
@@ -72,6 +72,8 @@ namespace CustomUIConfig
                 c.DocumentTitle = "CustomUIConfig";
                 c.InjectStylesheet("/ext/custom-stylesheet.css");
                 c.InjectJavascript("/ext/custom-javascript.js");
+                c.UseRequestInterceptor("(req) => { req.headers['x-my-custom-header'] = 'MyCustomValue'; return req; }");
+                c.UseResponseInterceptor("(res) => { console.log('Custom interceptor intercepted response from:', res.url); return res; }");
             });
         }
     }


### PR DESCRIPTION
This will allow us to define interceptors without having to replace the
entire index.html for simple use cases such as adding XSRF tokens to all
requests. The functions are parsed and passed to the SwaggerUI
configuration without using eval().