### PR TITLE
Ensure UseSwaggerUI & AddSwaggerGen defaults match

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
@@ -32,7 +32,9 @@ namespace Microsoft.AspNetCore.Builder
             // To simplify the common case, use a default that will work with the SwaggerMiddleware defaults
             if (options.ConfigObject.Urls == null)
             {
-                options.ConfigObject.Urls = new[] { new UrlDescriptor { Name = "V1 Docs", Url = "v1/swagger.json" } };
+                var hostingEnv = app.ApplicationServices.GetRequiredService<IWebHostEnvironment>();
+                
+                options.ConfigObject.Urls = new[] { new UrlDescriptor { Name = $"{hostingEnv.ApplicationName} v1", Url = "v1/swagger.json" } };
             }
 
             return app.UseSwaggerUI(options);


### PR DESCRIPTION
Updated the defaults for `IApplicationBuilder.UseSwaggerUI` to better match the [defaults of `IServiceCollection.AddSwaggerGen`](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/master/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSwaggerGeneratorOptions.cs#L51) so that the displayed document name in the Swagger UI matches the actual document name and title.

We intend to change the default webapi project template code in ASP.NET Core in .NET 6.0 to simply use the Swashbuckle defaults and this change makes the UX align more clearly.