### PR TITLE
Add Skip Query Parameter Option In Swagger UI Configuration

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -117,7 +117,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// Setting if ignore query parameters in OAuth 2 redirect url
         /// </summary>
         [JsonPropertyName("ignoreOauth2RedirectUrlQueryParameters")]
-        public bool IgnoreOAuth2RedirectUrlQueryParameters { get; set; } = false;
+        public bool IgnoreOAuth2RedirectUrlQueryParameters { get; set; } = true;
 
         /// <summary>
         /// List of HTTP methods that have the Try it out feature enabled.

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -114,6 +114,12 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         public string OAuth2RedirectUrl { get; set; } = null;
 
         /// <summary>
+        /// Setting if ignore query parameters in OAuth 2 redirect url
+        /// </summary>
+        [JsonPropertyName("ignoreOauth2RedirectUrlQueryParameters")]
+        public bool IgnoreOAuth2RedirectUrlQueryParameters { get; set; } = false;
+
+        /// <summary>
         /// List of HTTP methods that have the Try it out feature enabled.
         /// An empty array disables Try it out for all operations. This does not filter the operations from the display
         /// </summary>

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
@@ -61,6 +61,9 @@
             if (!configObject.hasOwnProperty("oauth2RedirectUrl"))
                 configObject.oauth2RedirectUrl = window.location.href.replace("index.html", "oauth2-redirect.html").split('#')[0];
 
+            if (configObject.ignoreOauth2RedirectUrlQueryParameters)
+                configObject.oauth2RedirectUrl = configObject.oauth2RedirectUrl.split('?')[0];
+
             // Apply mandatory parameters
             configObject.dom_id = "#swagger-ui";
             configObject.presets = [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset];


### PR DESCRIPTION
To make the package more flexible in response of Issue #1854 
 I add a SwaggerUIOptions ConfigObject property name 'IgnoreOAuth2RedirectUrlQueryParameters' with default false.
``` C#
app.UseSwaggerUI(options =>
{
    options.ConfigObject.IgnoreOAuth2RedirectUrlQueryParameters = true;
}
```
If the property is true, in index.html the script will just keep the url before query '?'.
``` JavaScript
if (configObject.ignoreOauth2RedirectUrlQueryParameters)
    configObject.oauth2RedirectUrl = configObject.oauth2RedirectUrl.split('?')[0];
```