### PR TITLE
Enable custom schema sorting

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -106,6 +106,18 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Provide a custom comprarer to sort schemas with
+        /// </summary>
+        /// <param name="swaggerGenOptions"></param>
+        /// <param name="schemaComparer"></param>
+        public static void SortSchemasWith(
+            this SwaggerGenOptions swaggerGenOptions,
+            IComparer<string> schemaComparer)
+        {
+            swaggerGenOptions.SwaggerGeneratorOptions.SchemaComparer = schemaComparer;
+        }
+
+        /// <summary>
         /// Describe all parameters, regardless of how they appear in code, in camelCase
         /// </summary>
         public static void DescribeAllParametersInCamelCase(this SwaggerGenOptions swaggerGenOptions)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -58,7 +58,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 filter.Apply(swaggerDoc, filterContext);
             }
 
-            swaggerDoc.Components.Schemas = new SortedDictionary<string, OpenApiSchema>(swaggerDoc.Components.Schemas);
+            swaggerDoc.Components.Schemas = new SortedDictionary<string, OpenApiSchema>(swaggerDoc.Components.Schemas, _options.SchemaComparer);
 
             return swaggerDoc;
         }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
@@ -16,6 +16,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             OperationIdSelector = DefaultOperationIdSelector;
             TagsSelector = DefaultTagsSelector;
             SortKeySelector = DefaultSortKeySelector;
+            SchemaComparer = StringComparer.CurrentCulture;
             Servers = new List<OpenApiServer>();
             SecuritySchemes = new Dictionary<string, OpenApiSecurityScheme>();
             SecurityRequirements = new List<OpenApiSecurityRequirement>();
@@ -46,6 +47,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         public IDictionary<string, OpenApiSecurityScheme> SecuritySchemes { get; set; }
 
         public IList<OpenApiSecurityRequirement> SecurityRequirements { get; set; }
+
+        public IComparer<string> SchemaComparer { get; set; }
 
         public IList<IParameterFilter> ParameterFilters { get; set; }
 


### PR DESCRIPTION
Typically, this would be done by DocumentFilters, but since the schemas are sorted after filters are applied, it's impossible to do this. Commit 224a0843bf5faa180ebd9a93d05e35f53c76a5ee moved the schema sorting to after filter application.

This PR adds a new SchemaComparer SwaggerGeneratorOptions property that will handle last-mile schema sorting.