### PR TITLE
Add support for scopes param

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -190,6 +190,11 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         public string ScopeSeparator { get; set; } = " ";
 
         /// <summary>
+        /// Scope separator (i.e. space) separated string of initially selected oauth scopes.
+        /// </summary>
+        public string Scopes { get; set; }
+
+        /// <summary>
         /// Additional query parameters added to authorizationUrl and tokenUrl
         /// </summary>
         public Dictionary<string, string> AdditionalQueryStringParams { get; set; } = null;

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptionsExtensions.cs
@@ -245,6 +245,16 @@ namespace Microsoft.AspNetCore.Builder
         }
 
         /// <summary>
+        /// Scope separator (i.e. space) separated string of initially selected oauth scopes.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="value"></param>
+        public static void OAuthScopes(this SwaggerUIOptions options, string value)
+        {
+            options.OAuthConfigObject.Scopes = value;
+        }
+
+        /// <summary>
         /// Additional query parameters added to authorizationUrl and tokenUrl
         /// </summary>
         /// <param name="options"></param>


### PR DESCRIPTION
Fixes #1857

Swagger UI docs: https://github.com/yinzara/swagger-ui/blob/master/docs/usage/oauth2.md

Open question: The "Scopes" param could also be an array instead of a space separated string (see docs). Do it?