### PR TITLE
Update swagger-ui-dist to 3.36.2

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/package-lock.json
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "swagger-ui-dist": {
-      "version": "3.32.5",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.32.5.tgz",
-      "integrity": "sha512-3SKHv8UVqsKKknivtACHbFDGcn297jkoZN2h6zAZ7b2yoaJNMaRadQpC3qFw3GobZTGzqHCgHph4ZH9NkaCjrQ=="
+      "version": "3.36.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.36.1.tgz",
+      "integrity": "sha512-p7lx/OubaaCzOfSYDuMbkRvf/a+rTnQAOySN/NhL+k6D5o9WXEEeKZwj/6fRHRoLSHKZq28jc1xQcz8HuYcgwQ=="
     }
   }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/package-lock.json
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "swagger-ui-dist": {
-      "version": "3.36.1",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.36.1.tgz",
-      "integrity": "sha512-p7lx/OubaaCzOfSYDuMbkRvf/a+rTnQAOySN/NhL+k6D5o9WXEEeKZwj/6fRHRoLSHKZq28jc1xQcz8HuYcgwQ=="
+      "version": "3.36.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.36.2.tgz",
+      "integrity": "sha512-jbxorhRC/FKk8yMx5zEbg1A1sXc/vsW2vrDTJ3clmaMr9F12zsy161kwnxjVt/vVkMglDOz+BC8ZMY01toxHwA=="
     }
   }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/package.json
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "swagger-ui-dist": "3.32.5"
+    "swagger-ui-dist": "3.36.1"
   }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/package.json
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "swagger-ui-dist": "3.36.1"
+    "swagger-ui-dist": "3.36.2"
   }
 }


### PR DESCRIPTION
Makes sure that the fixes having to do with allOf/oneOf nesting in swagger-js/swagger-ui are also pulled into Swashbuckle.AspNetCore.

Examples of the issues this upgrade fixes:
https://github.com/swagger-api/swagger-js/issues/1362
https://github.com/swagger-api/swagger-ui/issues/5194
https://github.com/swagger-api/swagger-ui/issues/5923
https://github.com/swagger-api/swagger-ui/issues/4672

Also fixes #1905