### PR TITLE
Fix XML comments on Swagger UI interceptors

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -234,7 +234,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// MUST be a valid Javascript function.
         /// Function to intercept remote definition, "Try it out", and OAuth 2.0 requests.
         /// Accepts one argument requestInterceptor(request) and must return the modified request, or a Promise that resolves to the modified request.
-        /// Ex: "req => { req.headers['MyCustomHeader'] = 'CustomValue'; return req; }"
+        /// Ex: "function (req) { req.headers['MyCustomHeader'] = 'CustomValue'; return req; }"
         /// </summary>
         public string RequestInterceptorFunction { get; set; }
 
@@ -242,7 +242,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// MUST be a valid Javascript function.
         /// Function to intercept remote definition, "Try it out", and OAuth 2.0 responses.
         /// Accepts one argument responseInterceptor(response) and must return the modified response, or a Promise that resolves to the modified response.
-        /// Ex: "res => { console.log(res); return res; }"
+        /// Ex: "function (res) { console.log(res); return res; }"
         /// </summary>
         public string ResponseInterceptorFunction { get; set; }
     }


### PR DESCRIPTION
The examples provided in XML comments for `RequestInterceptorFunction` and `ResponseInterceptorFunction` didn't work because [`parseFunction`](https://gist.github.com/lamberta/3768814) in general cannot handle lambdas (it requires that the function body must be enclosed in `{}`, and parameters list be enclosed in `()`, neither of which is definitively true for lambdas). Fixed by changing the example to a function expression.