### PR TITLE
Update filter behavior to match MVC pattern

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
@@ -71,7 +71,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 #if (!NETSTANDARD2_0)
             return
                 actionDescriptor.AttributeRouteInfo?.Name
-                ?? (actionDescriptor.EndpointMetadata?.FirstOrDefault(m => m is IEndpointNameMetadata) as IEndpointNameMetadata)?.EndpointName;
+                ?? (actionDescriptor.EndpointMetadata?.LastOrDefault(m => m is IEndpointNameMetadata) as IEndpointNameMetadata)?.EndpointName;
 #else
             return actionDescriptor.AttributeRouteInfo?.Name;
 #endif


### PR DESCRIPTION
MVC uses `LastOrDefault` to pick the most recently inserted element.

https://github.com/dotnet/aspnetcore/blob/main/src/Mvc/Mvc.Core/src/Routing/ActionEndpointFactory.cs#L345-L347