### PR TITLE
Make defaults work with `UseAllOfToExtendReferenceSchemas`

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
@@ -9,7 +9,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     public static class OpenApiSchemaExtensions
     {
-        public static void ApplyCustomAttributes(this OpenApiSchema schema, IEnumerable<object> customAttributes)
+        public static void ApplyCustomAttributes(this OpenApiSchema schema, IEnumerable<object> customAttributes) => ApplyCustomAttributes(schema, null, customAttributes);
+
+        public static void ApplyCustomAttributes(this OpenApiSchema schema, SchemaRepository schemaRepository, IEnumerable<object> customAttributes)
         {
             foreach (var attribute in customAttributes)
             {
@@ -20,7 +22,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     ApplyDataTypeAttribute(schema, dataTypeAttribute);
 
                 else if (attribute is DefaultValueAttribute defaultValueAttribute)
-                    ApplyDefaultValueAttribute(schema, defaultValueAttribute);
+                    ApplyDefaultValueAttribute(schema, schemaRepository, defaultValueAttribute);
 
                 else if (attribute is EmailAddressAttribute emailAddressAttribute)
                     ApplyEmailAddressAttribute(schema, emailAddressAttribute);
@@ -83,9 +85,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             }
         }
 
-        private static void ApplyDefaultValueAttribute(OpenApiSchema schema, DefaultValueAttribute defaultValueAttribute)
+        private static void ApplyDefaultValueAttribute(OpenApiSchema schema, SchemaRepository schemaRepository, DefaultValueAttribute defaultValueAttribute)
         {
-            schema.Default = OpenApiAnyFactory.CreateFor(schema, defaultValueAttribute.Value);
+            schema.Default = OpenApiAnyFactory.CreateFor(schema, schemaRepository, defaultValueAttribute.Value);
         }
 
         private static void ApplyEmailAddressAttribute(OpenApiSchema schema, EmailAddressAttribute emailAddressAttribute)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/OpenApiAnyFactory.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/OpenApiAnyFactory.cs
@@ -6,35 +6,46 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     public static class OpenApiAnyFactory
     {
-        public static IOpenApiAny CreateFor(OpenApiSchema schema, object value)
+        public static IOpenApiAny CreateFor(OpenApiSchema schema, object value) => CreateFor(schema, null, value);
+
+        public static IOpenApiAny CreateFor(OpenApiSchema schema, SchemaRepository schemaRepository, object value)
         {
             if (value == null) return null;
 
-            if (schema.Type == "integer" && schema.Format == "int64" && TryCast(value, out long longValue))
+            OpenApiSchema replacementSchema = null;
+            if (schema.AllOf.Count > 0 && schemaRepository != null)
+            {
+                // will set null in self-referencing loop
+                schemaRepository.Schemas.TryGetValue(schema.AllOf[0].Reference.Id, out replacementSchema);
+            }
+
+            var typeSchema = replacementSchema ?? schema;
+
+            if (typeSchema.Type == "integer" && typeSchema.Format == "int64" && TryCast(value, out long longValue))
                 return new OpenApiLong(longValue);
 
-            else if (schema.Type == "integer" && TryCast(value, out int intValue))
+            else if (typeSchema.Type == "integer" && TryCast(value, out int intValue))
                 return new OpenApiInteger(intValue);
 
-            else if (schema.Type == "number" && schema.Format == "double" && TryCast(value, out double doubleValue))
+            else if (typeSchema.Type == "number" && typeSchema.Format == "double" && TryCast(value, out double doubleValue))
                 return new OpenApiDouble(doubleValue);
 
-            else if (schema.Type == "number" && TryCast(value, out float floatValue))
+            else if (typeSchema.Type == "number" && TryCast(value, out float floatValue))
                 return new OpenApiFloat(floatValue);
 
-            if (schema.Type == "boolean" && TryCast(value, out bool boolValue))
+            if (typeSchema.Type == "boolean" && TryCast(value, out bool boolValue))
                 return new OpenApiBoolean(boolValue);
 
-            else if (schema.Type == "string" && schema.Format == "date" && TryCast(value, out DateTime dateValue))
+            else if (typeSchema.Type == "string" && typeSchema.Format == "date" && TryCast(value, out DateTime dateValue))
                 return new OpenApiDate(dateValue);
 
-            else if (schema.Type == "string" && schema.Format == "date-time" && TryCast(value, out DateTime dateTimeValue))
+            else if (typeSchema.Type == "string" && typeSchema.Format == "date-time" && TryCast(value, out DateTime dateTimeValue))
                 return new OpenApiDate(dateTimeValue);
 
-            else if (schema.Type == "string" && value.GetType().IsEnum)
+            else if (typeSchema.Type == "string" && value.GetType().IsEnum)
                 return new OpenApiString(Enum.GetName(value.GetType(), value));
 
-            else if (schema.Type == "string")
+            else if (typeSchema.Type == "string")
                 return new OpenApiString(value.ToString());
 
             return null;

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/EnumDefaultValueAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/EnumDefaultValueAnnotatedType.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel;
+using Swashbuckle.AspNetCore.TestSupport;
+
+namespace Swashbuckle.AspNetCore.Newtonsoft.Test
+{
+    public class EnumDefaultValueAnnotatedType
+    {
+        [DefaultValue(IntEnum.Value8)]
+        public IntEnum IntEnumWithDefaultValue { get; set; }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -544,6 +544,39 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         }
 
         [Fact]
+        public void GenerateSchema_UseAllOfToExtendReferenceSchemas_SupportsDefault()
+        {
+            var subject = Subject(
+                configureGenerator: c => c.UseAllOfToExtendReferenceSchemas = true
+            );
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = subject.GenerateSchema(typeof(EnumDefaultValueAnnotatedType), schemaRepository);
+
+            var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
+            Assert.Null(schema.Properties["IntEnumWithDefaultValue"].Type);
+            Assert.IsType<OpenApiInteger>(schema.Properties["IntEnumWithDefaultValue"].Default);
+            Assert.Equal(8, ((OpenApiInteger)schema.Properties["IntEnumWithDefaultValue"].Default).Value);
+        }
+
+        [Fact]
+        public void GenerateSchema_UseAllOfToExtendReferenceSchemas_SupportsStringEnumDefault()
+        {
+            var subject = Subject(
+                configureGenerator: c => c.UseAllOfToExtendReferenceSchemas = true,
+                configureSerializer: c => c.Converters.Add(new StringEnumConverter())
+            );
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = subject.GenerateSchema(typeof(EnumDefaultValueAnnotatedType), schemaRepository);
+
+            var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
+            Assert.Null(schema.Properties["IntEnumWithDefaultValue"].Type);
+            Assert.IsType<OpenApiString>(schema.Properties["IntEnumWithDefaultValue"].Default);
+            Assert.Equal("Value8", ((OpenApiString)schema.Properties["IntEnumWithDefaultValue"].Default).Value);
+        }
+
+        [Fact]
         public void GenerateSchema_SupportsOption_UseInlineDefinitionsForEnums()
         {
             var subject = Subject(

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/EnumDefaultValueAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/EnumDefaultValueAnnotatedType.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel;
+using Swashbuckle.AspNetCore.TestSupport;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test
+{
+    public class EnumDefaultValueAnnotatedType
+    {
+        [DefaultValue(IntEnum.Value8)]
+        public IntEnum IntEnumWithDefaultValue { get; set; }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -560,6 +560,39 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
+        public void GenerateSchema_UseAllOfToExtendReferenceSchemas_SupportsDefault()
+        {
+            var subject = Subject(
+                configureGenerator: c => c.UseAllOfToExtendReferenceSchemas = true
+            );
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = subject.GenerateSchema(typeof(EnumDefaultValueAnnotatedType), schemaRepository);
+
+            var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
+            Assert.Null(schema.Properties["IntEnumWithDefaultValue"].Type);
+            Assert.IsType<OpenApiInteger>(schema.Properties["IntEnumWithDefaultValue"].Default);
+            Assert.Equal(8, ((OpenApiInteger)schema.Properties["IntEnumWithDefaultValue"].Default).Value);
+        }
+
+        [Fact]
+        public void GenerateSchema_UseAllOfToExtendReferenceSchemas_SupportsStringEnumDefault()
+        {
+            var subject = Subject(
+                configureGenerator: c => c.UseAllOfToExtendReferenceSchemas = true,
+                configureSerializer: c => c.Converters.Add(new JsonStringEnumConverter())
+            );
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = subject.GenerateSchema(typeof(EnumDefaultValueAnnotatedType), schemaRepository);
+
+            var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
+            Assert.Null(schema.Properties["IntEnumWithDefaultValue"].Type);
+            Assert.IsType<OpenApiString>(schema.Properties["IntEnumWithDefaultValue"].Default);
+            Assert.Equal("Value8", ((OpenApiString)schema.Properties["IntEnumWithDefaultValue"].Default).Value);
+        }
+
+        [Fact]
         public void GenerateSchema_HandlesTypesWithNestedTypes()
         {
             var schemaRepository = new SchemaRepository();


### PR DESCRIPTION
This addresses #1850. i.e. it allows `OpenApiSchema.Default` values to work when using `UseAllOfToExtendReferenceSchemas`, which I think is good/needed/helpful for the reasons mentioned there.

Most of the changed lines here are [the tests](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/1851/commits/778fb986d633072ed22e6cf3aa9f40bc5041e055), the [change itself](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/1851/commits/014af8c3e64edf7d131f0e38fc93a2edf3090ec2) is simple - while generating a schema in which `Reference` is being replaced with `AllOf`, temporarily set the schema type to the referenced type, so that attribute processing can work properly, then clear it again when done.

Note that the code path for setting defaults was always running in this case anyway, but just didn't have quite enough info to actually set the value.

This produces JSON like:

```js
{
 "name": "matchType",
 "in": "query",
 "schema": {
   "allOf": [
     {
       "$ref": "#/components/schemas/AutocompleteMatchType"
     }
   ],
   "description": "Allowed match types",
   "default": "BeginFirst"
  }
}
```

`"default"` would have always been null, even though specified by the API, without this suggested change.