### PR TITLE
Change how IsRequired for parameter descriptions work

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiParameterDescriptionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiParameterDescriptionExtensions.cs
@@ -20,9 +20,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public static bool IsRequiredParameter(this ApiParameterDescription apiParameter)
         {
+            // From the OpenAPI spec:
+            // If the parameter location is "path", this property is REQUIRED and its value MUST be true.
+            if (apiParameter.IsFromPath())
+            {
+                return true;
+            }
+
             // This is the default logic for IsRequired
-            bool IsRequired() => apiParameter.IsFromPath() ||
-                                 apiParameter.CustomAttributes().Any(attr => RequiredAttributeTypes.Contains(attr.GetType()));
+            bool IsRequired() => apiParameter.CustomAttributes().Any(attr => RequiredAttributeTypes.Contains(attr.GetType()));
 
             // This is to keep compatibility with MVC controller logic that has existed in the past
             if (apiParameter.ParameterDescriptor is ControllerParameterDescriptor)
@@ -33,7 +39,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             // For non-controllers, prefer the IsRequired flag if we're not on netstandard 2.0, otherwise fallback to the default logic.
             return
 #if !NETSTANDARD2_0
-            apiParameter.IsFromPath() || apiParameter.IsRequired;
+            apiParameter.IsRequired;
 #else
             IsRequired();
 #endif

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiParameterDescriptionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiParameterDescriptionExtensions.cs
@@ -33,7 +33,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             // For non-controllers, prefer the IsRequired flag if we're not on netstandard 2.0, otherwise fallback to the default logic.
             return
 #if !NETSTANDARD2_0
-            apiParameter.IsRequired;
+            apiParameter.IsFromPath() || apiParameter.IsRequired;
 #else
             IsRequired();
 #endif

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -196,8 +195,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 ? ParameterLocationMap[apiParameter.Source]
                 : ParameterLocation.Query;
 
-            var isRequired = (apiParameter.IsFromPath())
-                || apiParameter.CustomAttributes().Any(attr => RequiredAttributeTypes.Contains(attr.GetType()));
+            var isRequired = apiParameter.IsRequiredParameter();
 
             var schema = (apiParameter.ModelMetadata != null)
                 ? GenerateSchema(
@@ -300,7 +298,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             var contentTypes = InferRequestContentTypes(apiDescription);
 
-            var isRequired = bodyParameter.CustomAttributes().Any(attr => RequiredAttributeTypes.Contains(attr.GetType()));
+            var isRequired = bodyParameter.IsRequiredParameter();
 
             var schema = GenerateSchema(
                 bodyParameter.ModelMetadata.ModelType,
@@ -389,7 +387,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
                 properties.Add(name, schema);
 
-                if (formParameter.IsFromPath() || formParameter.CustomAttributes().Any(attr => RequiredAttributeTypes.Contains(attr.GetType())))
+                if (formParameter.IsRequiredParameter())
                     requiredPropertyNames.Add(name);
             }
 
@@ -484,12 +482,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             { BindingSource.Query, ParameterLocation.Query },
             { BindingSource.Header, ParameterLocation.Header },
             { BindingSource.Path, ParameterLocation.Path }
-        };
-
-        private static readonly IEnumerable<Type> RequiredAttributeTypes = new[]
-        {
-            typeof(BindRequiredAttribute),
-            typeof(RequiredAttribute)
         };
 
         private static readonly Dictionary<string, string> ResponseDescriptionMap = new Dictionary<string, string>

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -249,38 +249,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void GetSwagger_SetsParameterRequired_IfParameterIsPath(bool isRequired)
-        {
-            void Execute(int id) { }
-
-            Action<int> action = Execute;
-
-            var actionDescriptor = new ActionDescriptor
-            {
-                RouteValues = new Dictionary<string, string>
-                {
-                    ["controller"] = "Foo",
-                }
-            };
-
-            var parameter = new ApiParameterDescription { Name = "id", Source = BindingSource.Path, IsRequired = isRequired };
-
-            var subject = Subject(
-                apiDescriptions: new[]
-                {
-                    ApiDescriptionFactory.Create(actionDescriptor, action.Method, groupName: "v1", httpMethod: "POST", relativePath: "resource", parameterDescriptions: new[]{ parameter }),
-                }
-            );
-
-            var document = subject.GetSwagger("v1");
-
-            Assert.True(document.Paths["/resource"].Operations[OperationType.Post].Parameters[0].Required);
-        }
-
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void GetSwagger_SetsParameterRequired_IfApiParameterDescriptionForBodyIsRequired(bool isRequired)
+        public void GetSwagger_SetsParameterRequired_ForNonControllerActionDescriptor_IfApiParameterDescriptionForBodyIsRequired(bool isRequired)
         {
             void Execute(object obj) { }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -1,16 +1,16 @@
-﻿using System.Linq;
+﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
+using System.Linq;
 using System.Text.Json;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Abstractions;
-using Microsoft.OpenApi.Models;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.OpenApi.Any;
-using Xunit;
+using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.TestSupport;
+using Xunit;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
@@ -35,7 +35,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
                     {
-                        [ "v1" ] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                        ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
                     }
                 }
             );
@@ -101,7 +101,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var document = subject.GetSwagger("v1");
 
-            Assert.Equal("SomeEndpointName", document.Paths["/resource"].Operations[OperationType.Post].OperationId);     
+            Assert.Equal("SomeEndpointName", document.Paths["/resource"].Operations[OperationType.Post].OperationId);
         }
 
 
@@ -244,6 +244,75 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(1, operation.Parameters.Count);
             Assert.Equal(expectedRequired, operation.Parameters.First().Required);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GetSwagger_SetsParameterRequired_IfApiParameterDescriptionForPathIsRequired(bool isRequired)
+        {
+            void Execute(int id) { }
+
+            Action<int> action = Execute;
+
+            var actionDescriptor = new ActionDescriptor
+            {
+                RouteValues = new Dictionary<string, string>
+                {
+                    ["controller"] = "Foo",
+                }
+            };
+
+            var parameter = new ApiParameterDescription { Name = "id", Source = BindingSource.Path, IsRequired = isRequired };
+
+            var subject = Subject(
+                apiDescriptions: new[]
+                {
+                    ApiDescriptionFactory.Create(actionDescriptor, action.Method, groupName: "v1", httpMethod: "POST", relativePath: "resource", parameterDescriptions: new[]{ parameter }),
+                }
+            );
+
+            var document = subject.GetSwagger("v1");
+
+            Assert.Equal(isRequired, document.Paths["/resource"].Operations[OperationType.Post].Parameters[0].Required);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GetSwagger_SetsParameterRequired_IfApiParameterDescriptionForBodyIsRequired(bool isRequired)
+        {
+            void Execute(object obj) { }
+
+            Action<object> action = Execute;
+
+            var actionDescriptor = new ActionDescriptor
+            {
+                RouteValues = new Dictionary<string, string>
+                {
+                    ["controller"] = "Foo",
+                }
+            };
+
+            var parameter = new ApiParameterDescription
+            {
+                Name = "obj",
+                Source = BindingSource.Body,
+                IsRequired = isRequired,
+                Type = typeof(object),
+                ModelMetadata = ModelMetadataFactory.CreateForParameter(action.Method.GetParameters()[0])
+            };
+
+            var subject = Subject(
+                apiDescriptions: new[]
+                {
+                    ApiDescriptionFactory.Create(actionDescriptor, action.Method, groupName: "v1", httpMethod: "POST", relativePath: "resource", parameterDescriptions: new[]{ parameter }),
+                }
+            );
+
+            var document = subject.GetSwagger("v1");
+
+            Assert.Equal(isRequired, document.Paths["/resource"].Operations[OperationType.Post].RequestBody.Required);
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -249,7 +249,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void GetSwagger_SetsParameterRequired_IfApiParameterDescriptionForPathIsRequired(bool isRequired)
+        public void GetSwagger_SetsParameterRequired_IfParameterIsPath(bool isRequired)
         {
             void Execute(int id) { }
 
@@ -274,7 +274,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var document = subject.GetSwagger("v1");
 
-            Assert.Equal(isRequired, document.Paths["/resource"].Operations[OperationType.Post].Parameters[0].Required);
+            Assert.True(document.Paths["/resource"].Operations[OperationType.Post].Parameters[0].Required);
         }
 
         [Theory]


### PR DESCRIPTION
- For non-controllers, change the logic to look for the IsRequired flag on the ApiParameterDescription instead of the fallback logic. This is to avoid potentially breaking existing behavior for controller based API descriptions. In theory, this logic could be changed for controllers since MVC does use that logic but that's a behavior change that would likely need to be opted into.

~TODO: Add tests.~