### PR TITLE
Add support for resolving conflicting actions using URL fragments

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSwaggerGeneratorOptions.cs
@@ -57,6 +57,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             target.SwaggerDocs = new Dictionary<string, OpenApiInfo>(source.SwaggerDocs);
             target.DocInclusionPredicate = source.DocInclusionPredicate;
             target.IgnoreObsoleteActions = source.IgnoreObsoleteActions;
+            target.ResolveConflictingActionsUsingFragments = source.ResolveConflictingActionsUsingFragments;
             target.ConflictingActionsResolver = source.ConflictingActionsResolver;
             target.OperationIdSelector = source.OperationIdSelector;
             target.TagsSelector = source.TagsSelector;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -46,6 +46,14 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Resolve conflicting actions by appending incrementing fragments to the path of the actions.
+        /// </summary>
+        public static void ResolveConflictingActionsUsingFragments(this SwaggerGenOptions swaggerGenOptions)
+        {
+            swaggerGenOptions.SwaggerGeneratorOptions.ResolveConflictingActionsUsingFragments = true;
+        }
+
+        /// <summary>
         /// Merge actions that have conflicting HTTP methods and paths (must be unique for Swagger 2.0)
         /// </summary>
         /// <param name="swaggerGenOptions"></param>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
@@ -31,6 +31,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public bool IgnoreObsoleteActions { get; set; }
 
+        public bool ResolveConflictingActionsUsingFragments { get; set; }
+
         public Func<IEnumerable<ApiDescription>, ApiDescription> ConflictingActionsResolver { get; set; }
 
         public Func<ApiDescription, string> OperationIdSelector { get; set; }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -636,6 +636,35 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
+        public void GetSwagger_SupportsOption_ResolveConflictingActionsUsingFragments()
+        {
+            var subject = Subject(
+                apiDescriptions: new[]
+                {
+                    ApiDescriptionFactory.Create<FakeController>(
+                        c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource"),
+
+                    ApiDescriptionFactory.Create<FakeController>(
+                        c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource")
+                },
+                options: new SwaggerGeneratorOptions
+                {
+                    SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                    {
+                        ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                    },
+                    ResolveConflictingActionsUsingFragments = true
+                }
+            );
+
+            var document = subject.GetSwagger("v1");
+
+            Assert.Equal(new[] { "/resource", "/resource#1" }, document.Paths.Keys.ToArray());
+            Assert.Equal(new[] { OperationType.Post }, document.Paths["/resource"].Operations.Keys);
+            Assert.Equal(new[] { OperationType.Post }, document.Paths["/resource#1"].Operations.Keys);
+        }
+
+        [Fact]
         public void GetSwagger_SupportsOption_ConflictingActionsResolver()
         {
             var subject = Subject(


### PR DESCRIPTION
I have several APIs that use the same URL and method but disambiguate based on the request content-type. This causes conflicts in the generated swagger document. The current pattern using `ConflictingActionsResolver` only allows you to choose which operation to use rather than providing a mechanism to support both. A common pattern for resolving this is to use URL fragments to force the key to be unique. One approach would be to use the operation ID as the fragment. The approach that I took here is to just use an incrementing index on conflicting actions. I added tests to ensure that it behaves as expected but I am certainly open to other approaches to disambiguating the paths. 