### PR TITLE
Nullable strings showing string null in examples

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/OpenApiAnyFactory.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/OpenApiAnyFactory.cs
@@ -44,6 +44,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private static IOpenApiAny CreateFromJsonElement(JsonElement jsonElement)
         {
+            if (jsonElement.ValueKind == JsonValueKind.Null)
+                return new OpenApiNull();
+
             if (jsonElement.ValueKind == JsonValueKind.True || jsonElement.ValueKind == JsonValueKind.False)
                 return new OpenApiBoolean(jsonElement.GetBoolean());
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
@@ -48,7 +48,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             var exampleNode = fieldOrPropertyNode.SelectSingleNode("example");
             if (exampleNode != null)
             {
-                var exampleAsJson = (schema.ResolveType(context.SchemaRepository) == "string")
+                var exampleAsJson = (schema.ResolveType(context.SchemaRepository) == "string") && !exampleNode.Value.Equals("null")
                     ? $"\"{exampleNode.InnerXml}\""
                     : exampleNode.InnerXml;
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/XmlAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/XmlAnnotatedType.cs
@@ -58,6 +58,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public Guid GuidProperty { get; set; }
 
         /// <summary>
+        /// Summary for Nullable StringProperty
+        /// </summary>
+        /// <example>null</example>
+        public string NullableStringProperty { get; set; }
+
+        /// <summary>
         /// Summary for StringProperty
         /// </summary>
         /// <example>Example for StringProperty</example>

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/XmlAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/XmlAnnotatedType.cs
@@ -58,10 +58,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public Guid GuidProperty { get; set; }
 
         /// <summary>
-        /// Summary for Nullable StringProperty
+        /// Summary for Nullable StringPropertyWithNullExample
         /// </summary>
         /// <example>null</example>
-        public string NullableStringProperty { get; set; }
+        public string StringPropertyWithNullExample { get; set; }
 
         /// <summary>
         /// Summary for StringProperty

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/OpenApiAnyFactoryTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/OpenApiAnyFactoryTests.cs
@@ -27,6 +27,18 @@
         }
 
         [Theory]
+        [InlineData("null", typeof(OpenApiNull), null)]
+        public void CreateFromJson_NullType(string json, Type expectedType, object expectedValue)
+        {
+            var openApiAnyObject = OpenApiAnyFactory.CreateFromJson(json);
+            Assert.NotNull(openApiAnyObject);
+            Assert.Equal(expectedType, openApiAnyObject.GetType());
+            Assert.Equal(AnyType.Null, openApiAnyObject.AnyType);
+            var valueProperty = expectedType.GetProperty("Value");
+            Assert.Equal(expectedValue, valueProperty);
+        }
+
+        [Theory]
         [InlineData("[1,2]", typeof(OpenApiInteger), 1, 2)]
         [InlineData("[4294877294,4294877295]", typeof(OpenApiLong), 4294877294L, 4294877295L)]
         [InlineData("[1.5,-1.5]", typeof(OpenApiFloat), 1.5f, -1.5f)]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/OpenApiAnyFactoryTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/OpenApiAnyFactoryTests.cs
@@ -26,16 +26,17 @@
             Assert.Equal(expectedValue, actualValue);
         }
 
-        [Theory]
-        [InlineData("null", typeof(OpenApiNull), null)]
-        public void CreateFromJson_NullType(string json, Type expectedType, object expectedValue)
+        [Fact]
+        public void CreateFromJson_NullType()
         {
-            var openApiAnyObject = OpenApiAnyFactory.CreateFromJson(json);
+            var expectedType = typeof(OpenApiNull);
+
+            var openApiAnyObject = OpenApiAnyFactory.CreateFromJson("null");
             Assert.NotNull(openApiAnyObject);
             Assert.Equal(expectedType, openApiAnyObject.GetType());
             Assert.Equal(AnyType.Null, openApiAnyObject.AnyType);
             var valueProperty = expectedType.GetProperty("Value");
-            Assert.Equal(expectedValue, valueProperty);
+            Assert.Null(valueProperty);
         }
 
         [Theory]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.xml
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.xml
@@ -127,6 +127,12 @@
             </summary>
             <example>d3966535-2637-48fa-b911-e3c27405ee09</example>
         </member>
+        <member name="P:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedType.NullableStringProperty">
+            <summary>
+            Summary for Nullable StringProperty
+            </summary>
+            <example>null</example>
+        </member>
         <member name="P:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedType.StringProperty">
             <summary>
             Summary for StringProperty

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.xml
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.xml
@@ -127,9 +127,9 @@
             </summary>
             <example>d3966535-2637-48fa-b911-e3c27405ee09</example>
         </member>
-        <member name="P:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedType.NullableStringProperty">
+        <member name="P:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlAnnotatedType.StringPropertyWithNullExample">
             <summary>
-            Summary for Nullable StringProperty
+            Summary for Nullable StringPropertyWithNullExample
             </summary>
             <example>null</example>
         </member>

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
@@ -66,7 +66,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.GuidProperty), "string", "\"d3966535-2637-48fa-b911-e3c27405ee09\"")]
         [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.StringProperty), "string", "\"Example for StringProperty\"")]
         [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.ObjectProperty), "object", "{\n  \"prop1\": 1,\n  \"prop2\": \"foobar\"\n}")]
-        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.NullableStringProperty), "string", "null")]
+        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.StringPropertyWithNullExample), "string", "null")]
         [UseInvariantCulture]
         public void Apply_SetsExample_FromPropertyExampleTag(
             Type declaringType,

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
@@ -66,6 +66,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.GuidProperty), "string", "\"d3966535-2637-48fa-b911-e3c27405ee09\"")]
         [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.StringProperty), "string", "\"Example for StringProperty\"")]
         [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.ObjectProperty), "object", "{\n  \"prop1\": 1,\n  \"prop2\": \"foobar\"\n}")]
+        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.NullableStringProperty), "string", "null")]
         [UseInvariantCulture]
         public void Apply_SetsExample_FromPropertyExampleTag(
             Type declaringType,


### PR DESCRIPTION
Addresses a reversion in closed issue:
- https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/1768

### Comments

XML Comments for String properties with <example> tags that contain null were showing the string "null" 

For the string property Subtitle:
```C#
        /// <summary>
        /// The Subtitle of the book
        /// </summary>
        /// <example>null</example>
        public string Subtitle { get; set; }
```

Expected:
```json
{
  "generatedAt": "2021-06-28T02:12:19.2734596Z",
  "id": 419200,
  "title": "The Moonstone",
  "subtitle": null
}

```
Actual:
```json
{
  "generatedAt": "2021-06-28T02:12:19.2734596Z",
  "id": 419200,
  "title": "The Moonstone",
  "subtitle": "null"
}
```

This was initially fixed in PR https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/1866 but broke again in 6.0.1 when swagger-ui fixed a bug where it was being passed a string "null" and turning it into a "null" value. (See https://github.com/swagger-api/swagger-ui/pull/6872)

Please find tests and bug fixes included.