### PR TITLE
Fixed nullabillity problems with dictionaries

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
@@ -58,6 +58,31 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             return false;
         }
 
+        public static bool IsDictionaryValueNonNullable(this MemberInfo memberInfo)
+        {
+            var memberType = memberInfo.MemberType == MemberTypes.Field
+                ? ((FieldInfo)memberInfo).FieldType
+                : ((PropertyInfo)memberInfo).PropertyType;
+
+            if (memberType.IsValueType) return false;
+
+            var nullableAttribute = memberInfo.GetNullableAttribute();
+
+            if (nullableAttribute == null)
+            {
+                return memberInfo.GetNullableFallbackValue();
+            }
+
+            if (nullableAttribute.GetType().GetField(NullableFlagsFieldName) is FieldInfo field &&
+                field.GetValue(nullableAttribute) is byte[] flags &&
+                flags.Length == 3 && flags[2] == 1)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         private static object GetNullableAttribute(this MemberInfo memberInfo)
         {
             var nullableAttribute = memberInfo.GetCustomAttributes()

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -85,6 +85,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     schema.Deprecated = true;
                 }
 
+                // NullableAttribute behaves diffrently for Dictionaries
+                if (modelType.IsGenericType && modelType.GetGenericTypeDefinition() == typeof(Dictionary<,>))
+                {
+                    schema.AdditionalProperties.Nullable = !memberInfo.IsDictionaryValueNonNullable();
+                }
+
                 schema.ApplyValidationAttributes(customAttributes);
 
                 ApplyFilters(schema, modelType, schemaRepository, memberInfo: memberInfo);

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -491,7 +491,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.NotNull(schema.OneOf[0].Reference);
             var baseSchema = schemaRepository.Schemas[schema.OneOf[0].Reference.Id];
             Assert.Equal("object", baseSchema.Type);
-            Assert.Equal(new[] { "BaseProperty"}, baseSchema.Properties.Keys);
+            Assert.Equal(new[] { "BaseProperty" }, baseSchema.Properties.Keys);
             // The first sub type schema
             Assert.NotNull(schema.OneOf[1].Reference);
             var subType1Schema = schemaRepository.Schemas[schema.OneOf[1].Reference.Id];
@@ -566,9 +566,33 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableDictionaryWithNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableDictionaryWithNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableDictionaryWithNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableDictionaryWithNullableContent), true, true)]
+        public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations(
+            Type declaringType,
+            string propertyName,
+            bool expectedNullableProperty,
+            bool expectedNullableContent)
+        {
+            var subject = Subject(
+                configureGenerator: c => c.SupportNonNullableReferenceTypes = true
+            );
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = subject.GenerateSchema(declaringType, schemaRepository);
+
+            var propertySchema = schemaRepository.Schemas[referenceSchema.Reference.Id].Properties[propertyName];
+            var contentSchema = schemaRepository.Schemas[referenceSchema.Reference.Id].Properties[propertyName].AdditionalProperties;
+            Assert.Equal(expectedNullableProperty, propertySchema.Nullable);
+            Assert.Equal(expectedNullableContent, contentSchema.Nullable);
+        }
+
+        [Theory]
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.SubTypeWithOneNullableContent), nameof(TypeWithNullableContext.NullableString), true)]
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContext.NonNullableString), false)]
-        public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations(
+        public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypesInDictionary_NullableAttribute_Compiler_Optimizations_Situations(
             Type declaringType,
             string subType,
             string propertyName,
@@ -584,7 +608,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var propertySchema = schemaRepository.Schemas[subType].Properties[propertyName];
             Assert.Equal(expectedNullable, propertySchema.Nullable);
         }
-
 
         [Fact]
         public void GenerateSchema_HandlesTypesWithNestedTypes()
@@ -719,7 +742,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var referenceSchema = Subject().GenerateSchema(typeof(JsonPropertyNameAnnotatedType), schemaRepository);
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal( new[] { "string-with-json-property-name" }, schema.Properties.Keys.ToArray());
+            Assert.Equal(new[] { "string-with-json-property-name" }, schema.Properties.Keys.ToArray());
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
@@ -15,6 +15,11 @@ namespace Swashbuckle.AspNetCore.TestSupport
         public List<SubTypeWithOneNullableContent>? NullableList { get; set; }
         public List<SubTypeWithOneNonNullableContent> NonNullableList { get; set; } = default!;
 
+        public Dictionary<string, string>? NullableDictionaryWithNonNullableContent { get; set; }
+        public Dictionary<string, string> NonNullableDictionaryWithNonNullableContent { get; set; } = default!;
+        public Dictionary<string, string?> NonNullableDictionaryWithNullableContent { get; set; } = default!;
+        public Dictionary<string, string?>? NullableDictionaryWithNullableContent { get; set; }
+
         public class SubTypeWithOneNullableContent
         {
             public string? NullableString { get; set; }


### PR DESCRIPTION
This PR fixes nullabillity issues with Dictionaries like:

```
        public Dictionary<string, string>? NullableDictionaryWithNonNullableContent { get; set; }
        public Dictionary<string, string> NonNullableDictionaryWithNonNullableContent { get; set; } = default!;
        public Dictionary<string, string?> NonNullableDictionaryWithNullableContent { get; set; } = default!;
        public Dictionary<string, string?>? NullableDictionaryWithNullableContent { get; set; }
```

Fixes #1849
