### PR TITLE
Ignore case when serving /index.html in redoc

### DIFF
--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
@@ -58,7 +58,7 @@ namespace Swashbuckle.AspNetCore.ReDoc
                 return;
             }
 
-            if (httpMethod == "GET" && Regex.IsMatch(path, $"/{_options.RoutePrefix}/?index.html"))
+            if (httpMethod == "GET" && Regex.IsMatch(path, $"/{_options.RoutePrefix}/?index.html",  RegexOptions.IgnoreCase))
             {
                 await RespondWithIndexHtml(httpContext.Response);
                 return;

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
@@ -30,5 +30,18 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
             Assert.Contains("Redoc.init", indexContent);
             Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
         }
+
+        [Fact]
+        public async Task IndexUrl_IgnoresUrlCase()
+        {
+            var client = new TestSite(typeof(ReDocApp.Startup)).BuildClient();
+
+            var indexResponse = await client.GetAsync("/Api-Docs/index.html");
+            var jsResponse = await client.GetAsync("/Api-Docs/redoc.standalone.js");
+
+            var indexContent = await indexResponse.Content.ReadAsStringAsync();
+            Assert.Contains("Redoc.init", indexContent);
+            Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1902, making the check for {routeprefix}/index.html case insensitive like /{routeprefix}.

I also noticed the regex escape in the redirect url check. Should that also be applied here?