### PR TITLE
Use the URL API to create a location-relative path to "oauth2-redirect.html

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
@@ -88,7 +88,7 @@
 
             // If oauth2RedirectUrl isn't specified, use the built-in default
             if (!configObject.hasOwnProperty("oauth2RedirectUrl"))
-                configObject.oauth2RedirectUrl = window.location.href.replace("index.html", "oauth2-redirect.html").split('#')[0];
+                configObject.oauth2RedirectUrl = (new URL("oauth2-redirect.html", window.location.href)).href;
 
             // Apply mandatory parameters
             configObject.dom_id = "#swagger-ui";

--- a/test/WebSites/CustomUIIndex/Swagger/index.html
+++ b/test/WebSites/CustomUIIndex/Swagger/index.html
@@ -59,7 +59,7 @@
 
       // If oauth2RedirectUrl isn't specified, use the built-in default
       if (!configObject.hasOwnProperty("oauth2RedirectUrl"))
-        configObject.oauth2RedirectUrl = window.location.href.replace("index.html", "oauth2-redirect.html").split('#')[0];
+        configObject.oauth2RedirectUrl = (new URL("oauth2-redirect.html", window.location.href)).href;
 
       // Begin Swagger UI call region
 


### PR DESCRIPTION
Fixes #1854

URL JS API: https://caniuse.com/url (no IE 11, but there are already other non-IE 11 usages like [startsWith()](https://caniuse.com/mdn-javascript_builtins_string_startswith))