### PR TITLE
Fix issue 1899

### DIFF
--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/JsonIgnoreAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/JsonIgnoreAnnotatedType.cs
@@ -7,6 +7,18 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [JsonIgnore]
         public string StringWithJsonIgnore { get; set; }
 
+        [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+        public string StringWithJsonIgnoreConditionNever { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
+        public string StringWithJsonIgnoreConditionAlways { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string StringWithJsonIgnoreConditionWhenWritingDefault { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string StringWithJsonIgnoreConditionWhenWritingNull { get; set; }
+
         public string StringWithNoAnnotation { get; set; }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -676,7 +676,16 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var referenceSchema = Subject().GenerateSchema(typeof(JsonIgnoreAnnotatedType), schemaRepository);
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal( new[] { /* "StringWithJsonIgnore" */ "StringWithNoAnnotation" }, schema.Properties.Keys.ToArray());
+
+            string[] expectedKeys =
+            {
+                nameof(JsonIgnoreAnnotatedType.StringWithJsonIgnoreConditionNever),
+                nameof(JsonIgnoreAnnotatedType.StringWithJsonIgnoreConditionWhenWritingDefault),
+                nameof(JsonIgnoreAnnotatedType.StringWithJsonIgnoreConditionWhenWritingNull),
+                nameof(JsonIgnoreAnnotatedType.StringWithNoAnnotation)
+            };
+
+            Assert.Equal(expectedKeys, schema.Properties.Keys.ToArray());
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.csproj
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <DocumentationFile>Swashbuckle.AspNetCore.SwaggerGen.Test.xml</DocumentationFile>
     <NoWarn>1701;1702;1591</NoWarn>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
This PR corrects https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/1899

I updated the SwaggerGen test project to .Net 5, so JsonIgnoreAnnotatedType.cs can use JsonIgnoreAttribute.Condition. If you'd prefer, I can create a separate .Net 5 project and create a new class there to validate this fix (and leave JsonIgnoreAnnotatedType.cs alone to validate passivity).

Let me know if you'd like me to change anything, thanks!