### PR TITLE
AllOf-Support for Interface-Types

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
@@ -35,6 +35,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             target.SchemaIdSelector = source.SchemaIdSelector;
             target.IgnoreObsoleteProperties = source.IgnoreObsoleteProperties;
             target.UseAllOfForInheritance = source.UseAllOfForInheritance;
+            target.IgnoreAllOfSubTypesSelector = source.IgnoreAllOfSubTypesSelector;
             target.UseOneOfForPolymorphism = source.UseOneOfForPolymorphism;
             target.SubTypesSelector = source.SubTypesSelector;
             target.DiscriminatorNameSelector = source.DiscriminatorNameSelector;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -218,9 +218,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// incorporate properties from the base class instead of defining those properties inline.
         /// </summary>
         /// <param name="swaggerGenOptions"></param>
-        public static void UseAllOfForInheritance(this SwaggerGenOptions swaggerGenOptions)
+        /// <param name="ignoreAllOfSubTypesSelector">When set true, SubTypesSelector won't be used for allOf-information but just for anyOf</param>
+        public static void UseAllOfForInheritance(this SwaggerGenOptions swaggerGenOptions, bool ignoreAllOfSubTypesSelector = false)
         {
             swaggerGenOptions.SchemaGeneratorOptions.UseAllOfForInheritance = true;
+            swaggerGenOptions.SchemaGeneratorOptions.IgnoreAllOfSubTypesSelector = ignoreAllOfSubTypesSelector;
         }
 
         /// <summary>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -398,11 +398,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             if (dataContract.UnderlyingType.IsInterface)
             {
-                var baseTypes = dataContract.UnderlyingType.GetInterfaces()
+                var allInterfaces = dataContract.UnderlyingType.GetInterfaces();
+                var baseTypes = allInterfaces
+                    //Only respect the top most interfaces
+                    .Except(allInterfaces.SelectMany(t => t.GetInterfaces()))
                     //Do NOT exclude unlisted types, since the current behavior just doesn't work for interfaces
                     //Any better ideas here?
                     //.Where(t => _generatorOptions.SubTypesSelector(t).Contains(dataContract.UnderlyingType))
-                    ;
+                ;
 
                 if (!baseTypes.Any()) { return false; }
                 baseTypeDataContracts = baseTypes.Select(t => GetDataContractFor(t));

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.OpenApi.Models;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -7,9 +10,6 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.OpenApi.Models;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
@@ -402,10 +402,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 var baseTypes = allInterfaces
                     //Only respect the top most interfaces
                     .Except(allInterfaces.SelectMany(t => t.GetInterfaces()))
-                    //Do NOT exclude unlisted types, since the current behavior just doesn't work for interfaces
-                    //Any better ideas here?
-                    //.Where(t => _generatorOptions.SubTypesSelector(t).Contains(dataContract.UnderlyingType))
                 ;
+
+                if (!_generatorOptions.IgnoreAllOfSubTypesSelector) { baseTypes = baseTypes.Where(t => _generatorOptions.SubTypesSelector(t).Contains(dataContract.UnderlyingType)); }
 
                 if (!baseTypes.Any()) { return false; }
                 baseTypeDataContracts = baseTypes.Select(t => GetDataContractFor(t));
@@ -415,7 +414,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             {
                 var baseType = dataContract.UnderlyingType.BaseType;
 
-                if (baseType == null || baseType == typeof(object) || !_generatorOptions.SubTypesSelector(baseType).Contains(dataContract.UnderlyingType))
+                if (baseType == null || baseType == typeof(object) || (!_generatorOptions.IgnoreAllOfSubTypesSelector && !_generatorOptions.SubTypesSelector(baseType).Contains(dataContract.UnderlyingType)))
                     return false;
 
                 baseTypeDataContracts = new[] { GetDataContractFor(baseType) };

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
@@ -27,6 +27,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public bool UseAllOfForInheritance { get; set; }
 
+        public bool IgnoreAllOfSubTypesSelector { get; set; }
+
         public bool UseOneOfForPolymorphism { get; set; }
 
         public Func<Type, IEnumerable<Type>> SubTypesSelector { get; set; }
@@ -54,7 +56,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private IEnumerable<Type> DefaultSubTypesSelector(Type baseType)
         {
-            return baseType.Assembly.GetTypes().Where(type => type.IsSubclassOf(baseType));
+            //This would not change to current logic - but I guess my approach is ok for every case?
+            //return baseType.Assembly.GetTypes().Where(type => type.IsInterface ? type.IsAssignableTo(baseType) : type.IsSubclassOf(baseType));
+            return baseType.Assembly.GetTypes().Where(type => type.IsAssignableTo(baseType));
         }
 
         private string DefaultDiscriminatorNameSelector(Type baseType)


### PR DESCRIPTION
Using this PR Swashbuckle is able to use AllOf for interface types.

I think the `_generatorOptions.SubTypesSelector` is not required, what do you think? It is related to this issue and I finally found the time to analyse it: https://github.com/domaindrivendev/Swashbuckle.WebApi/issues/1409. I'd love to see this getting merged since I'd like to stay with the head.