### PR TITLE
For STJ - don't set readonly if set via constructor

### DIFF
--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TypeWithPropertiesSetViaConstructor.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TypeWithPropertiesSetViaConstructor.cs
@@ -1,6 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
-namespace Swashbuckle.AspNetCore.Newtonsoft.Test
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
     public class TypeWithPropertiesSetViaConstructor
     {
@@ -12,7 +12,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 
         public int Id { get; }
 
-        [JsonProperty("Desc")]
+        [JsonPropertyName("Desc")]
         public string Description { get; }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -334,6 +334,18 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
+        public void GenerateSchema_DoesNotSetReadOnlyFlag_IfPropertyIsReadOnlyButCanBeSetViaConstructor()
+        {
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = Subject().GenerateSchema(typeof(TypeWithPropertiesSetViaConstructor), schemaRepository);
+
+            var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
+            Assert.False(schema.Properties["Id"].ReadOnly);
+            Assert.False(schema.Properties["Desc"].ReadOnly);
+        }
+
+        [Fact]
         public void GenerateSchema_SetsDefault_IfParameterHasDefaultValueAttribute()
         {
             var schemaRepository = new SchemaRepository();


### PR DESCRIPTION
It looks like STJ now supports deserialization of readonly properties that are set via constructor