### PR TITLE
Add support for using <remarks> on schema XML comments

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
@@ -27,10 +27,18 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             var typeMemberName = XmlCommentsNodeNameHelper.GetMemberNameForType(type);
             var typeSummaryNode = _xmlNavigator.SelectSingleNode($"/doc/members/member[@name='{typeMemberName}']/summary");
+            var typeRemarkNode = _xmlNavigator.SelectSingleNode($"/doc/members/member[@name='{typeMemberName}']/remarks");
 
             if (typeSummaryNode != null)
             {
+                // Default to using <summary> for description for backwards compatibility
                 schema.Description = XmlCommentsTextHelper.Humanize(typeSummaryNode.InnerXml);
+
+                if (typeRemarkNode != null)
+                {
+                    schema.Title = schema.Description;
+                    schema.Description = XmlCommentsTextHelper.Humanize(typeRemarkNode.InnerXml); 
+                }
             }
         }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/XmlRemarkAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/XmlRemarkAnnotatedType.cs
@@ -1,0 +1,12 @@
+﻿namespace Swashbuckle.AspNetCore.SwaggerGen.Test
+{
+    /// <summary>
+    /// Summary for XmlRemarkAnnotatedType
+    /// </summary>
+    /// <remarks>
+    /// Remarks for XmlRemarkAnnotatedType
+    /// </remarks>
+    public class XmlRemarkAnnotatedType
+    {
+    }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.xml
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.xml
@@ -190,6 +190,14 @@
             Summary of DoubleNestedType.InnerType.Property
             </summary>
         </member>
+        <member name="T:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlRemarkAnnotatedType">
+            <summary>
+            Summary for XmlRemarkAnnotatedType
+            </summary>
+            <remarks>
+            Remarks for XmlRemarkAnnotatedType
+            </remarks>
+        </member>
         <member name="T:Swashbuckle.AspNetCore.SwaggerGen.Test.JsonSerializerTesting">
             <summary>
             For ad-hoc serializer testing

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
@@ -11,11 +11,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
     public class XmlCommentsSchemaFilterTests
     {
         [Theory]
-        [InlineData(typeof(XmlAnnotatedType), "Summary for XmlAnnotatedType")]
-        [InlineData(typeof(XmlAnnotatedType.NestedType), "Summary for NestedType")]
-        [InlineData(typeof(XmlAnnotatedGenericType<int, string>), "Summary for XmlAnnotatedGenericType")]
+        [InlineData(typeof(XmlAnnotatedType), null, "Summary for XmlAnnotatedType")]
+        [InlineData(typeof(XmlAnnotatedType.NestedType), null, "Summary for NestedType")]
+        [InlineData(typeof(XmlAnnotatedGenericType<int, string>), null, "Summary for XmlAnnotatedGenericType")]
+        [InlineData(typeof(XmlRemarkAnnotatedType), "Summary for XmlRemarkAnnotatedType", "Remarks for XmlRemarkAnnotatedType")]
         public void Apply_SetsDescription_FromTypeSummaryTag(
             Type type,
+            string expectedTitle,
             string expectedDescription)
         {
             var schema = new OpenApiSchema { };
@@ -23,6 +25,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Subject().Apply(schema, filterContext);
 
+            Assert.Equal(expectedTitle, schema.Title);
             Assert.Equal(expectedDescription, schema.Description);
         }
 


### PR DESCRIPTION
Currently, schema types always set the `Description` to match the `<summary>` XML comment. However, `OpenApiSchema` does have a `Title` field and in many other places, `Title=<summary>` and `Description=<remarks>`. This PR updates the schema filter to align with that. It does however, default to the current behavior if the `<remarks>` node is not present in the extracted comments.