### PR TITLE
Filter Out Qualifiers Only between Curly Braces

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiDescriptionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiDescriptionExtensions.cs
@@ -2,16 +2,14 @@
 using System.Linq;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Routing.Template;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     public static class ApiDescriptionExtensions
     {
-        private static readonly char[] Disallowed = { ':', '=', '?' };
-
         public static bool TryGetMethodInfo(this ApiDescription apiDescription, out MethodInfo methodInfo)
         {
             if (apiDescription.ActionDescriptor is ControllerActionDescriptor controllerActionDescriptor)
@@ -53,56 +51,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         internal static string RelativePathSansParameterConstraints(this ApiDescription apiDescription)
         {
-            var routeTemplate = apiDescription.RelativePath;
-
-            // We want to filter out qualifiers that indicate a constraint (":")
-            // a default value ("=") or an optional parameter ("?")
-            if (routeTemplate.IndexOfAny(Disallowed) == -1)
-            {
-                // Quick-exit if there's nothing to remove.
-                return routeTemplate;
-            }
-
-            var modifiedTemplate = new StringBuilder(routeTemplate.Length);
-            var index = 0;
-            var isBetweenCurlyBraces = false;
-            while (index < routeTemplate.Length)
-            {
-                var current = routeTemplate[index];
-
-                if (current == '{')
-                {
-                    isBetweenCurlyBraces = true;
-                    goto next;
-                }
-
-                if (current == '}')
-                {
-                    isBetweenCurlyBraces = false;
-                    goto next;
-                }
-
-                if (isBetweenCurlyBraces && Disallowed.Contains(current))
-                {
-                    // Only find a single instance of a '}' after our start
-                    // character to avoid capturing escaped curly braces
-                    // in a regular expression constraint
-                findEndBrace:
-                    index = routeTemplate.IndexOf('}', index + 1);
-                    if (index < routeTemplate.Length - 1 && routeTemplate[index + 1] == '}')
-                    {
-                        index += 2;
-                        goto findEndBrace;
-                    }
-                    continue;
-                }
-
-            next:
-                modifiedTemplate = modifiedTemplate.Append(current);
-                index += 1;
-            }
-
-            return modifiedTemplate.ToString();
+            var routeTemplate = TemplateParser.Parse(apiDescription.RelativePath);
+            var sanitizedSegments = routeTemplate
+                .Segments
+                .Select(s => string.Concat(s.Parts.Select(p => p.Name != null ? $"{{{p.Name}}}" : p.Text)));
+            return string.Join("/", sanitizedSegments);
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -51,6 +51,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
         [Theory]
         [InlineData("resources/{id}", "/resources/{id}")]
+        [InlineData("resources;secondary={secondary}", "/resources;secondary={secondary}")]
+        [InlineData("resources:deposit", "/resources:deposit")]
         [InlineData("{category}/{product?}/{sku}", "/{category}/{product}/{sku}")]
         [InlineData("{area=Home}/{controller:required}/{id=0:int}", "/{area}/{controller}/{id}")]
         [InlineData("{category}/product/{group?}", "/{category}/product/{group}")]
@@ -79,7 +81,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal("V1", document.Info.Version);
             Assert.Equal("Test API", document.Info.Title);
-            Assert.Equal(new[] { expectedPath }, document.Paths.Keys.ToArray());
+            var (actualPath, _) = Assert.Single(document.Paths);
+            Assert.Equal(expectedPath, actualPath);
         }
 
         [Fact]
@@ -751,7 +754,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var document = subject.GetSwagger("v1");
 
-            Assert.Equal(new[] { "Some", "Tags", "Here" }, document.Paths["/resource"].Operations[OperationType.Post].Tags.Select(t => t.Name)); 
+            Assert.Equal(new[] { "Some", "Tags", "Here" }, document.Paths["/resource"].Operations[OperationType.Post].Tags.Select(t => t.Name));
         }
 
         [Fact]


### PR DESCRIPTION
The current implementation can, for example, corrupt paths which
legitimately contain equals signs which are not indicating a default
value. This can come up in OData or when simulating matrix parameters.

Other contributors have taken a swing at this problem, but I'm hoping that
the small size of this solution will help its acceptance.

Fixes #2239
Fixes #2247
Fixes #2245
Fixes #2294