### PR TITLE
Fixes #2117

### DIFF
--- a/src/Swashbuckle.AspNetCore.Cli/Program.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/Program.cs
@@ -42,14 +42,24 @@ namespace Swashbuckle.AspNetCore.Cli
 
                     var depsFile = namedArgs["startupassembly"].Replace(".dll", ".deps.json");
                     var runtimeConfig = namedArgs["startupassembly"].Replace(".dll", ".runtimeconfig.json");
+                    var commandName = args[0];
 
-                    var subProcess = Process.Start("dotnet", string.Format(
-                        "exec --depsfile {0} --runtimeconfig {1} {2} _{3}", // note the underscore
+                    var subProcessArguments = new string[args.Length - 1];
+                    if (subProcessArguments.Length > 0)
+                    {
+                        Array.Copy(args, 1, subProcessArguments, 0, subProcessArguments.Length);
+                    }
+
+                    var subProcessCommandLine = string.Format(
+                        "exec --depsfile {0} --runtimeconfig {1} {2} _{3} {4}", // note the underscore prepended to the command name
                         EscapePath(depsFile),
                         EscapePath(runtimeConfig),
                         EscapePath(typeof(Program).GetTypeInfo().Assembly.Location),
-                        string.Join(" ", args)
-                    ));
+                        commandName,
+                        string.Join(" ", subProcessArguments.Select(x => EscapePath(x)))
+                    );
+
+                    var subProcess = Process.Start("dotnet", subProcessCommandLine);
 
                     subProcess.WaitForExit();
                     return subProcess.ExitCode;


### PR DESCRIPTION
Fixes #2117

The main command "tofile", if it has arguments that are enclosed in double quotes, will receive them as independent elements in the args array.  When the call to dotnet exec is made to invoke the subcommand "_tofile", if there are any arguments that contain spaces, they will now be regarded as multiple arguments and the subcommand run will have a different set of arguments, ones that do not match the users' intentions.

Uses the existing EscapePath to enclose those parameters that contain spaces with double quotes.  The result is that if the paths that are arguments for the "tofile" command (startupassembly or --output) contain spaces, they should now be seen by the subcommand the same as they were in the main command.