### PR TITLE
Replace <c></c> with Markdown backticks instead of curly brackets

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
@@ -9,6 +9,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     {
         private static Regex RefTagPattern = new Regex(@"<(see|paramref) (name|cref)=""([TPF]{1}:)?(?<display>.+?)"" ?/>");
         private static Regex CodeTagPattern = new Regex(@"<c>(?<display>.+?)</c>");
+        private static Regex MultilineCodeTagPattern = new Regex(@"<code>(?<display>.+?)</code>", RegexOptions.Singleline);
         private static Regex ParaTagPattern = new Regex(@"<para>(?<display>.+?)</para>", RegexOptions.Singleline);
 
         public static string Humanize(string text)
@@ -16,12 +17,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             if (text == null)
                 throw new ArgumentNullException("text");
 
-            //Call DecodeXml at last to avoid entities like &lt and &gt to break valid xml          
+            //Call DecodeXml at last to avoid entities like &lt and &gt to break valid xml
 
             return text
                 .NormalizeIndentation()
                 .HumanizeRefTags()
                 .HumanizeCodeTags()
+                .HumanizeMultilineCodeTags()
                 .HumanizeParaTags()
                 .DecodeXml();
         }
@@ -92,7 +94,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private static string HumanizeCodeTags(this string text)
         {
-            return CodeTagPattern.Replace(text, (match) => "{" + match.Groups["display"].Value + "}");
+            return CodeTagPattern.Replace(text, (match) => "`" + match.Groups["display"].Value + "`");
+        }
+
+        private static string HumanizeMultilineCodeTags(this string text)
+        {
+            return MultilineCodeTagPattern.Replace(text, (match) => "```" + match.Groups["display"].Value + "```");
         }
 
         private static string HumanizeParaTags(this string text)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
@@ -126,9 +126,10 @@ A line of text",
         [Theory]
         [InlineData(@"Returns a <see cref=""T:Product""/>", "Returns a Product")]
         [InlineData(@"<paramref name=""param1"" /> does something", "param1 does something")]
-        [InlineData(@"<c>DoWork</c> is a method in <c>TestClass</c>.", "{DoWork} is a method in {TestClass}.")]
-        [InlineData(@"<para>This is a paragraph</para>.", "<br>This is a paragraph.")]
-        [InlineData(@"GET /Todo?iscomplete=true&amp;owner=mike", "GET /Todo?iscomplete=true&owner=mike")]
+        [InlineData("<c>DoWork</c> is a method in <c>TestClass</c>.", "`DoWork` is a method in `TestClass`.")]
+        [InlineData("<code>DoWork</code> is a method in <code>\nTestClass\n</code>.", "```DoWork``` is a method in ```\nTestClass\n```.")]
+        [InlineData("<para>This is a paragraph</para>.", "<br>This is a paragraph.")]
+        [InlineData("GET /Todo?iscomplete=true&amp;owner=mike", "GET /Todo?iscomplete=true&owner=mike")]
         public void Humanize_HumanizesInlineTags(
             string input,
             string expectedOutput)


### PR DESCRIPTION
`<c></c>` tags are currently [replaced](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/master/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs#L11) by [`{}`](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/master/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs#L95), but this is [rather old code](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/commit/85d4d09707679b5a04c7a6b3770820d24b786127#diff-233d46370aa00ef71a1979e91ebef89acdf75f0d7280e89d424eb207eeff6002R9), and I couldn't find anything about this being standard practice in OpenAPI/Swagger (the only mention I could find of `{}` was in relation to [URL path parameters](https://swagger.io/docs/specification/paths-and-operations/)). Redoc displays curly brackets as-is.

This PR changes the behaviour to use GitHub-flavoured markdown, instead - `<c></c>` tags are replaced with single backticks and `<code></code>` tags (previously ignored) are replaced with triple backticks. Redoc supports this style of code formatting out of the box.