### PR TITLE
Add schema validator for controllers methods

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenServiceCollectionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenServiceCollectionExtensions.cs
@@ -9,6 +9,8 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
+    using Swashbuckle.AspNetCore.SwaggerGen.SchemaValidator;
+
     public static class SwaggerGenServiceCollectionExtensions
     {
         public static IServiceCollection AddSwaggerGen(
@@ -46,6 +48,12 @@ namespace Microsoft.Extensions.DependencyInjection
 
             if (setupAction != null) services.ConfigureSwaggerGen(setupAction);
 
+            return services;
+        }
+
+        public static IServiceCollection ValidateControllersResponses(this IServiceCollection services)
+        {
+            services.TryAddTransient<ISchemaValidator, SchemaValidator>();
             return services;
         }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaValidator/ISchemaValidator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaValidator/ISchemaValidator.cs
@@ -1,0 +1,7 @@
+namespace Swashbuckle.AspNetCore.SwaggerGen.SchemaValidator
+{
+    public interface ISchemaValidator
+    {
+        SchemaValidationResult ValidateControllerResponses();
+    }
+}

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaValidator/SchemaValidationResult.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaValidator/SchemaValidationResult.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.SchemaValidator
+{
+    public class SchemaValidationResult
+    {
+        public List<SchemaValidationError> Errors { get; }
+
+        private SchemaValidationResult(List<SchemaValidationError> errors)
+        {
+            Errors = errors;
+        }
+
+        internal static SchemaValidationResult Create()
+            => new SchemaValidationResult(new List<SchemaValidationError>());
+
+        internal void AddError(SchemaValidationError error)
+        {
+            Errors.Add(error);
+        }
+
+        public bool HasErrors() => Errors.Count > 0;
+    }
+
+    public class SchemaValidationError
+    {
+        public string HttpMethod { get; }
+        public string Path { get; }
+        public string Reason { get; }
+
+        private SchemaValidationError(string httpMethod, string path, string reason)
+        {
+            HttpMethod = httpMethod;
+            Path = path;
+            Reason = reason;
+        }
+
+        internal static SchemaValidationError Create(
+            ApiDescription api,
+            Type expectedResponseType,
+            Type methodResultType
+        )
+            => new SchemaValidationError(
+                api.HttpMethod,
+                api.RelativePath,
+                $"It should return: {expectedResponseType} but instead it returns {methodResultType}"
+            );
+    }
+}

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaValidator/SchemaValidator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaValidator/SchemaValidator.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.SchemaValidator
+{
+    class SchemaValidator : ISchemaValidator
+    {
+        private const int MIN_SUCCESS_STATUS_CODE = 200;
+        private const int MAX_SUCCESS_STATUS_CODE = 299;
+
+        private readonly IApiDescriptionGroupCollectionProvider _apiDescriptionsProvider;
+        private readonly SwaggerGeneratorOptions _options;
+
+        public SchemaValidator(
+            IApiDescriptionGroupCollectionProvider apiDescriptionsProvider,
+            SwaggerGeneratorOptions options
+        )
+        {
+            _apiDescriptionsProvider = apiDescriptionsProvider;
+            _options = options;
+        }
+
+        public SchemaValidationResult ValidateControllerResponses()
+        {
+            var schemaValidationResult = SchemaValidationResult.Create();
+
+            var applicableApiDescriptions = _apiDescriptionsProvider.ApiDescriptionGroups.Items
+                .SelectMany(group => group.Items)
+                .Where(apiDesc => !(
+                        _options.IgnoreObsoleteActions &&
+                        apiDesc.CustomAttributes().OfType<ObsoleteAttribute>().Any()
+                    )
+                );
+
+            foreach (var apiDescription in applicableApiDescriptions)
+            {
+
+                if (apiDescription.ActionDescriptor is ControllerActionDescriptor controllerActionDescriptor)
+                {
+                    var methodReturnType = controllerActionDescriptor.MethodInfo.ReturnParameter
+                        .ParameterType;
+
+                    // Check if it is task
+                    if (
+                        methodReturnType.IsGenericType &&
+                        methodReturnType.GetTypeInfo().GetGenericTypeDefinition() == typeof(Task<>) &&
+                        methodReturnType.GetTypeInfo().GetGenericArguments().Length > 0
+                    )
+                    {
+                        methodReturnType = methodReturnType.GetGenericArguments().First();
+                    }
+
+                    // Check if it is ActionResult
+                    if (
+                        methodReturnType.IsGenericType &&
+                        methodReturnType.GetTypeInfo().GetGenericTypeDefinition() == typeof(ActionResult<>)
+                    )
+                    {
+                        methodReturnType = methodReturnType.GetGenericArguments().First();
+                    }
+
+                    // Get list of unsupported response type (e.g. From [ProducesResponseType])
+                    var unsupportedSuccessResponseSystemTypes = GetSuccessSupportedResponsesTypes(
+                        apiDescription
+                    )
+                    .Where(type => methodReturnType != type)
+                    .ToList();
+
+                    foreach (var unsupportedType in unsupportedSuccessResponseSystemTypes)
+                    {
+                        schemaValidationResult.AddError(
+                            SchemaValidationError.Create(
+                                apiDescription,
+                                unsupportedType,
+                                methodReturnType
+                            )
+                        );
+                    }
+                }
+            }
+
+            return schemaValidationResult;
+        }
+
+        private IEnumerable<Type> GetSuccessSupportedResponsesTypes(ApiDescription apiDescription)
+            => apiDescription.SupportedResponseTypes
+                .Where(supportedResponseType =>
+                    CheckIfSuccessResponseType(supportedResponseType) &&
+                    supportedResponseType.Type != typeof(void) // This annotation: [ProducesResponseType(200)] make supportedResponseType = System.Void
+                )
+                .Select(supportedResponseType => supportedResponseType.Type
+                        .GetTypeInfo().ImplementedInterfaces.Contains(typeof(IConvertToActionResult))
+                        ? supportedResponseType.Type.GetGenericArguments().First()
+                        : supportedResponseType.Type
+                )
+                .DefaultIfEmpty(typeof(ActionResult)) // if list is empty, add ActionResult as default value
+                .ToList();
+
+        // Check if response status is inside range of success statuses codes
+        private bool CheckIfSuccessResponseType(ApiResponseType responseType)
+            => responseType.StatusCode is >= MIN_SUCCESS_STATUS_CODE and <= MAX_SUCCESS_STATUS_CODE;
+    }
+}


### PR DESCRIPTION
Hi all, I need to ensure that response type (for success, so >= 200 && <= 299) indicated with the attribute ProducesReponseType is congruent with actual return type of controller method.
So I developed a service to do that, in my case, in startup process I check if there are some issues and I throw an exception to get notified of that.
I added that service to SwaggerGen.

PS. I know that we can mark a controller method with return type: ActionResult<int>, and then return another thing like: new JsonResult("hello world") and for the compiler it is ok, and also my code is ok, if attribute: ProducesReponseType is marked with int. But for solving that I've made another dedicated Type which implements IActionResult and doesn't support implicit operators, like ActionResult, but I don't know if that is something that should stay in this repository.