### PR TITLE
Fixed problem with finding nullable attribute in nested types because of roslyn optimizations

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
@@ -39,10 +39,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 ? ((FieldInfo)memberInfo).FieldType
                 : ((PropertyInfo)memberInfo).PropertyType;
 
-            if (memberType.IsValueType)
-            {
-                return false;
-            }
+            if (memberType.IsValueType) return false;
 
             var nullableAttribute = memberInfo.GetNullableAttribute();
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
@@ -64,7 +64,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private static object GetNullableAttribute(this MemberInfo memberInfo)
         {
             var nullableAttribute = memberInfo.GetCustomAttributes()
-                .FirstOrDefault(attr => string.Equals(attr.GetType().FullName, NullableAttributeFullTypeName));
+                .Where(attr => string.Equals(attr.GetType().FullName, NullableAttributeFullTypeName))
+                .FirstOrDefault();
 
             return nullableAttribute;
         }
@@ -80,7 +81,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 var attributes = (IEnumerable<object>)declaringType.GetCustomAttributes(false);
 
                 var nullableContext = attributes
-                .FirstOrDefault(attr => string.Equals(attr.GetType().FullName, NullableContextAttributeFullTypeName));
+                .Where(attr => string.Equals(attr.GetType().FullName, NullableContextAttributeFullTypeName))
+                .FirstOrDefault();
 
                 if (nullableContext != null)
                 {

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -547,6 +547,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableString), false)]
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableArray), true)]
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableArray), false)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableList), true)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableList), false)]
         public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes(
             Type declaringType,
             string propertyName,
@@ -562,6 +564,27 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var propertySchema = schemaRepository.Schemas[referenceSchema.Reference.Id].Properties[propertyName];
             Assert.Equal(expectedNullable, propertySchema.Nullable);
         }
+
+        [Theory]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.SubTypeWithOneNullableContent), nameof(TypeWithNullableContext.NullableString), true)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContext.NonNullableString), false)]
+        public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations(
+            Type declaringType,
+            string subType,
+            string propertyName,
+            bool expectedNullable)
+        {
+            var subject = Subject(
+                configureGenerator: c => c.SupportNonNullableReferenceTypes = true
+            );
+            var schemaRepository = new SchemaRepository();
+
+            subject.GenerateSchema(declaringType, schemaRepository);
+
+            var propertySchema = schemaRepository.Schemas[subType].Properties[propertyName];
+            Assert.Equal(expectedNullable, propertySchema.Nullable);
+        }
+
 
         [Fact]
         public void GenerateSchema_HandlesTypesWithNestedTypes()

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
@@ -1,4 +1,6 @@
-﻿namespace Swashbuckle.AspNetCore.TestSupport
+﻿using System.Collections.Generic;
+
+namespace Swashbuckle.AspNetCore.TestSupport
 {
 #nullable enable
     public class TypeWithNullableContext
@@ -6,9 +8,24 @@
         public int? NullableInt { get; set; }
         public int NonNullableInt { get; set; }
         public string? NullableString { get; set; }
-        public string NonNullableString { get; set; }
+        public string NonNullableString { get; set; } = default!;
         public int[]? NullableArray { get; set; }
-        public int[] NonNullableArray { get; set; }
+        public int[] NonNullableArray { get; set; } = default!;
+
+        public List<SubTypeWithOneNullableContent>? NullableList { get; set; }
+        public List<SubTypeWithOneNonNullableContent> NonNullableList { get; set; } = default!;
+
+        public class SubTypeWithOneNullableContent
+        {
+            public string? NullableString { get; set; }
+        }
+
+        public class SubTypeWithOneNonNullableContent
+        {
+            public string NonNullableString { get; set; } = default!;
+        }
+
+
     }
 #nullable restore
 }


### PR DESCRIPTION
This change only affects the logic in finding compiler annotated null attributes when using the "SupportNonNullableReferenceTypes" option.

- [x] Adjusted code to handle roslyn compiler optimizations for nested types.
- [x] Fixed bug that cause a crash if annotation nullable attribute flag returned was byte[].
- [x] Added tests for compiler optimization senarios.
- [x] Added default values to test class to remove warnings.

More information about roslyn nullable metadata can be found here https://github.com/dotnet/roslyn/blob/main/docs/features/nullable-metadata.md

This PR should fix #2017 and probobly #1487