### PR TITLE
Set invariant culture in unit tests

### DIFF
--- a/ci/test.ps1
+++ b/ci/test.ps1
@@ -1,5 +1,5 @@
 function dotnet-test {
-  Get-ChildItem -Path "test\**\*.csproj" | ForEach-Object {
+  Get-ChildItem -Path "test\**\*.csproj" -Exclude "*TestSupport.csproj" | ForEach-Object {
     dotnet test $_ -c Release --no-build
     if ($LastExitCode -ne 0) { Exit $LastExitCode } # because dotnet test isn't behaving correctly
   }

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -258,6 +258,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.IntArrayWithDefault), "[\n  1,\n  2,\n  3\n]")]
         [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.StringArrayWithDefault), "[\n  \"foo\",\n  \"bar\"\n]")]
         [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.StringWithDefaultNull), "null")]
+        [UseInvariantCulture]
         public void GenerateSchema_SetsDefault_IfPropertyHasDefaultValueAttribute(
             Type declaringType,
             string propertyName,

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/SystemTextJsonSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/SystemTextJsonSchemaGeneratorTests.cs
@@ -255,6 +255,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.IntArrayWithDefault), "[\n  1,\n  2,\n  3\n]")]
         [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.StringArrayWithDefault), "[\n  \"foo\",\n  \"bar\"\n]")]
         [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.StringWithDefaultNull), "null")]
+        [UseInvariantCulture]
         public void GenerateSchema_SetsDefault_IfPropertyHasDefaultValueAttribute(
             Type declaringType,
             string propertyName,

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
@@ -65,6 +65,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.EnumProperty), "2")]
         [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.GuidProperty), "\"d3966535-2637-48fa-b911-e3c27405ee09\"")]
         [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.StringProperty), "\"Example for StringProperty\"")]
+        [UseInvariantCulture]
         public void Apply_SetsExample_FromPropertyExampleTag(
             Type declaringType,
             string propertyName,

--- a/test/Swashbuckle.AspNetCore.TestSupport/Attributes/UseInvariantCultureAttribute.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Attributes/UseInvariantCultureAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Globalization;
+using System.Reflection;
+
+using Xunit.Sdk;
+
+namespace Swashbuckle.AspNetCore.TestSupport
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public sealed class UseInvariantCultureAttribute : BeforeAfterTestAttribute
+    {
+        public override void Before(MethodInfo methodUnderTest)
+        {
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+        }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.TestSupport/Swashbuckle.AspNetCore.TestSupport.csproj
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Swashbuckle.AspNetCore.TestSupport.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
+    <PackageReference Include="xunit.core" Version="2.4.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Some tests are failing if executed with `CurrentCulture`, where decimal separator is different from period.

For example (`CultureInfo.CurrentCulture` is "ru-RU" where comma is decimal separator):

![image](https://user-images.githubusercontent.com/20906347/97997910-88422d80-1dfa-11eb-9859-a06fda32e888.png)
