### PR TITLE
Add default username for OAuth2 password flow.

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -180,6 +180,11 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
     public class OAuthConfigObject
     {
         /// <summary>
+        /// Default username for OAuth2 password flow.
+        /// </summary>
+        public string Username { get; set; } = null;
+
+        /// <summary>
         /// Default clientId
         /// </summary>
         public string ClientId { get; set; } = null;

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptionsExtensions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.Builder
         public static void SwaggerEndpoint(this SwaggerUIOptions options, string url, string name)
         {
             var urls = new List<UrlDescriptor>(options.ConfigObject.Urls ?? Enumerable.Empty<UrlDescriptor>());
-            urls.Add(new UrlDescriptor { Url = url, Name = name} );
+            urls.Add(new UrlDescriptor { Url = url, Name = name });
             options.ConfigObject.Urls = urls;
         }
 
@@ -219,6 +219,16 @@ namespace Microsoft.AspNetCore.Builder
         public static void OAuthClientId(this SwaggerUIOptions options, string value)
         {
             options.OAuthConfigObject.ClientId = value;
+        }
+
+        /// <summary>
+        /// Default userName
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="value"></param>
+        public static void OAuthUsername(this SwaggerUIOptions options, string value)
+        {
+            options.OAuthConfigObject.Username = value;
         }
 
         /// <summary>

--- a/test/WebSites/OAuth2Integration/Startup.cs
+++ b/test/WebSites/OAuth2Integration/Startup.cs
@@ -132,6 +132,7 @@ namespace OAuth2Integration
                     c.EnableDeepLinking();
 
                     // Additional OAuth settings (See https://github.com/swagger-api/swagger-ui/blob/v3.10.0/docs/usage/oauth2.md)
+                    c.OAuthUsername("username");
                     c.OAuthClientId("test-id");
                     c.OAuthClientSecret("test-secret");
                     c.OAuthAppName("test-app");


### PR DESCRIPTION
I wanted to set default username for OAuth2 password flow.
Unfortunately, its not exposed.

Added possibility to do so.