### PR TITLE
Handle multiple document versions in SwaggerUI and Redoc

### DIFF
--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocBuilderExtensions.cs
@@ -22,9 +22,12 @@ namespace Microsoft.AspNetCore.Builder
             this IApplicationBuilder app,
             Action<ReDocOptions> setupAction = null)
         {
-            var options = app.ApplicationServices.GetRequiredService<IOptions<ReDocOptions>>().Value;
-
-            setupAction?.Invoke(options);
+            ReDocOptions options;
+            using (var scope = app.ApplicationServices.CreateScope())
+            {
+                options = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<ReDocOptions>>().Value;
+                setupAction?.Invoke(options);
+            }
 
             // To simplify the common case, use a default that will work with the SwaggerMiddleware defaults
             if (options.SpecUrl == null)

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
@@ -22,9 +22,12 @@ namespace Microsoft.AspNetCore.Builder
             this IApplicationBuilder app,
             Action<SwaggerUIOptions> setupAction = null)
         {
-            var options = app.ApplicationServices.GetRequiredService<IOptions<SwaggerUIOptions>>().Value;
-
-            setupAction?.Invoke(options);
+            SwaggerUIOptions options;
+            using (var scope = app.ApplicationServices.CreateScope())
+            {
+                options = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<SwaggerUIOptions>>().Value;
+                setupAction?.Invoke(options);
+            }
 
             // To simplify the common case, use a default that will work with the SwaggerMiddleware defaults
             if (options.ConfigObject.Urls == null)

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
@@ -43,5 +43,19 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
             Assert.Contains("Redoc.init", indexContent);
             Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
         }
+
+        [Theory]
+        [InlineData("/redoc/1.0/index.html", "/swagger/1.0/swagger.json")]
+        [InlineData("/redoc/2.0/index.html", "/swagger/2.0/swagger.json")]
+        public async Task VersionUrls_ProperlyHandlesDifferentVersions(string redocUrl, string swaggerPath)
+        {
+            var client = new TestSite(typeof(MultipleVersions.Startup)).BuildClient();
+
+            var response = await client.GetAsync(redocUrl);
+            var content = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Contains(swaggerPath, content);
+        }
     }
 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -54,5 +54,23 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
 
             Assert.Contains("Example.com", content);
         }
+
+        [Theory]
+        [InlineData("/swagger/index.html", new [] { "Version 1.0", "Version 2.0" })]
+        [InlineData("/swagger/1.0/index.html", new [] { "Version 1.0" })]
+        [InlineData("/swagger/2.0/index.html", new [] { "Version 2.0" })]
+        public async Task VersionUrls_ProperlyHandlesDifferentVersions(string swaggerUiUrl, string[] versions)
+        {
+            var client = new TestSite(typeof(MultipleVersions.Startup)).BuildClient();
+
+            var response = await client.GetAsync(swaggerUiUrl);
+            var content = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            foreach (var version in versions)
+            {
+                Assert.Contains(version, content);
+            }
+        }
     }
 }

--- a/test/WebSites/MultipleVersions/MultipleVersions.csproj
+++ b/test/WebSites/MultipleVersions/MultipleVersions.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.ReDoc\Swashbuckle.AspNetCore.ReDoc.csproj" />
     <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.Swagger\Swashbuckle.AspNetCore.Swagger.csproj" />
     <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerGen\Swashbuckle.AspNetCore.SwaggerGen.csproj" />
     <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerUI\Swashbuckle.AspNetCore.SwaggerUI.csproj" />

--- a/test/WebSites/MultipleVersions/Startup.cs
+++ b/test/WebSites/MultipleVersions/Startup.cs
@@ -38,6 +38,8 @@ namespace MultipleVersions
                 app.UseDeveloperExceptionPage();
             }
 
+            app.UseStaticFiles();
+
             app.UseRouting();
 
             app.UseAuthorization();
@@ -48,13 +50,31 @@ namespace MultipleVersions
             });
 
             app.UseSwagger();
+
+            // A common endpoint that contains both versions
             app.UseSwaggerUI(c =>
             {
+                c.RoutePrefix = "swagger";
                 foreach (var description in provider.ApiVersionDescriptions)
                 {
-                    c.SwaggerEndpoint($"{description.GroupName}/swagger.json", description.GroupName.ToUpperInvariant());
+                    c.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.json", $"Version {description.GroupName}");
                 }
             });
+
+            // Separate endpoints that contain only one version
+            foreach (var description in provider.ApiVersionDescriptions)
+            {
+                app.UseSwaggerUI(c =>
+                {
+                    c.RoutePrefix = $"swagger/{description.GroupName}";
+                    c.SwaggerEndpoint($"/swagger/{description.GroupName}/swagger.json", $"Version {description.GroupName}");
+                });
+                app.UseReDoc(c =>
+                {
+                    c.RoutePrefix = $"redoc/{description.GroupName}";
+                    c.SpecUrl($"/swagger/{description.GroupName}/swagger.json");
+                });
+            }
         }
     }
 }


### PR DESCRIPTION
Last changes to Swashbuckle returned back old options' mutation bug that prevents generating SwaggerUI and Redoc pages for separate swagger document versions.
Authors suggest to use a different overload of UseSwaggerUI and UseRedoc here: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/1996
But I still think that singleton options mutation is misleading and users don't expect that. So in this PR I restored the old behaviour and also added new tests to ensure it will not break again.