### PR TITLE
Add remarks from XML comments to OpenAPI schema descriptions.

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -386,19 +386,23 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Flag to indicate if controller XML comments (i.e. summary) should be used to assign Tag descriptions.
         /// Don't set this flag if you're customizing the default tag for operations via TagActionsBy.
         /// </param>
+        /// <param name="includeRemarksFromXmlComments">
+        /// Flag to indicate if remarks XML comments should be used to assign Tag descriptions.
+        /// </param>
         public static void IncludeXmlComments(
             this SwaggerGenOptions swaggerGenOptions,
             Func<XPathDocument> xmlDocFactory,
-            bool includeControllerXmlComments = false)
+            bool includeControllerXmlComments = false,
+            bool includeRemarksFromXmlComments = false)
         {
             var xmlDoc = xmlDocFactory();
-            swaggerGenOptions.ParameterFilter<XmlCommentsParameterFilter>(xmlDoc);
-            swaggerGenOptions.RequestBodyFilter<XmlCommentsRequestBodyFilter>(xmlDoc);
+            swaggerGenOptions.ParameterFilter<XmlCommentsParameterFilter>(xmlDoc, includeRemarksFromXmlComments);
+            swaggerGenOptions.RequestBodyFilter<XmlCommentsRequestBodyFilter>(xmlDoc, includeRemarksFromXmlComments);
             swaggerGenOptions.OperationFilter<XmlCommentsOperationFilter>(xmlDoc);
-            swaggerGenOptions.SchemaFilter<XmlCommentsSchemaFilter>(xmlDoc);
+            swaggerGenOptions.SchemaFilter<XmlCommentsSchemaFilter>(xmlDoc, includeRemarksFromXmlComments);
 
             if (includeControllerXmlComments)
-                swaggerGenOptions.DocumentFilter<XmlCommentsDocumentFilter>(xmlDoc);
+                swaggerGenOptions.DocumentFilter<XmlCommentsDocumentFilter>(xmlDoc, includeRemarksFromXmlComments);
         }
 
         /// <summary>
@@ -410,12 +414,16 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Flag to indicate if controller XML comments (i.e. summary) should be used to assign Tag descriptions.
         /// Don't set this flag if you're customizing the default tag for operations via TagActionsBy.
         /// </param>
+        /// <param name="includeRemarksFromXmlComments">
+        /// Flag to indicate if remarks XML comments should be used to assign Tag descriptions.
+        /// </param>
         public static void IncludeXmlComments(
             this SwaggerGenOptions swaggerGenOptions,
             string filePath,
-            bool includeControllerXmlComments = false)
+            bool includeControllerXmlComments = false,
+            bool includeRemarksFromXmlComments = false)
         {
-            swaggerGenOptions.IncludeXmlComments(() => new XPathDocument(filePath), includeControllerXmlComments);
+            swaggerGenOptions.IncludeXmlComments(() => new XPathDocument(filePath), includeControllerXmlComments, includeRemarksFromXmlComments);
         }
 
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsOperationFilter.cs
@@ -7,6 +7,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     public class XmlCommentsOperationFilter : IOperationFilter
     {
+        private const string SummaryTag = "summary";
+        private const string RemarksTag = "remarks";
+        private const string ResponseTag = "response";
+
         private readonly XPathNavigator _xmlNavigator;
 
         public XmlCommentsOperationFilter(XPathDocument xmlDoc)
@@ -32,7 +36,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private void ApplyControllerTags(OpenApiOperation operation, Type controllerType)
         {
             var typeMemberName = XmlCommentsNodeNameHelper.GetMemberNameForType(controllerType);
-            var responseNodes = _xmlNavigator.Select($"/doc/members/member[@name='{typeMemberName}']/response");
+            var responseNodes = _xmlNavigator.Select($"/doc/members/member[@name='{typeMemberName}']/{ResponseTag}");
             ApplyResponseTags(operation, responseNodes);
         }
 
@@ -43,15 +47,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             if (methodNode == null) return;
 
-            var summaryNode = methodNode.SelectSingleNode("summary");
+            var summaryNode = methodNode.SelectSingleNode(SummaryTag);
             if (summaryNode != null)
                 operation.Summary = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml);
 
-            var remarksNode = methodNode.SelectSingleNode("remarks");
+            var remarksNode = methodNode.SelectSingleNode(RemarksTag);
             if (remarksNode != null)
                 operation.Description = XmlCommentsTextHelper.Humanize(remarksNode.InnerXml);
 
-            var responseNodes = methodNode.Select("response");
+            var responseNodes = methodNode.Select(ResponseTag);
             ApplyResponseTags(operation, responseNodes);
         }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithXmlComments.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithXmlComments.cs
@@ -6,6 +6,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
     /// <summary>
     /// Summary for FakeControllerWithXmlComments
     /// </summary>
+    /// <remarks>
+    /// Remarks for FakeControllerWithXmlComments
+    /// </remarks>
     /// <response code="default">Description for default response</response>
     public class FakeControllerWithXmlComments
     {

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/XmlAnnotatedGenericType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/XmlAnnotatedGenericType.cs
@@ -5,6 +5,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
     /// <summary>
     /// Summary for XmlAnnotatedGenericType
     /// </summary>
+    /// <remarks>
+    /// Remarks for XmlAnnotatedGenericType
+    /// </remarks>
     /// <typeparam name="T"></typeparam>
     /// <typeparam name="K"></typeparam>
     public class XmlAnnotatedGenericType<T,K>
@@ -12,6 +15,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         /// <summary>
         /// Summary for GenericProperty
         /// </summary>
+        /// <remarks>
+        /// Remarks for GenericProperty
+        /// </remarks>
         public T GenericProperty { get; set; }
 
         /// <summary>

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/XmlAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/XmlAnnotatedType.cs
@@ -7,11 +7,17 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
     /// <summary>
     /// Summary for XmlAnnotatedType
     /// </summary>
+    /// <remarks>
+    /// Remarks for XmlAnnotatedType
+    /// </remarks>
     public class XmlAnnotatedType
     {
         /// <summary>
         /// Summary for BoolField
         /// </summary>
+        /// <remarks>
+        /// Remarks for BoolField
+        /// </remarks>
         /// <example>true</example>
         public bool BoolField;
 
@@ -60,6 +66,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         /// <summary>
         /// Summary for StringProperty
         /// </summary>
+        /// <remarks>
+        /// Remarks for StringProperty
+        /// </remarks>
         /// <example>Example for StringProperty</example>
         public string StringProperty { get; set; }
 
@@ -106,6 +115,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         /// <summary>
         /// Summary for NestedType
         /// </summary>
+        /// <remarks>
+        /// Remarks for NestedType
+        /// </remarks>
         public class NestedType
         {
             public string Property { get; set; }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.xml
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.xml
@@ -25,6 +25,9 @@
             <summary>
             Summary for FakeControllerWithXmlComments
             </summary>
+            <remarks>
+            Remarks for FakeControllerWithXmlComments
+            </remarks>
             <response code="default">Description for default response</response>
         </member>
         <member name="M:Swashbuckle.AspNetCore.SwaggerGen.Test.FakeControllerWithXmlComments.ActionWithSummaryAndRemarksTags">
@@ -58,6 +61,9 @@
             <summary>
             Summary for XmlAnnotatedGenericType
             </summary>
+            <remarks>
+            Remarks for XmlAnnotatedGenericType
+            </remarks>
             <typeparam name="T"></typeparam>
             <typeparam name="K"></typeparam>
         </member>
@@ -65,6 +71,9 @@
             <summary>
             Summary for GenericProperty
             </summary>
+            <remarks>
+            Remarks for GenericProperty
+            </remarks>
         </member>
         <member name="M:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedGenericType`2.AcceptsTypeParameters(System.Int32,`0,`1)">
             <summary>
@@ -89,11 +98,17 @@
             <summary>
             Summary for XmlAnnotatedType
             </summary>
+            <remarks>
+            Remarks for XmlAnnotatedType
+            </remarks>
         </member>
         <member name="F:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedType.BoolField">
             <summary>
             Summary for BoolField
             </summary>
+            <remarks>
+            Remarks for BoolField
+            </remarks>
             <example>true</example>
         </member>
         <member name="P:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedType.BoolProperty">
@@ -142,6 +157,9 @@
             <summary>
             Summary for StringProperty
             </summary>
+            <remarks>
+            Remarks for StringProperty
+            </remarks>
             <example>Example for StringProperty</example>
         </member>
         <member name="P:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedType.BadExampleIntProperty">
@@ -183,6 +201,9 @@
             <summary>
             Summary for NestedType
             </summary>
+            <remarks>
+            Remarks for NestedType
+            </remarks>
         </member>
         <member name="P:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedType.NestedType.InnerNestedType.InnerProperty">
             <summary>

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsDocumentFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsDocumentFilterTests.cs
@@ -11,8 +11,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
     public class XmlCommentsDocumentFilterTests
     {
-        [Fact]
-        public void Apply_SetsTagDescription_FromControllerSummaryTags()
+        [Theory]
+        [InlineData("Summary for FakeControllerWithXmlComments (Remarks for FakeControllerWithXmlComments)", true)]
+        [InlineData("Summary for FakeControllerWithXmlComments", false)]
+        public void Apply_SetsTagDescription_FromControllerSummaryAndRemarksTags(
+            string expectedDescription,
+            bool includeRemarksFromXmlComments)
         {
             var document = new OpenApiDocument();
             var filterContext = new DocumentFilterContext(
@@ -38,17 +42,17 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 null,
                 null);
 
-            Subject().Apply(document, filterContext);
+            Subject(includeRemarksFromXmlComments).Apply(document, filterContext);
 
             Assert.Equal(1, document.Tags.Count);
-            Assert.Equal("Summary for FakeControllerWithXmlComments", document.Tags[0].Description);
+            Assert.Equal(expectedDescription, document.Tags[0].Description);
         }
 
-        private XmlCommentsDocumentFilter Subject()
+        private XmlCommentsDocumentFilter Subject(bool includeRemarksFromXmlComments = false)
         {
             using (var xmlComments = File.OpenText($"{typeof(FakeControllerWithXmlComments).Assembly.GetName().Name}.xml"))
             {
-                return new XmlCommentsDocumentFilter(new XPathDocument(xmlComments));
+                return new XmlCommentsDocumentFilter(new XPathDocument(xmlComments), includeRemarksFromXmlComments);
             }
         }
     }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsParameterFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsParameterFilterTests.cs
@@ -41,25 +41,29 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal("Example for param1", ((OpenApiString)parameter.Example).Value);
         }
 
-        [Fact]
-        public void Apply_SetsDescriptionAndExample_FromPropertySummaryAndExampleTags()
+        [Theory]
+        [InlineData("Summary for StringProperty (Remarks for StringProperty)", true)]
+        [InlineData("Summary for StringProperty", false)]
+        public void Apply_SetsDescriptionAndExample_FromPropertySummaryAndRemarksAndExampleTags(
+            string expectedDescription,
+            bool includeRemarksFromXmlComments)
         {
             var parameter = new OpenApiParameter { Schema = new OpenApiSchema { Type = "string" } };
             var propertyInfo = typeof(XmlAnnotatedType).GetProperty(nameof(XmlAnnotatedType.StringProperty));
             var apiParameterDescription = new ApiParameterDescription { };
             var filterContext = new ParameterFilterContext(apiParameterDescription, null, null, propertyInfo: propertyInfo);
 
-            Subject().Apply(parameter, filterContext);
+            Subject(includeRemarksFromXmlComments).Apply(parameter, filterContext);
 
-            Assert.Equal("Summary for StringProperty", parameter.Description);
+            Assert.Equal(expectedDescription, parameter.Description);
             Assert.Equal("Example for StringProperty", ((OpenApiString)parameter.Example).Value);
         }
 
-        private XmlCommentsParameterFilter Subject()
+        private XmlCommentsParameterFilter Subject(bool includeRemarksFromXmlComments = false)
         {
             using (var xmlComments = File.OpenText(typeof(FakeControllerWithXmlComments).Assembly.GetName().Name + ".xml"))
             {
-                return new XmlCommentsParameterFilter(new XPathDocument(xmlComments));
+                return new XmlCommentsParameterFilter(new XPathDocument(xmlComments), includeRemarksFromXmlComments);
             }
         }
     }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsRequestBodyFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsRequestBodyFilterTests.cs
@@ -46,8 +46,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal("Description for param1", requestbody.Description);
         }
 
-        [Fact]
-        public void Apply_SetsDescription_FromPropertySummaryTag()
+        [Theory]
+        [InlineData("Summary for StringProperty (Remarks for StringProperty)", true)]
+        [InlineData("Summary for StringProperty", false)]
+        public void Apply_SetsDescription_FromPropertySummaryAndRemarksTag(
+            string expectedDescription,
+            bool includeRemarksFromXmlComments)
         {
             var requestBody = new OpenApiRequestBody();
             var bodyParameterDescription = new ApiParameterDescription
@@ -56,16 +60,16 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             };
             var filterContext = new RequestBodyFilterContext(bodyParameterDescription, null, null, null);
 
-            Subject().Apply(requestBody, filterContext);
+            Subject(includeRemarksFromXmlComments).Apply(requestBody, filterContext);
 
-            Assert.Equal("Summary for StringProperty", requestBody.Description);
+            Assert.Equal(expectedDescription, requestBody.Description);
         }
 
-        private XmlCommentsRequestBodyFilter Subject()
+        private XmlCommentsRequestBodyFilter Subject(bool includeRemarksFromXmlComments = false)
         {
             using (var xmlComments = File.OpenText(typeof(FakeControllerWithXmlComments).Assembly.GetName().Name + ".xml"))
             {
-                return new XmlCommentsRequestBodyFilter(new XPathDocument(xmlComments));
+                return new XmlCommentsRequestBodyFilter(new XPathDocument(xmlComments), includeRemarksFromXmlComments);
             }
         }
     }

--- a/test/WebSites/Basic/Controllers/CrudActionsController.cs
+++ b/test/WebSites/Basic/Controllers/CrudActionsController.cs
@@ -7,6 +7,9 @@ namespace Basic.Controllers
     /// <summary>
     /// Summary for CrudActionsController
     /// </summary>
+    /// <remarks>
+    /// Remarks for CrudActionsControllerI
+    /// </remarks>
     [Route("/products")]
     [Produces("application/json")]
     public class CrudActionsController
@@ -16,13 +19,13 @@ namespace Basic.Controllers
         /// </summary>
         /// <remarks>
         /// ## Heading 1
-        /// 
+        ///
         ///     POST /products
         ///     {
         ///         "id": "123",
         ///         "description": "Some product"
         ///     }
-        /// 
+        ///
         /// </remarks>
         /// <param name="product"></param>
         /// <returns></returns>
@@ -88,6 +91,12 @@ namespace Basic.Controllers
         }
     }
 
+    /// <summary>
+    /// Product status
+    /// </summary>
+    /// <remarks>
+    /// 0 = All, 1 = OutOfStock, 2 = InStock
+    /// </remarks>
     public enum ProductStatus
     {
         All = 0,
@@ -98,16 +107,25 @@ namespace Basic.Controllers
     /// <summary>
     /// Represents a product
     /// </summary>
+    /// <remarks>
+    /// Product to buy
+    /// </remarks>
     public class Product
     {
         /// <summary>
         /// Uniquely identifies the product
         /// </summary>
+        /// <remarks>
+        /// Must be unique
+        /// </remarks>
         public int Id { get; set; }
 
         /// <summary>
         /// Describes the product
         /// </summary>
+        /// <remarks>
+        /// Description
+        /// </remarks>
         public string Description { get; set; }
 
         public ProductStatus Status { get; set; }

--- a/test/WebSites/Basic/Startup.cs
+++ b/test/WebSites/Basic/Startup.cs
@@ -52,7 +52,7 @@ namespace Basic
                 c.SelectDiscriminatorNameUsing((baseType) => "TypeName");
                 c.SelectDiscriminatorValueUsing((subType) => subType.Name);
 
-                c.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, "Basic.xml"));
+                c.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, "Basic.xml"), includeControllerXmlComments: true, includeRemarksFromXmlComments: true);
 
                 c.EnableAnnotations();
             });


### PR DESCRIPTION
Added the `includeRemarksFromXmlComments` boolean parameter to `IncludeXmlComments` extension method.
This flag indicates if remarks XML comments should be used to assign Tag descriptions.

For example, in test `Basic` Web Site we need to use:

1. In `Startup.cs`:

```csharp
public void ConfigureServices(IServiceCollection services)
{
	//...
	
	c.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, "Basic.xml"), includeControllerXmlComments: true, includeRemarksFromXmlComments: true);
	
	//...
}
```

2. Add XML-comments (summary and remarks) to `CrudActionsController`:

```csharp
/// <summary>
/// Summary for CrudActionsController
/// </summary>
/// <remarks>
/// Remarks for CrudActionsController
/// </remarks>
[Route("/products")]
[Produces("application/json")]
public class CrudActionsController
{

	//...

	/// <summary>
	/// Creates a <paramref name="product"/>
	/// </summary>
	/// <remarks>
	/// ## Heading 1
	///
	///     POST /products
	///     {
	///         "id": "123",
	///         "description": "Some product"
	///     }
	///
	/// </remarks>
	/// <param name="product"></param>
	/// <returns></returns>
	[HttpPost(Name = "CreateProduct")]
	public Product Create([FromBody, Required]Product product)
	{
		return product;
	}

	//...

	/// <summary>
	/// Product status
	/// </summary>
	/// <remarks>
	/// 0 = All, 1 = OutOfStock, 2 = InStock
	/// </remarks>
	public enum ProductStatus
	{
		All = 0,
		OutOfStock = 1,
		InStock = 2
	}

	/// <summary>
	/// Represents a product
	/// </summary>
	/// <remarks>
	/// Product to buy
	/// </remarks>
	public class Product
	{
		/// <summary>
		/// Uniquely identifies the product
		/// </summary>
		/// <remarks>
		/// Must be unique
		/// </remarks>
		public int Id { get; set; }
		
		/// <summary>
		/// Describes the product
		/// </summary>
		/// <remarks>
		/// Description
		/// </remarks>
		public string Description { get; set; }
		
		public ProductStatus Status { get; set; }
		
		public ProductStatus? Status2 { get; set; }
	}

	//...	
}
```

As a result we get:

![remarks](https://user-images.githubusercontent.com/29679226/95379956-bbbe9480-08ee-11eb-9422-6b5e8a026f8e.png)