### PR TITLE
Added possibility to register schema factory instances with more access to the type internals

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -184,6 +184,34 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Provide a custom mapping, for a given type, to the Swagger-flavored JSONSchema
         /// </summary>
+        /// <param name="swaggerGenOptions"></param>
+        /// <param name="type">System type</param>
+        /// <param name="schemaFactory">A factory method that generates Schema's for the provided type</param>
+        public static void MapType(
+            this SwaggerGenOptions swaggerGenOptions,
+            Type type,
+            Func<SchemaFactoryContext, OpenApiSchema> schemaFactory)
+        {
+            swaggerGenOptions.SchemaGeneratorOptions.SchemaFactories.Add(type, new DelegatedSchemaFactory(schemaFactory));
+        }
+
+        /// <summary>
+        /// Provide a custom mapping, for a given type, to the Swagger-flavored JSONSchema
+        /// </summary>
+        /// <param name="swaggerGenOptions"></param>
+        /// <param name="type">System type</param>
+        /// <param name="schemaFactory">A factory method that generates Schema's for the provided type</param>
+        public static void MapType(
+            this SwaggerGenOptions swaggerGenOptions,
+            Type type,
+            ISchemaFactory schemaFactory)
+        {
+            swaggerGenOptions.SchemaGeneratorOptions.SchemaFactories.Add(type, schemaFactory);
+        }
+
+        /// <summary>
+        /// Provide a custom mapping, for a given type, to the Swagger-flavored JSONSchema
+        /// </summary>
         /// <typeparam name="T">System type</typeparam>
         /// <param name="swaggerGenOptions"></param>
         /// <param name="schemaFactory">A factory method that generates Schema's for the provided type</param>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/ISchemaFactory.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/ISchemaFactory.cs
@@ -1,0 +1,44 @@
+using System;
+using Microsoft.OpenApi.Models;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen
+{
+    public interface ISchemaFactory
+    {
+        OpenApiSchema CreateSchema(SchemaFactoryContext context);
+    }
+
+    public class DelegatedSchemaFactory : ISchemaFactory
+    {
+        private readonly Func<SchemaFactoryContext, OpenApiSchema> _schemaFactory;
+
+        public DelegatedSchemaFactory(Func<SchemaFactoryContext, OpenApiSchema> schemaFactory)
+        {
+            _schemaFactory = schemaFactory;
+        }
+
+        public OpenApiSchema CreateSchema(SchemaFactoryContext context)
+        {
+            return _schemaFactory.Invoke(context);
+        }
+    }
+
+    public class SchemaFactoryContext
+    {
+        public Type Type { get; }
+
+        public DataContract DataContract { get; }
+
+        public ISchemaGenerator SchemaGenerator { get; }
+
+        public SchemaRepository SchemaRepository { get; }
+
+        public SchemaFactoryContext(Type type, DataContract dataContract, ISchemaGenerator schemaGenerator, SchemaRepository schemaRepository)
+        {
+            Type = type;
+            DataContract = dataContract;
+            SchemaGenerator = schemaGenerator;
+            SchemaRepository = schemaRepository;
+        }
+    }
+}

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
@@ -10,6 +10,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         public SchemaGeneratorOptions()
         {
             CustomTypeMappings = new Dictionary<Type, Func<OpenApiSchema>>();
+            SchemaFactories = new Dictionary<Type, ISchemaFactory>();
             SchemaIdSelector = DefaultSchemaIdSelector;
             SubTypesSelector = DefaultSubTypesSelector;
             DiscriminatorNameSelector = DefaultDiscriminatorNameSelector;
@@ -18,6 +19,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         }
 
         public IDictionary<Type, Func<OpenApiSchema>> CustomTypeMappings { get; set; }
+        public IDictionary<Type, ISchemaFactory> SchemaFactories { get; set; }
 
         public bool UseInlineDefinitionsForEnums { get; set; }
 


### PR DESCRIPTION
Fixes #2333

I changed the approach to be more in-line on how other features like the filters. I introduced a new interface which can be registered and also a context which allows access to auxiliary services. The proposal in #2333 would be maybe a bit a larger initiative to bring more DI compatibility into Swashbuckle. 

This minimal solution would solve my intermediate needs quite well. 

I tried to stick to the current established pracices (conventions, level of documentation and testing) but can adapt the code if needed. 