### PR TITLE
Adding support for comma separated X-Forward-* headers

### DIFF
--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerGenIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerGenIntegrationTests.cs
@@ -83,6 +83,7 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
 
         [Theory]
         [InlineData("tempuri.org", null, null, null, "http://tempuri.org")]
+        [InlineData("tempuri.org, foobar-proxy.org", null, null, null, "http://tempuri.org")]
         [InlineData("tempuri.org:8080", null, null, null, "http://tempuri.org:8080")]
         [InlineData("tempuri.org", "https", "443", null, "https://tempuri.org")]
         [InlineData("tempuri.org", null, "8080", null, "http://tempuri.org:8080")]


### PR DESCRIPTION
Bugfix for following [issue](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/1836). 