### PR TITLE
Add option that allows to cache OpenApiDocument for identical requests until applying PreSerializeFilters

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/DependencyInjection/SwaggerBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/DependencyInjection/SwaggerBuilderExtensions.cs
@@ -54,6 +54,7 @@ namespace Microsoft.AspNetCore.Builder
 
                 options.RouteTemplate = pattern;
                 options.SerializeAsV2 = endpointOptions.SerializeAsV2;
+                options.UseOpenApiDocumentMemoryCaching = endpointOptions.UseOpenApiDocumentMemoryCaching;
                 options.PreSerializeFilters.AddRange(endpointOptions.PreSerializeFilters);
             };
 

--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerEndpointOptions.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerEndpointOptions.cs
@@ -12,6 +12,7 @@ namespace Swashbuckle.AspNetCore.Swagger
         {
             PreSerializeFilters = new List<Action<OpenApiDocument, HttpRequest>>();
             SerializeAsV2 = false;
+            UseOpenApiDocumentMemoryCaching = false;
         }
 
 
@@ -19,6 +20,12 @@ namespace Swashbuckle.AspNetCore.Swagger
         /// Return Swagger JSON in the V2 format rather than V3
         /// </summary>
         public bool SerializeAsV2 { get; set; }
+
+        /// <summary>
+        /// Allows to cache generated OpenApiDocument for identical requests until
+        /// applying <see cref="PreSerializeFilters"/>.
+        /// </summary>
+        public bool UseOpenApiDocumentMemoryCaching { get; set; }
 
         /// <summary>
         /// Actions that can be applied SwaggerDocument's before they're serialized to JSON.

--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Template;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Primitives;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Writers;
@@ -28,7 +29,7 @@ namespace Swashbuckle.AspNetCore.Swagger
             _requestMatcher = new TemplateMatcher(TemplateParser.Parse(_options.RouteTemplate), new RouteValueDictionary());
         }
 
-        public async Task Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)
+        public async Task Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider, IMemoryCache memoryCache)
         {
             if (!RequestingSwaggerDocument(httpContext.Request, out string documentName))
             {
@@ -38,13 +39,29 @@ namespace Swashbuckle.AspNetCore.Swagger
 
             try
             {
-                var host = httpContext.Request.Host.HasValue
-                    ? $"{httpContext.Request.Scheme ?? "http"}://{httpContext.Request.Host}"
+                var basePath = httpContext.Request.PathBase.HasValue
+                    ? httpContext.Request.PathBase.Value
                     : null;
 
-                var basePath = httpContext.Request.PathBase;
-
-                var swagger = swaggerProvider.GetSwagger(documentName, host, basePath);
+                OpenApiDocument swagger = null;
+                if (!_options.UseOpenApiDocumentMemoryCaching)
+                {
+                    swagger = swaggerProvider.GetSwagger(
+                        documentName: documentName,
+                        host: null,
+                        basePath: basePath);
+                }
+                else
+                {
+                    if (memoryCache?.TryGetValue((documentName, (string)null, basePath), out swagger) != true)
+                    {
+                        swagger = swaggerProvider.GetSwagger(
+                            documentName: documentName,
+                            host: null,
+                            basePath: basePath);
+                        memoryCache?.Set((documentName, (string)null, basePath), swagger);
+                    }
+                }
 
                 // One last opportunity to modify the Swagger Document - this time with request context
                 foreach (var filter in _options.PreSerializeFilters)

--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerOptions.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerOptions.cs
@@ -11,6 +11,7 @@ namespace Swashbuckle.AspNetCore.Swagger
         {
             PreSerializeFilters = new List<Action<OpenApiDocument, HttpRequest>>();
             SerializeAsV2 = false;
+            UseOpenApiDocumentMemoryCaching = false;
         }
 
         /// <summary>
@@ -23,6 +24,12 @@ namespace Swashbuckle.AspNetCore.Swagger
         /// Return Swagger JSON in the V2 format rather than V3
         /// </summary>
         public bool SerializeAsV2 { get; set; }
+
+        /// <summary>
+        /// Allows to cache generated OpenApiDocument for identical requests until
+        /// applying <see cref="PreSerializeFilters"/>.
+        /// </summary>
+        public bool UseOpenApiDocumentMemoryCaching { get; set; }
 
         /// <summary>
         /// Actions that can be applied SwaggerDocument's before they're serialized to JSON.

--- a/src/Swashbuckle.AspNetCore.Swagger/Swashbuckle.AspNetCore.Swagger.csproj
+++ b/src/Swashbuckle.AspNetCore.Swagger/Swashbuckle.AspNetCore.Swagger.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/DocumentProvider.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/DocumentProvider.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Writers;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -24,15 +26,18 @@ namespace Microsoft.Extensions.ApiDescriptions
         private readonly SwaggerGeneratorOptions _generatorOptions;
         private readonly SwaggerOptions _options;
         private readonly ISwaggerProvider _swaggerProvider;
+        private readonly IMemoryCache _memoryCache;
 
         public DocumentProvider(
             IOptions<SwaggerGeneratorOptions> generatorOptions,
             IOptions<SwaggerOptions> options,
-            ISwaggerProvider swaggerProvider)
+            ISwaggerProvider swaggerProvider,
+            IMemoryCache memoryCache)
         {
             _generatorOptions = generatorOptions.Value;
             _options = options.Value;
             _swaggerProvider = swaggerProvider;
+            _memoryCache = memoryCache;
         }
 
         public IEnumerable<string> GetDocumentNames()
@@ -43,7 +48,19 @@ namespace Microsoft.Extensions.ApiDescriptions
         public Task GenerateAsync(string documentName, TextWriter writer)
         {
             // Let UnknownSwaggerDocument or other exception bubble up to caller.
-            var swagger = _swaggerProvider.GetSwagger(documentName, host: null, basePath: null);
+            OpenApiDocument swagger = null;
+            if (!_options.UseOpenApiDocumentMemoryCaching)
+            {
+                swagger = _swaggerProvider.GetSwagger(documentName, host: null, basePath: null);
+            }
+            else
+            {
+                if (_memoryCache?.TryGetValue((documentName, (string)null, (string)null), out swagger) != true)
+                {
+                    swagger = _swaggerProvider.GetSwagger(documentName, host: null, basePath: null);
+                    _memoryCache?.Set((documentName, (string)null, (string)null), swagger);
+                }
+            }
             var jsonWriter = new OpenApiJsonWriter(writer);
             if (_options.SerializeAsV2)
             {

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenServiceCollectionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenServiceCollectionExtensions.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 return new JsonSerializerDataContractResolver(serializerOptions);
             });
 
+            // Used for caching generated OpenApiDocument in SwaggerMiddleware and DocumentProvider.
+            services.AddMemoryCache();
+
             // Used by the <c>dotnet-getdocument</c> tool from the Microsoft.Extensions.ApiDescription.Server package.
             services.TryAddSingleton<IDocumentProvider, DocumentProvider>();
 


### PR DESCRIPTION
This will help to load the large OpenAPI documents much faster for the second and subsequent identical requests.