### PR TITLE
Remove constraints from route parameters in path

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiDescriptionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiDescriptionExtensions.cs
@@ -47,5 +47,26 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             customAttributes = Enumerable.Empty<object>();
         }
+
+        internal static string RelativePathSansParameterConstraints(this ApiDescription apiDescription)
+        {
+            var routeTemplate = apiDescription.RelativePath;
+            
+            while (routeTemplate.IndexOfAny(new[] { ':', '=', '?' }) != -1)
+            {
+                var startIndex = routeTemplate.IndexOfAny(new[] { ':', '=', '?' }) ;
+                var tokenStart = startIndex + 1;
+                findEndBrace:
+                    var endIndex = routeTemplate.IndexOf('}', tokenStart);
+                    if (endIndex < routeTemplate.Length - 1 && routeTemplate[endIndex + 1] == '}')
+                    {
+                        tokenStart = endIndex + 2;
+                        goto findEndBrace;
+                    }
+                routeTemplate = routeTemplate.Remove(startIndex, endIndex - startIndex);
+            }
+            
+            return routeTemplate;
+        }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiDescriptionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiDescriptionExtensions.cs
@@ -52,10 +52,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             var routeTemplate = apiDescription.RelativePath;
             
+            // We want to filter out qualifiers that indicate a constract (":")
+            // a default value ("=") or an optional parameter ("?")
             while (routeTemplate.IndexOfAny(new[] { ':', '=', '?' }) != -1)
             {
                 var startIndex = routeTemplate.IndexOfAny(new[] { ':', '=', '?' }) ;
                 var tokenStart = startIndex + 1;
+                // Only find a single instance of a '}' after our start
+                // character to avoid capturing escaped curly braces
+                // in a regular expression constraint
                 findEndBrace:
                     var endIndex = routeTemplate.IndexOf('}', tokenStart);
                     if (endIndex < routeTemplate.Length - 1 && routeTemplate[endIndex + 1] == '}')
@@ -63,6 +68,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                         tokenStart = endIndex + 2;
                         goto findEndBrace;
                     }
+
                 routeTemplate = routeTemplate.Remove(startIndex, endIndex - startIndex);
             }
             

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -79,7 +79,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             var apiDescriptionsByPath = apiDescriptions
                 .OrderBy(_options.SortKeySelector)
-                .GroupBy(apiDesc => apiDesc.RelativePath);
+                .GroupBy(apiDesc => apiDesc.RelativePathSansParameterConstraints());
 
             var paths = new OpenApiPaths();
             foreach (var group in apiDescriptionsByPath)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -48,20 +48,22 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal(new[] { OperationType.Post, OperationType.Get }, document.Paths["/resource"].Operations.Keys);
         }
 
-        [Fact]
-        public void GetSwagger_GeneratesSwaggerDocument_ForApiDescriptionsWithVariousRelativePaths()
+        [Theory]
+        [InlineData("resources/{id}", "/resources/{id}")]
+        [InlineData("{category}/{product?}/{sku}", "/{category}/{product}/{sku}")]
+        [InlineData("{area=Home}/{controller:required}/{id=0:int}", "/{area}/{controller}/{id}")]
+        [InlineData("{category}/product/{group?}", "/{category}/product/{group}")]
+        [InlineData("{category:int}/product/{group:range(10, 20)?}", "/{category}/product/{group}")]
+        [InlineData("{person:int}/{ssn:regex(^\\d{{3}}-\\d{{2}}-\\d{{4}}$)}", "/{person}/{ssn}")]
+        [InlineData("{person:int}/{ssn:regex(^(?=.*kind)(?=.*good).*$)}", "/{person}/{ssn}")]
+        public void GetSwagger_GeneratesSwaggerDocument_ForApiDescriptionsWithConstrainedRelativePaths(string routeTemplate, string processedRouteTemplate)
         {
             var subject = Subject(
                 apiDescriptions: new[]
                 {
                     ApiDescriptionFactory.Create<FakeController>(
-                        c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource/{id}"),
+                        c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: routeTemplate),
 
-                    ApiDescriptionFactory.Create<FakeController>(
-                        c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "GET", relativePath: "resource/{id?}"),
-                    
-                    ApiDescriptionFactory.Create<FakeController>(
-                        c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource/foo"),
                 },
                 options: new SwaggerGeneratorOptions
                 {
@@ -76,7 +78,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal("V1", document.Info.Version);
             Assert.Equal("Test API", document.Info.Title);
-            Assert.Equal(new[] { "/resource/{id}", "/resource/{id?}", "/resource/foo" }, document.Paths.Keys.ToArray());
+            Assert.Equal(new[] { processedRouteTemplate }, document.Paths.Keys.ToArray());
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -56,13 +56,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [InlineData("{category:int}/product/{group:range(10, 20)?}", "/{category}/product/{group}")]
         [InlineData("{person:int}/{ssn:regex(^\\d{{3}}-\\d{{2}}-\\d{{4}}$)}", "/{person}/{ssn}")]
         [InlineData("{person:int}/{ssn:regex(^(?=.*kind)(?=.*good).*$)}", "/{person}/{ssn}")]
-        public void GetSwagger_GeneratesSwaggerDocument_ForApiDescriptionsWithConstrainedRelativePaths(string routeTemplate, string processedRouteTemplate)
+        public void GetSwagger_GeneratesSwaggerDocument_ForApiDescriptionsWithConstrainedRelativePaths(string path, string expectedPath)
         {
             var subject = Subject(
                 apiDescriptions: new[]
                 {
                     ApiDescriptionFactory.Create<FakeController>(
-                        c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: routeTemplate),
+                        c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: path),
 
                 },
                 options: new SwaggerGeneratorOptions
@@ -78,7 +78,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal("V1", document.Info.Version);
             Assert.Equal("Test API", document.Info.Title);
-            Assert.Equal(new[] { processedRouteTemplate }, document.Paths.Keys.ToArray());
+            Assert.Equal(new[] { expectedPath }, document.Paths.Keys.ToArray());
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/36413.

This fix expands on the changes made in https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/2209.

Currently, the route constraints that are included in the route template path are included in the generated schema which breaks things like the `curl` command generated in the UI. This resolves that issue by stripping out constraints/qualifiers from the path.

Note that there is work tracked in https://github.com/dotnet/aspnetcore/issues/36525 to ensure that these route constraints show up in the schema.