### PR TITLE
Allow add endpoint metadata to Swagger Enpoint.

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/DependencyInjection/SwaggerBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/DependencyInjection/SwaggerBuilderExtensions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.AspNetCore.Builder
         }
 
 #if (!NETSTANDARD2_0)
-        public static IEndpointRouteBuilder MapSwagger(
+        public static IEndpointConventionBuilder MapSwagger(
             this IEndpointRouteBuilder endpoints,
             string pattern = "/swagger/{documentName}/swagger.json",
             Action<SwaggerEndpointOptions> setupAction = null)
@@ -65,9 +65,7 @@ namespace Microsoft.AspNetCore.Builder
                 .UseSwagger(endpointSetupAction)
                 .Build();
 
-            endpoints.MapGet(pattern, pipeline);
-
-            return endpoints;
+            return endpoints.MapGet(pattern, pipeline);
         }
 #endif
     }


### PR DESCRIPTION
Allowed add endpoint metadata to SwaggerEndpoint.

Such as:

``` csharp

app.UseEnpoint(endpoint=>{
    endpoint.MapSwagger().RequireCors().RequireAuthorize().RequireHost("host");
});

```

Address #2078