### PR TITLE
Check if custom mapping has base class

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -249,7 +249,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private bool TryGetCustomTypeMapping(Type modelType, out Func<OpenApiSchema> schemaFactory)
         {
             return _generatorOptions.CustomTypeMappings.TryGetValue(modelType, out schemaFactory)
-                || (modelType.IsConstructedGenericType && _generatorOptions.CustomTypeMappings.TryGetValue(modelType.GetGenericTypeDefinition(), out schemaFactory));
+                || (modelType.IsConstructedGenericType && _generatorOptions.CustomTypeMappings.TryGetValue(modelType.GetGenericTypeDefinition(), out schemaFactory)
+                || (modelType.BaseType != null && _generatorOptions.CustomTypeMappings.TryGetValue(modelType.BaseType, out schemaFactory)));
         }
 
         private OpenApiSchema CreatePrimitiveSchema(DataContract dataContract)


### PR DESCRIPTION
This adds a check to see if the type has a base class which is inserted as custom type to map to.
This allows to map a base class and apply the mapping  to all the classes that inherit from that base class.

Closes #2250