### PR TITLE
Fixed NRE when non ControllerDescriptor presented not at the beginningof the collection

### DIFF
--- a/src/Swashbuckle.AspNetCore.Annotations/AnnotationsDocumentFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Annotations/AnnotationsDocumentFilter.cs
@@ -17,7 +17,7 @@ namespace Swashbuckle.AspNetCore.Annotations
             // Collect (unique) controller names and custom attributes in a dictionary
             var controllerNamesAndAttributes = context.ApiDescriptions
                 .Select(apiDesc => apiDesc.ActionDescriptor as ControllerActionDescriptor)
-                .SkipWhile(actionDesc => actionDesc == null)
+                .Where(actionDesc => actionDesc != null)
                 .GroupBy(actionDesc => actionDesc.ControllerName)
                 .Select(group => new KeyValuePair<string, IEnumerable<object>>(group.Key, group.First().ControllerTypeInfo.GetCustomAttributes(true)));
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentFilter.cs
@@ -24,7 +24,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             // Collect (unique) controller names and types in a dictionary
             var controllerNamesAndTypes = context.ApiDescriptions
                 .Select(apiDesc => apiDesc.ActionDescriptor as ControllerActionDescriptor)
-                .SkipWhile(actionDesc => actionDesc == null)
+                .Where(actionDesc => actionDesc != null)
                 .GroupBy(actionDesc => actionDesc.ControllerName)
                 .Select(group => new KeyValuePair<string, Type>(group.Key, group.First().ControllerTypeInfo.AsType()));
 


### PR DESCRIPTION
I've come across this issue with `Microsoft.AspNetCore.Grpc.Swagger` lib, which is in preview. That lib has [Order of GrpcHttpApiDescriptionProvider](https://github.com/aspnet/AspLabs/blob/7ddba9bbf566138dac11d463c8cbed73ee94f806/src/GrpcHttpApi/src/Microsoft.AspNetCore.Grpc.Swagger/Internal/GrpcHttpApiDescriptionProvider.cs#L27) set to -900, which is greater than asp.net default -1000. Hence it inserts non `ControllerActionDescriptor`s after them. It causes NRE.
I didn't find any reason why it's a `SkipWhile` and not a `Where` clause.