### PR TITLE
Added HostFactoryResolver to detect new application patterns

### DIFF
--- a/src/Swashbuckle.AspNetCore.Cli/HostFactoryResolver.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/HostFactoryResolver.cs
@@ -1,0 +1,330 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.Hosting
+{
+    internal sealed class HostFactoryResolver
+    {
+        private const BindingFlags DeclaredOnlyLookup = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+        public const string BuildWebHost = nameof(BuildWebHost);
+        public const string CreateWebHostBuilder = nameof(CreateWebHostBuilder);
+        public const string CreateHostBuilder = nameof(CreateHostBuilder);
+
+        // The amount of time we wait for the diagnostic source events to fire
+        private static readonly TimeSpan s_defaultWaitTimeout = TimeSpan.FromSeconds(5);
+
+        public static Func<string[], TWebHost> ResolveWebHostFactory<TWebHost>(Assembly assembly)
+        {
+            return ResolveFactory<TWebHost>(assembly, BuildWebHost);
+        }
+
+        public static Func<string[], TWebHostBuilder> ResolveWebHostBuilderFactory<TWebHostBuilder>(Assembly assembly)
+        {
+            return ResolveFactory<TWebHostBuilder>(assembly, CreateWebHostBuilder);
+        }
+
+        public static Func<string[], THostBuilder> ResolveHostBuilderFactory<THostBuilder>(Assembly assembly)
+        {
+            return ResolveFactory<THostBuilder>(assembly, CreateHostBuilder);
+        }
+
+        // This helpers encapsulates all of the complex logic required to:
+        // 1. Execute the entry point of the specified assembly in a different thread.
+        // 2. Wait for the diagnostic source events to fire
+        // 3. Give the caller a chance to execute logic to mutate the IHostBuilder
+        // 4. Resolve the instance of the applications's IHost
+        // 5. Allow the caller to determine if the entry point has completed
+        public static Func<string[], object> ResolveHostFactory(Assembly assembly,
+                                                                 TimeSpan? waitTimeout = null,
+                                                                 bool stopApplication = true,
+                                                                 Action<object> configureHostBuilder = null,
+                                                                 Action<Exception> entrypointCompleted = null)
+        {
+            if (assembly.EntryPoint is null)
+            {
+                return null;
+            }
+
+            try
+            {
+                // Attempt to load hosting and check the version to make sure the events
+                // even have a chance of firing (they were added in .NET >= 6)
+                var hostingAssembly = Assembly.Load("Microsoft.Extensions.Hosting");
+                if (hostingAssembly.GetName().Version is Version version && version.Major < 6)
+                {
+                    return null;
+                }
+
+                // We're using a version >= 6 so the events can fire. If they don't fire
+                // then it's because the application isn't using the hosting APIs
+            }
+            catch
+            {
+                // There was an error loading the extensions assembly, return null.
+                return null;
+            }
+
+            return args => new HostingListener(args, assembly.EntryPoint, waitTimeout ?? s_defaultWaitTimeout, stopApplication, configureHostBuilder, entrypointCompleted).CreateHost();
+        }
+
+        private static Func<string[], T> ResolveFactory<T>(Assembly assembly, string name)
+        {
+            var programType = assembly?.EntryPoint?.DeclaringType;
+            if (programType == null)
+            {
+                return null;
+            }
+
+            var factory = programType.GetMethod(name, DeclaredOnlyLookup);
+            if (!IsFactory<T>(factory))
+            {
+                return null;
+            }
+
+            return args => (T)factory.Invoke(null, new object[] { args });
+        }
+
+        // TReturn Factory(string[] args);
+        private static bool IsFactory<TReturn>(MethodInfo factory)
+        {
+            return factory != null
+                && typeof(TReturn).IsAssignableFrom(factory.ReturnType)
+                && factory.GetParameters().Length == 1
+                && typeof(string[]).Equals(factory.GetParameters()[0].ParameterType);
+        }
+
+        // Used by EF tooling without any Hosting references. Looses some return type safety checks.
+        public static Func<string[], IServiceProvider> ResolveServiceProviderFactory(Assembly assembly, TimeSpan? waitTimeout = null)
+        {
+            // Prefer the older patterns by default for back compat.
+            var webHostFactory = ResolveWebHostFactory<object>(assembly);
+            if (webHostFactory != null)
+            {
+                return args =>
+                {
+                    var webHost = webHostFactory(args);
+                    return GetServiceProvider(webHost);
+                };
+            }
+
+            var webHostBuilderFactory = ResolveWebHostBuilderFactory<object>(assembly);
+            if (webHostBuilderFactory != null)
+            {
+                return args =>
+                {
+                    var webHostBuilder = webHostBuilderFactory(args);
+                    var webHost = Build(webHostBuilder);
+                    return GetServiceProvider(webHost);
+                };
+            }
+
+            var hostBuilderFactory = ResolveHostBuilderFactory<object>(assembly);
+            if (hostBuilderFactory != null)
+            {
+                return args =>
+                {
+                    var hostBuilder = hostBuilderFactory(args);
+                    var host = Build(hostBuilder);
+                    return GetServiceProvider(host);
+                };
+            }
+
+            var hostFactory = ResolveHostFactory(assembly, waitTimeout: waitTimeout);
+            if (hostFactory != null)
+            {
+                return args =>
+                {
+                    var host = hostFactory(args);
+                    return GetServiceProvider(host);
+                };
+            }
+
+            return null;
+        }
+
+        private static object Build(object builder)
+        {
+            var buildMethod = builder.GetType().GetMethod("Build");
+            return buildMethod?.Invoke(builder, Array.Empty<object>());
+        }
+
+        private static IServiceProvider GetServiceProvider(object host)
+        {
+            if (host == null)
+            {
+                return null;
+            }
+            var hostType = host.GetType();
+            var servicesProperty = hostType.GetProperty("Services", DeclaredOnlyLookup);
+            return (IServiceProvider)servicesProperty?.GetValue(host);
+        }
+
+        private sealed class HostingListener : IObserver<DiagnosticListener>, IObserver<KeyValuePair<string, object>>
+        {
+            private readonly string[] _args;
+            private readonly MethodInfo _entryPoint;
+            private readonly TimeSpan _waitTimeout;
+            private readonly bool _stopApplication;
+
+            private readonly TaskCompletionSource<object> _hostTcs = new TaskCompletionSource<object>();
+            private IDisposable _disposable;
+            private Action<object> _configure;
+            private Action<Exception> _entrypointCompleted;
+            private static readonly AsyncLocal<HostingListener> _currentListener = new AsyncLocal<HostingListener>();
+
+            public HostingListener(string[] args, MethodInfo entryPoint, TimeSpan waitTimeout, bool stopApplication, Action<object> configure, Action<Exception> entrypointCompleted)
+            {
+                _args = args;
+                _entryPoint = entryPoint;
+                _waitTimeout = waitTimeout;
+                _stopApplication = stopApplication;
+                _configure = configure;
+                _entrypointCompleted = entrypointCompleted;
+            }
+
+            public object CreateHost()
+            {
+                using (var subscription = DiagnosticListener.AllListeners.Subscribe(this))
+                {
+
+                    // Kick off the entry point on a new thread so we don't block the current one
+                    // in case we need to timeout the execution
+                    var thread = new Thread(() =>
+                    {
+                        Exception exception = null;
+
+                        try
+                        {
+                            // Set the async local to the instance of the HostingListener so we can filter events that
+                            // aren't scoped to this execution of the entry point.
+                            _currentListener.Value = this;
+
+                            var parameters = _entryPoint.GetParameters();
+                            if (parameters.Length == 0)
+                            {
+                                _entryPoint.Invoke(null, Array.Empty<object>());
+                            }
+                            else
+                            {
+                                _entryPoint.Invoke(null, new object[] { _args });
+                            }
+
+                            // Try to set an exception if the entry point returns gracefully, this will force
+                            // build to throw
+                            _hostTcs.TrySetException(new InvalidOperationException("Unable to build IHost"));
+                        }
+                        catch (TargetInvocationException tie) when (tie.InnerException is StopTheHostException)
+                        {
+                            // The host was stopped by our own logic
+                        }
+                        catch (TargetInvocationException tie)
+                        {
+                            exception = tie.InnerException ?? tie;
+
+                            // Another exception happened, propagate that to the caller
+                            _hostTcs.TrySetException(exception);
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ex;
+
+                            // Another exception happened, propagate that to the caller
+                            _hostTcs.TrySetException(ex);
+                        }
+                        finally
+                        {
+                            // Signal that the entry point is completed
+                            _entrypointCompleted?.Invoke(exception);
+                        }
+                    })
+                    {
+                        // Make sure this doesn't hang the process
+                        IsBackground = true
+                    };
+
+                    // Start the thread
+                    thread.Start();
+
+                    try
+                    {
+                        // Wait before throwing an exception
+                        if (!_hostTcs.Task.Wait(_waitTimeout))
+                        {
+                            throw new InvalidOperationException("Unable to build IHost");
+                        }
+                    }
+                    catch (AggregateException) when (_hostTcs.Task.IsCompleted)
+                    {
+                        // Lets this propagate out of the call to GetAwaiter().GetResult()
+                    }
+
+                    Debug.Assert(_hostTcs.Task.IsCompleted);
+
+                    return _hostTcs.Task.GetAwaiter().GetResult();
+                }
+            }
+
+            public void OnCompleted()
+            {
+                _disposable?.Dispose();
+            }
+
+            public void OnError(Exception error)
+            {
+
+            }
+
+            public void OnNext(DiagnosticListener value)
+            {
+                if (_currentListener.Value != this)
+                {
+                    // Ignore events that aren't for this listener
+                    return;
+                }
+
+                if (value.Name == "Microsoft.Extensions.Hosting")
+                {
+                    _disposable = value.Subscribe(this);
+                }
+            }
+
+            public void OnNext(KeyValuePair<string, object> value)
+            {
+                if (_currentListener.Value != this)
+                {
+                    // Ignore events that aren't for this listener
+                    return;
+                }
+
+                if (value.Key == "HostBuilding")
+                {
+                    _configure?.Invoke(value.Value);
+                }
+
+                if (value.Key == "HostBuilt")
+                {
+                    _hostTcs.TrySetResult(value.Value);
+
+                    if (_stopApplication)
+                    {
+                        // Stop the host from running further
+                        throw new StopTheHostException();
+                    }
+                }
+            }
+
+            private sealed class StopTheHostException : Exception
+            {
+
+            }
+        }
+    }
+}

--- a/src/Swashbuckle.AspNetCore.Cli/HostingApplication.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/HostingApplication.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Swashbuckle.AspNetCore.Cli
+{
+    // Represents an application that uses Microsoft.Extensions.Hosting and supports
+    // the various entry point flavors. The final model *does not* have an explicit CreateHost entry point and thus inverts the typical flow where the
+    // execute Main and we wait for events to fire in order to access the appropriate state.
+    // This is what allows top level statements to work, but getting the IServiceProvider is slightly more complex.
+    internal class HostingApplication
+    {
+        internal static IServiceProvider GetServiceProvider(Assembly assembly)
+        {
+#if NETCOREAPP2_1
+            return null;
+#else
+            // We're disabling the default server and the console host lifetime. This will disable:
+            // 1. Listening on ports
+            // 2. Logging to the console from the default host.
+            // This is essentially what the test server does in order to get access to the application's
+            // IServicerProvider *and* middleware pipeline.
+            void ConfigureHostBuilder(object hostBuilder)
+            {
+                ((IHostBuilder)hostBuilder).ConfigureServices((context, services) =>
+                {
+                    services.AddSingleton<IServer, NoopServer>();
+                    services.AddSingleton<IHostLifetime, NoopHostLifetime>();
+                });
+            }
+
+            var waitForStartTcs = new TaskCompletionSource<object>();
+
+            void OnEntryPointExit(Exception exception)
+            {
+                // If the entry point exited, we'll try to complete the wait
+                if (exception != null)
+                {
+                    waitForStartTcs.TrySetException(exception);
+                }
+                else
+                {
+                    waitForStartTcs.TrySetResult(null);
+                }
+            }
+
+            // If all of the existing techniques fail, then try to resolve the ResolveHostFactory
+            var factory = HostFactoryResolver.ResolveHostFactory(assembly,
+                                                                 stopApplication: false,
+                                                                 configureHostBuilder: ConfigureHostBuilder,
+                                                                 entrypointCompleted: OnEntryPointExit);
+
+            // We're unable to resolve the factory. This could mean the application wasn't referencing the right
+            // version of hosting.
+            if (factory == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                // Get the IServiceProvider from the host
+                var services = ((IHost)factory(Array.Empty<string>())).Services;
+
+                // Wait for the application to start so that we know it's fully configured. This is important because
+                // we need the middleware pipeline to be configured before we access the ISwaggerProvider in
+                // in the IServiceProvider
+                var applicationLifetime = services.GetRequiredService<IHostApplicationLifetime>();
+
+                using (var registration = applicationLifetime.ApplicationStarted.Register(() => waitForStartTcs.TrySetResult(null)))
+                {
+                    waitForStartTcs.Task.Wait();
+                    return services;
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // We're unable to resolve the host, swallow the exception and return null
+            }
+
+            return null;
+#endif
+        }
+
+        private class NoopHostLifetime : IHostLifetime
+        {
+            public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task WaitForStartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        }
+
+        private class NoopServer : IServer
+        {
+            public IFeatureCollection Features { get; } = new FeatureCollection();
+            public void Dispose() { }
+            public Task StartAsync<TContext>(IHttpApplication<TContext> application, CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        }
+    }
+}

--- a/src/Swashbuckle.AspNetCore.Cli/Program.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/Program.cs
@@ -15,10 +15,18 @@ namespace Swashbuckle.AspNetCore.Cli
 {
     public class Program
     {
+        private CommandRunner _runner;
+
         static int Main(string[] args)
         {
+            var program = new Program(args);
+            return program.Run(args);
+        }
+
+        public Program(string[] args)
+        {
             // Helper to simplify command line parsing etc.
-            var runner = new CommandRunner("dotnet swagger", "Swashbuckle (Swagger) Command Line Tools", Console.Out);
+            _runner = new CommandRunner("dotnet swagger", "Swashbuckle (Swagger) Command Line Tools", Console.Out);
 
             // NOTE: The "dotnet swagger tofile" command does not serve the request directly. Instead, it invokes a corresponding
             // command (called _tofile) via "dotnet exec" so that the runtime configuration (*.runtimeconfig & *.deps.json) of the
@@ -26,7 +34,7 @@ namespace Swashbuckle.AspNetCore.Cli
             // startupassembly and it's transitive dependencies. See https://github.com/dotnet/coreclr/issues/13277 for more.
 
             // > dotnet swagger tofile ...
-            runner.SubCommand("tofile", "retrieves Swagger from a startup assembly, and writes to file ", c =>
+            _runner.SubCommand("tofile", "retrieves Swagger from a startup assembly, and writes to file ", c =>
             {
                 c.Argument("startupassembly", "relative path to the application's startup assembly");
                 c.Argument("swaggerdoc", "name of the swagger doc you want to retrieve, as configured in your startup class");
@@ -67,7 +75,7 @@ namespace Swashbuckle.AspNetCore.Cli
             });
 
             // > dotnet swagger _tofile ... (* should only be invoked via "dotnet exec")
-            runner.SubCommand("_tofile", "", c =>
+            _runner.SubCommand("_tofile", "", c =>
             {
                 c.Argument("startupassembly", "");
                 c.Argument("swaggerdoc", "");
@@ -117,8 +125,11 @@ namespace Swashbuckle.AspNetCore.Cli
                     return 0;
                 });
             });
+        }
 
-            return runner.Run(args);
+        public int Run(string[] args)
+        {
+            return _runner.Run(args);
         }
 
         private static string EscapePath(string path)

--- a/src/Swashbuckle.AspNetCore.Cli/Program.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/Program.cs
@@ -15,18 +15,10 @@ namespace Swashbuckle.AspNetCore.Cli
 {
     public class Program
     {
-        private CommandRunner _runner;
-
-        static int Main(string[] args)
-        {
-            var program = new Program(args);
-            return program.Run(args);
-        }
-
-        public Program(string[] args)
+        public static int Main(string[] args)
         {
             // Helper to simplify command line parsing etc.
-            _runner = new CommandRunner("dotnet swagger", "Swashbuckle (Swagger) Command Line Tools", Console.Out);
+            var runner = new CommandRunner("dotnet swagger", "Swashbuckle (Swagger) Command Line Tools", Console.Out);
 
             // NOTE: The "dotnet swagger tofile" command does not serve the request directly. Instead, it invokes a corresponding
             // command (called _tofile) via "dotnet exec" so that the runtime configuration (*.runtimeconfig & *.deps.json) of the
@@ -34,7 +26,7 @@ namespace Swashbuckle.AspNetCore.Cli
             // startupassembly and it's transitive dependencies. See https://github.com/dotnet/coreclr/issues/13277 for more.
 
             // > dotnet swagger tofile ...
-            _runner.SubCommand("tofile", "retrieves Swagger from a startup assembly, and writes to file ", c =>
+            runner.SubCommand("tofile", "retrieves Swagger from a startup assembly, and writes to file ", c =>
             {
                 c.Argument("startupassembly", "relative path to the application's startup assembly");
                 c.Argument("swaggerdoc", "name of the swagger doc you want to retrieve, as configured in your startup class");
@@ -75,7 +67,7 @@ namespace Swashbuckle.AspNetCore.Cli
             });
 
             // > dotnet swagger _tofile ... (* should only be invoked via "dotnet exec")
-            _runner.SubCommand("_tofile", "", c =>
+            runner.SubCommand("_tofile", "", c =>
             {
                 c.Argument("startupassembly", "");
                 c.Argument("swaggerdoc", "");
@@ -125,11 +117,8 @@ namespace Swashbuckle.AspNetCore.Cli
                     return 0;
                 });
             });
-        }
 
-        public int Run(string[] args)
-        {
-            return _runner.Run(args);
+            return runner.Run(args);
         }
 
         private static string EscapePath(string path)

--- a/src/Swashbuckle.AspNetCore.Cli/Program.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/Program.cs
@@ -140,10 +140,24 @@ namespace Swashbuckle.AspNetCore.Cli
                 return webHost.Services;
             }
 
-            return WebHost.CreateDefaultBuilder()
-               .UseStartup(startupAssembly.GetName().Name)
-               .Build()
-               .Services;
+            try
+            {
+                return WebHost.CreateDefaultBuilder()
+                   .UseStartup(startupAssembly.GetName().Name)
+                   .Build()
+                   .Services;
+            }
+            catch
+            {
+                var serviceProvider = HostingApplication.GetServiceProvider(startupAssembly);
+
+                if (serviceProvider != null)
+                {
+                    return serviceProvider;
+                }
+
+                throw;
+            }
         }
 
         private static bool TryGetCustomHost<THost>(

--- a/test/Swashbuckle.AspNetCore.Cli.Test/Swashbuckle.AspNetCore.Cli.Test.csproj
+++ b/test/Swashbuckle.AspNetCore.Cli.Test/Swashbuckle.AspNetCore.Cli.Test.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\WebSites\Basic\Basic.csproj" />
     <ProjectReference Include="..\..\src\Swashbuckle.AspNetCore.Cli\Swashbuckle.AspNetCore.Cli.csproj" />
   </ItemGroup>
 

--- a/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
+++ b/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
@@ -1,0 +1,40 @@
+﻿using System.IO;
+using System.Text.Json;
+using Xunit;
+
+namespace Swashbuckle.AspNetCore.Cli.Test
+{
+    public class ToolTests
+    {
+        [Fact]
+        public void Throws_When_Startup_Assembly_Does_Not_Exist()
+        {
+            var args = new string[] { "tofile", "--output", "swagger.json", "--serializeasv2", "./does_not_exist.dll", "v1" };
+            var program = new Program(args);
+            Assert.Throws<FileNotFoundException>(() => program.Run(args));
+        }
+
+        [Fact]
+        public void Can_Generate_Swagger_Json()
+        {
+            var dir = Directory.CreateDirectory(Path.Join(Path.GetTempPath(), Path.GetRandomFileName()));
+            try
+            {
+                var args = new string[] { "tofile", "--output", $"{dir}/swagger.json", "--serializeasv2", $"{Directory.GetCurrentDirectory()}/basic.dll", "v1" };
+                var program = new Program(args);
+                Assert.Equal(0, program.Run(args));
+
+                using var document = JsonDocument.Parse(File.ReadAllText(Path.Combine(dir.FullName, "swagger.json")));
+
+                // verify one of the endpoints
+                var paths = document.RootElement.GetProperty("paths");
+                var productsPath = paths.GetProperty("/products");
+                Assert.True(productsPath.TryGetProperty("post", out _));
+            }
+            finally
+            {
+                dir.Delete(true);
+            }
+        }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
+++ b/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
@@ -10,8 +10,7 @@ namespace Swashbuckle.AspNetCore.Cli.Test
         public void Throws_When_Startup_Assembly_Does_Not_Exist()
         {
             var args = new string[] { "tofile", "--output", "swagger.json", "--serializeasv2", "./does_not_exist.dll", "v1" };
-            var program = new Program(args);
-            Assert.Throws<FileNotFoundException>(() => program.Run(args));
+            Assert.Throws<FileNotFoundException>(() => Program.Main(args));
         }
 
         [Fact]
@@ -21,8 +20,7 @@ namespace Swashbuckle.AspNetCore.Cli.Test
             try
             {
                 var args = new string[] { "tofile", "--output", $"{dir}/swagger.json", "--serializeasv2", $"{Directory.GetCurrentDirectory()}/basic.dll", "v1" };
-                var program = new Program(args);
-                Assert.Equal(0, program.Run(args));
+                Assert.Equal(0, Program.Main(args));
 
                 using var document = JsonDocument.Parse(File.ReadAllText(Path.Combine(dir.FullName, "swagger.json")));
 


### PR DESCRIPTION
- The HostFactoryResolver is [shared source](https://github.com/dotnet/runtime/blob/7ed5a67c0bbb48bdce3cfd962e333c8f7db047a4/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs) that is used by tools to resolve the entry point and service provider from applications that use Microsoft.Extensions.Hosting. It has been updated to handle a couple of new patterns introduced in .NET 6 and this change uses it as a fallback after detecting the other patterns. I've copied the source into this project since I didn't want to add a new nuget feed as a requirement to build this application. We'll need to keep this file in sync if there are changes.
- I had to make changes to make the shared source support C# 7.3 (and remove nullable support). I'd prefer to fix it so that the project targeted a newer C# version but I didn't want to introduce new requirements for building the repository.
- Introduce HostingApplication as a way to abstract how the IServiceProvider is retrieved when there's no special entry point.

Fixes https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2145

PS: I should probably add some tests, but I wasn't sure where to do so