### PR TITLE
Add the property Example to SwaggerSchemaAttribute

### DIFF
--- a/src/Swashbuckle.AspNetCore.Annotations/AnnotationsSchemaFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Annotations/AnnotationsSchemaFilter.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi.Models;
-using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Swashbuckle.AspNetCore.Annotations
 {
@@ -96,6 +96,12 @@ namespace Swashbuckle.AspNetCore.Annotations
 
             if (schemaAttribute.Title != null)
                 schema.Title = schemaAttribute.Title;
+
+            if (schemaAttribute.Example != null)
+                schema.Example = OpenApiAnyFactory.CreateFromJson(
+                    schemaAttribute.Example.All(char.IsDigit)
+                    ? schemaAttribute.Example
+                    : $"\"{schemaAttribute.Example}\"");
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.Annotations/SwaggerSchemaAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.Annotations/SwaggerSchemaAttribute.cs
@@ -41,6 +41,7 @@ namespace Swashbuckle.AspNetCore.Annotations
         public string[] Required { get; set; }
 
         public string Title { get; set; }
+        public string Example { get; set; }
 
         internal bool? ReadOnlyFlag { get; private set; }
 

--- a/test/Swashbuckle.AspNetCore.Annotations.Test/AnnotationsSchemaFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.Annotations.Test/AnnotationsSchemaFilterTests.cs
@@ -1,7 +1,8 @@
-﻿using System;
-using Microsoft.OpenApi.Models;
-using Xunit;
+﻿using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using Swashbuckle.AspNetCore.TestSupport;
+using System;
+using Xunit;
 
 namespace Swashbuckle.AspNetCore.Annotations.Test
 {
@@ -16,10 +17,10 @@ namespace Swashbuckle.AspNetCore.Annotations.Test
             var context = new SchemaFilterContext(type: type, schemaGenerator: null, schemaRepository: null);
 
             Subject().Apply(schema, context);
-
             Assert.Equal($"Description for {type.Name}", schema.Description);
             Assert.Equal(new[] { "StringWithSwaggerSchemaAttribute" }, schema.Required);
             Assert.Equal($"Title for {type.Name}", schema.Title);
+            Assert.Equal($"\"Example for {type.Name}\"", schema.Example.ToJson());
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.Annotations.Test/Fixtures/SwaggerAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.Annotations.Test/Fixtures/SwaggerAnnotatedType.cs
@@ -1,6 +1,6 @@
 ﻿namespace Swashbuckle.AspNetCore.Annotations.Test
 {
-    [SwaggerSchema("Description for SwaggerAnnotatedType", Required = new[] { "StringWithSwaggerSchemaAttribute" }, Title = "Title for SwaggerAnnotatedType")]
+    [SwaggerSchema("Description for SwaggerAnnotatedType", Required = new[] { "StringWithSwaggerSchemaAttribute" }, Title = "Title for SwaggerAnnotatedType", Example = "Example for SwaggerAnnotatedType")]
     [SwaggerSchemaFilter(typeof(VendorExtensionsSchemaFilter))]
     public class SwaggerAnnotatedType
     {
@@ -17,7 +17,7 @@
         public string StringWithSwaggerRequestBodyAttribute { get; set; }
     }
 
-    [SwaggerSchema("Description for SwaggerAnnotatedStruct", Required = new[] { "StringWithSwaggerSchemaAttribute" }, Title = "Title for SwaggerAnnotatedStruct")]
+    [SwaggerSchema("Description for SwaggerAnnotatedStruct", Required = new[] { "StringWithSwaggerSchemaAttribute" }, Title = "Title for SwaggerAnnotatedStruct", Example = "Example for SwaggerAnnotatedStruct")]
     [SwaggerSchemaFilter(typeof(VendorExtensionsSchemaFilter))]
     public struct SwaggerAnnotatedStruct
     {


### PR DESCRIPTION
This change add the feature of use an property example using SwaggerSchemaAttribute as we already have the XML option.