### PR TITLE
Support setting operation IDs from EndpointName metadata

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
@@ -71,7 +71,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 #if (!NETSTANDARD2_0)
             return
                 actionDescriptor.AttributeRouteInfo?.Name
-                ?? (actionDescriptor.EndpointMetadata.FirstOrDefault(m => m is EndpointNameMetadata) as EndpointNameMetadata)?.EndpointName;
+                ?? (actionDescriptor.EndpointMetadata.FirstOrDefault(m => m is IEndpointNameMetadata) as IEndpointNameMetadata)?.EndpointName;
 #else
             return actionDescriptor.AttributeRouteInfo?.Name;
 #endif

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi.Models;
+using Microsoft.AspNetCore.Routing;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
@@ -61,7 +62,19 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private string DefaultOperationIdSelector(ApiDescription apiDescription)
         {
-            return apiDescription.ActionDescriptor.AttributeRouteInfo?.Name;
+            var actionDescriptor = apiDescription.ActionDescriptor;
+
+            // Resolve the operation ID from the route name and fallback to the
+            // endpoint name if no route name is available. This allows us to
+            // generate operation IDs for endpoints that are defined using
+            // minimal APIs.
+#if (!NETSTANDARD2_0)
+            return
+                actionDescriptor.AttributeRouteInfo?.Name
+                ?? (actionDescriptor.EndpointMetadata.FirstOrDefault(m => m is EndpointNameMetadata) as EndpointNameMetadata)?.EndpointName;
+#else
+            return actionDescriptor.AttributeRouteInfo?.Name;
+#endif
         }
 
         private IList<string> DefaultTagsSelector(ApiDescription apiDescription)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
-using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.OpenApi.Models;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
@@ -84,11 +84,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SetsOperationIdToEndpointName_IfActionHasEndpointNameMetadata()
         {
             var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));
-            var actionDescriptor = new ControllerActionDescriptor
+            var actionDescriptor = new ActionDescriptor
             {
-                ControllerTypeInfo = methodInfo.DeclaringType.GetTypeInfo(),
-                ControllerName = methodInfo.DeclaringType.Name,
-                MethodInfo = methodInfo,
                 EndpointMetadata = new List<object>() { new EndpointNameMetadata("SomeEndpointName") },
                 RouteValues = new Dictionary<string, string>
                 {

--- a/test/Swashbuckle.AspNetCore.TestSupport/ApiExplorer/ApiDescriptionFactory.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/ApiExplorer/ApiDescriptionFactory.cs
@@ -12,6 +12,7 @@ namespace Swashbuckle.AspNetCore.TestSupport
     public static class ApiDescriptionFactory
     {
         public static ApiDescription Create(
+            ActionDescriptor actionDescriptor,
             MethodInfo methodInfo,
             string groupName = "v1",
             string httpMethod = "POST",
@@ -20,8 +21,6 @@ namespace Swashbuckle.AspNetCore.TestSupport
             IEnumerable<ApiRequestFormat> supportedRequestFormats = null,
             IEnumerable<ApiResponseType> supportedResponseTypes = null)
         {
-            var actionDescriptor = CreateActionDescriptor(methodInfo);
-
             var apiDescription = new ApiDescription
             {
                 ActionDescriptor = actionDescriptor,
@@ -72,6 +71,30 @@ namespace Swashbuckle.AspNetCore.TestSupport
             }
 
             return apiDescription;
+        }
+
+        public static ApiDescription Create(
+            MethodInfo methodInfo,
+            string groupName = "v1",
+            string httpMethod = "POST",
+            string relativePath = "resoure",
+            IEnumerable<ApiParameterDescription> parameterDescriptions = null,
+            IEnumerable<ApiRequestFormat> supportedRequestFormats = null,
+            IEnumerable<ApiResponseType> supportedResponseTypes = null)
+        {
+
+            var actionDescriptor = CreateActionDescriptor(methodInfo);
+
+            return Create(
+                actionDescriptor,
+                methodInfo,
+                groupName,
+                httpMethod,
+                relativePath,
+                parameterDescriptions,
+                supportedRequestFormats,
+                supportedResponseTypes
+            );
         }
 
         public static ApiDescription Create<TController>(


### PR DESCRIPTION
Fixes https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2165.

Part of https://github.com/dotnet/aspnetcore/issues/34514.