### PR TITLE
Update 'MapSwagger' default behavior to match the default route pattern for 'UseSwagger'

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/DependencyInjection/SwaggerBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/DependencyInjection/SwaggerBuilderExtensions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.AspNetCore.Builder
 #if (!NETSTANDARD2_0)
         public static IEndpointRouteBuilder MapSwagger(
             this IEndpointRouteBuilder endpoints,
-            string pattern = "/swagger/{documentName}/swagger.json",
+            string pattern = "/swagger/{documentName}/swagger.{json|yaml}",
             Action<SwaggerEndpointOptions> setupAction = null)
         {
             if (!RoutePatternFactory.Parse(pattern).Parameters.Any(x => x.Name == "documentName"))


### PR DESCRIPTION
This updates the default pattern of `MapSwagger` to match the [default pattern](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/master/src/Swashbuckle.AspNetCore.Swagger/SwaggerOptions.cs#L19) that is used in `UseSwagger`. This allows YAML support to be enabled by default when using `MapSwagger` as it is in `UseSwagger`.