### PR TITLE
Use IParameterInfoParameterDescriptor for parameter info

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiParameterDescriptionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiParameterDescriptionExtensions.cs
@@ -47,8 +47,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public static ParameterInfo ParameterInfo(this ApiParameterDescription apiParameter)
         {
-            var controllerParameterDescriptor = apiParameter.ParameterDescriptor as ControllerParameterDescriptor;
-            return controllerParameterDescriptor?.ParameterInfo;
+            var parameterDescriptor = apiParameter.ParameterDescriptor as
+#if NETCOREAPP2_2_OR_GREATER
+                Microsoft.AspNetCore.Mvc.Infrastructure.IParameterInfoParameterDescriptor;
+#else
+                ControllerParameterDescriptor;
+#endif
+
+            return parameterDescriptor?.ParameterInfo;
         }
 
         public static PropertyInfo PropertyInfo(this ApiParameterDescription apiParameter)

--- a/test/Swashbuckle.AspNetCore.TestSupport/ApiExplorer/ApiDescriptionFactory.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/ApiExplorer/ApiDescriptionFactory.cs
@@ -34,14 +34,21 @@ namespace Swashbuckle.AspNetCore.TestSupport
                 foreach (var parameter in parameterDescriptions)
                 {
                     // If the provided action has a matching parameter - use it to assign ParameterDescriptor & ModelMetadata
-                    var controllerParameterDescriptor = actionDescriptor.Parameters
-                        .OfType<ControllerParameterDescriptor>()
-                        .FirstOrDefault(parameterDescriptor => parameterDescriptor.Name == parameter.Name);
+                    parameter.ParameterDescriptor = actionDescriptor.Parameters
+                        .OfType<ParameterDescriptor>()
+                        .Where(parameterDescriptor => parameterDescriptor.Name == parameter.Name)
+                        .FirstOrDefault();
 
-                    if (controllerParameterDescriptor != null)
+                    var parameterDescriptorWithParameterInfo = parameter.ParameterDescriptor as
+#if NETCOREAPP2_2_OR_GREATER
+                        Microsoft.AspNetCore.Mvc.Infrastructure.IParameterInfoParameterDescriptor;
+#else
+                        ControllerParameterDescriptor;
+#endif
+
+                    if (parameterDescriptorWithParameterInfo != null)
                     {
-                        parameter.ParameterDescriptor = controllerParameterDescriptor;
-                        parameter.ModelMetadata = ModelMetadataFactory.CreateForParameter(controllerParameterDescriptor.ParameterInfo);
+                        parameter.ModelMetadata = ModelMetadataFactory.CreateForParameter(parameterDescriptorWithParameterInfo.ParameterInfo);
                     }
 
                     apiDescription.ParameterDescriptions.Add(parameter);


### PR DESCRIPTION
Use the `IParameterInfoParameterDescriptor` interface, where available, rather than `ControllerParameterDescriptor` so that parameter info is available on endpoints that are not MVC Controllers.

Relates to https://github.com/dotnet/aspnetcore/issues/36438.
