### PR TITLE
Fixed regression when looking for an operation id

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
@@ -71,7 +71,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 #if (!NETSTANDARD2_0)
             return
                 actionDescriptor.AttributeRouteInfo?.Name
-                ?? (actionDescriptor.EndpointMetadata.FirstOrDefault(m => m is IEndpointNameMetadata) as IEndpointNameMetadata)?.EndpointName;
+                ?? (actionDescriptor.EndpointMetadata?.FirstOrDefault(m => m is IEndpointNameMetadata) as IEndpointNameMetadata)?.EndpointName;
 #else
             return actionDescriptor.AttributeRouteInfo?.Name;
 #endif

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -104,6 +104,29 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal("SomeEndpointName", document.Paths["/resource"].Operations[OperationType.Post].OperationId);     
         }
 
+        [Fact]
+        public void GetSwagger_SetsOperationIdToNull_IfActionHasNoEndpointMetadata()
+        {
+            var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = null,
+                RouteValues = new Dictionary<string, string>
+                {
+                    ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
+                }
+            };
+            var subject = Subject(
+                apiDescriptions: new[]
+                {
+                    ApiDescriptionFactory.Create(actionDescriptor, methodInfo, groupName: "v1", httpMethod: "POST", relativePath: "resource"),
+                }
+            );
+
+            var document = subject.GetSwagger("v1");
+
+            Assert.Null(document.Paths["/resource"].Operations[OperationType.Post].OperationId);
+        }
 
         [Fact]
         public void GetSwagger_SetsDeprecated_IfActionHasObsoleteAttribute()


### PR DESCRIPTION
- Handle null EndpointMetadata
- Added test

Fixes https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2194