### PR TITLE
Add method to configure Bearer authentication

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -24,6 +24,32 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Add Bearer authentication.
+        /// </summary>
+        /// <param name="bearerFormat">The Bearer token format. Defaults to "JWT".</param>
+        /// <param name="swaggerGenOptions"></param>
+        public static void AddBearerAuthentication(this SwaggerGenOptions swaggerGenOptions, string bearerFormat = "JWT")
+        {
+            swaggerGenOptions.AddSecurityDefinition("bearerAuth", new OpenApiSecurityScheme
+            {
+                Type = SecuritySchemeType.Http,
+                Scheme = "bearer",
+                BearerFormat = bearerFormat,
+                Description = "Authorization header using the Bearer scheme."
+            });
+            swaggerGenOptions.AddSecurityRequirement(new OpenApiSecurityRequirement
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "bearerAuth" }
+                    },
+                    new string[] {}
+                }
+            });
+        }
+
+        /// <summary>
         /// Provide a custom strategy for selecting actions.
         /// </summary>
         /// <param name="swaggerGenOptions"></param>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Extensions.DependencyInjection
             swaggerGenOptions.AddSecurityDefinition("bearerAuth", new OpenApiSecurityScheme
             {
                 Type = SecuritySchemeType.Http,
-                Scheme = "bearer",
+                Scheme = "Bearer",
                 BearerFormat = bearerFormat,
                 Description = "Authorization header using the Bearer scheme."
             });


### PR DESCRIPTION
A method to quickly and easily add Bearer authentication without lots of boilerplate code.

Closes #2234