### PR TITLE
Small fix to "Describing Discriminators" example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1041,7 +1041,7 @@ services.AddSwaggerGen(c =>
 {
     ...
 
-    c.UseOneOfPolymorphism();
+    c.UseOneOfForPolymorphism();
 
     c.SelectDiscriminatorNameUsing((baseType) => "TypeName");
     c.SelectDiscriminatorValueUsing((subType) => subType.Name);


### PR DESCRIPTION
Small fix to example under _Describing Discriminators_.