### PR TITLE
Add option to enable try it out by default

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -125,6 +125,12 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         public IEnumerable<SubmitMethod> SupportedSubmitMethods { get; set; } = Enum.GetValues(typeof(SubmitMethod)).Cast<SubmitMethod>();
 
         /// <summary>
+        /// Controls whether the "Try it out" section should be enabled by default.
+        /// </summary>
+        [JsonPropertyName("tryItOutEnabled")]
+        public bool TryItOutEnabled { get; set; }
+
+        /// <summary>
         /// By default, Swagger-UI attempts to validate specs against swagger.io's online validator.
         /// You can use this parameter to set a different validator URL, for example for locally deployed validators (Validator Badge).
         /// Setting it to null will disable validation

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptionsExtensions.cs
@@ -129,6 +129,15 @@ namespace Microsoft.AspNetCore.Builder
         }
 
         /// <summary>
+        /// Enables the "Try it out" section by default.
+        /// </summary>
+        /// <param name="options"></param>
+        public static void EnableTryItOutByDefault(this SwaggerUIOptions options)
+        {
+            options.ConfigObject.TryItOutEnabled = true;
+        }
+
+        /// <summary>
         /// Limits the number of tagged operations displayed to at most this many. The default is to show all operations
         /// </summary>
         /// <param name="options"></param>


### PR DESCRIPTION
This will give a developer the option to have "Try It Out" enabled on
all operations. It can be tedious at times to have to click the button
for each operation if you are testing many things out in the Swagger UI.

Example:
```c#
app.UseSwaggerUI(options =>
{
    options.EnableTryItOutByDefault();
}
```