### PR TITLE
Fix parsing of optional params in route

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiDescriptionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiDescriptionExtensions.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Controllers;
+using System.Text.RegularExpressions;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
@@ -50,7 +51,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         internal static string RelativePathSansQueryString(this ApiDescription apiDescription)
         {
-            return apiDescription.RelativePath?.Split('?').First();
+            return Regex.Split(apiDescription.RelativePath, @"\?(?!\})").First();
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiDescriptionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiDescriptionExtensions.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Controllers;
-using System.Text.RegularExpressions;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
@@ -47,11 +46,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             }
 
             customAttributes = Enumerable.Empty<object>();
-        }
-
-        internal static string RelativePathSansQueryString(this ApiDescription apiDescription)
-        {
-            return Regex.Split(apiDescription.RelativePath, @"\?(?!\})").First();
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -79,7 +79,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             var apiDescriptionsByPath = apiDescriptions
                 .OrderBy(_options.SortKeySelector)
-                .GroupBy(apiDesc => apiDesc.RelativePathSansQueryString());
+                .GroupBy(apiDesc => apiDesc.RelativePath);
 
             var paths = new OpenApiPaths();
             foreach (var group in apiDescriptionsByPath)
@@ -119,7 +119,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                         "Conflicting method/path combination \"{0} {1}\" for actions - {2}. " +
                         "Actions require a unique method/path combination for Swagger/OpenAPI 3.0. Use ConflictingActionsResolver as a workaround",
                         httpMethod,
-                        group.First().RelativePathSansQueryString(),
+                        group.First().RelativePath,
                         string.Join(",", group.Select(apiDesc => apiDesc.ActionDescriptor.DisplayName))));
 
                 var apiDescription = (group.Count() > 1) ? _options.ConflictingActionsResolver(group) : group.Single();

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -59,9 +59,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "GET", relativePath: "resource/{id?}"),
-
-                    ApiDescriptionFactory.Create<FakeController>(
-                        c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource/?param1"),
                     
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource/foo"),
@@ -79,7 +76,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal("V1", document.Info.Version);
             Assert.Equal("Test API", document.Info.Title);
-            Assert.Equal(new[] { "/resource/{id}", "/resource/{id?}", "/resource/", "/resource/foo" }, document.Paths.Keys.ToArray());
+            Assert.Equal(new[] { "/resource/{id}", "/resource/{id?}", "/resource/foo" }, document.Paths.Keys.ToArray());
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -49,6 +49,40 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
+        public void GetSwagger_GeneratesSwaggerDocument_ForApiDescriptionsWithVariousRelativePaths()
+        {
+            var subject = Subject(
+                apiDescriptions: new[]
+                {
+                    ApiDescriptionFactory.Create<FakeController>(
+                        c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource/{id}"),
+
+                    ApiDescriptionFactory.Create<FakeController>(
+                        c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "GET", relativePath: "resource/{id?}"),
+
+                    ApiDescriptionFactory.Create<FakeController>(
+                        c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource/?param1"),
+                    
+                    ApiDescriptionFactory.Create<FakeController>(
+                        c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource/foo"),
+                },
+                options: new SwaggerGeneratorOptions
+                {
+                    SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                    {
+                        ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                    }
+                }
+            );
+
+            var document = subject.GetSwagger("v1");
+
+            Assert.Equal("V1", document.Info.Version);
+            Assert.Equal("Test API", document.Info.Title);
+            Assert.Equal(new[] { "/resource/{id}", "/resource/{id?}", "/resource/", "/resource/foo" }, document.Paths.Keys.ToArray());
+        }
+
+        [Fact]
         public void GetSwagger_SetsOperationIdToNull_ByDefault()
         {
             var subject = Subject(


### PR DESCRIPTION
The current `RelativePathSansQueryString` method causes problems with the approach that minimal APIs use for setting an endpoint names.

With an endpoint like:

```csharp
app.MapGet("/bar/{foo?}", (string foo) => ...);
```

Will produce a `relativePath` that looks something like `/bar/{foo` which is incorrect.

To mitigate this, I used a negative lookahead regular expression to only split on the query string part and to ignore optional parameters.

`Regex.Split` is not as performant as a `string.Split` but I wasn't sure what other alternatives might be best here.

Is there a particular reason that we remove the query string part? There might be another alternative to approach here (e.g. removing the query string with the existing strategy in another codepath).