### PR TITLE
Add MethodInfo discovery for Minimal API

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiDescriptionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiDescriptionExtensions.cs
@@ -18,6 +18,17 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 return true;
             }
 
+#if NET6_0_OR_GREATER
+            if (apiDescription.ActionDescriptor?.EndpointMetadata != null)
+            {
+                methodInfo = apiDescription.ActionDescriptor.EndpointMetadata
+                    .OfType<MethodInfo>()
+                    .FirstOrDefault();
+
+                return methodInfo != null;
+            }
+#endif
+
             methodInfo = null;
             return false;
         }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ApiDescriptionExtensions/ApiDescriptionExtensionsTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ApiDescriptionExtensions/ApiDescriptionExtensionsTests.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.AspNetCore.Mvc.Abstractions;
+using Swashbuckle.AspNetCore.SwaggerGen.Test.Fixtures;
+using Swashbuckle.AspNetCore.TestSupport;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test.ApiDescriptionExtensions
+{
+    public class ApiDescriptionExtensionsTests
+    {
+        [Fact]
+        public void TryGetMethodInfo_GetsMethodInfo_IfControllerActionDescriptor()
+        {
+            var apiDescription = ApiDescriptionFactory.Create<FakeController>(c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "/");
+
+            var result = apiDescription.TryGetMethodInfo(out var methodInfo);
+
+            Assert.True(result);
+            Assert.NotNull(methodInfo);
+        }
+
+        [Fact]
+        public void TryGetMethodInfo_GetsMethodInfo_IfEndpointActionDescriptor()
+        {
+            var testMethodInfo = typeof(TestMinimalApiMethod).GetMethod("RequestDelegate");
+
+            var actionDescriptor = new ActionDescriptor();
+            actionDescriptor.EndpointMetadata = new List<object> { testMethodInfo };
+            actionDescriptor.Parameters = testMethodInfo
+                .GetParameters()
+                .Select(p => new ParameterDescriptor
+                {
+                    Name = p.Name,
+                    ParameterType = p.ParameterType
+                })
+                .ToList();
+
+            var apiDescription = ApiDescriptionFactory.Create(actionDescriptor, testMethodInfo, groupName: "v1", httpMethod: "POST", relativePath: "/");
+
+            var result = apiDescription.TryGetMethodInfo(out var methodInfo);
+
+            Assert.True(result);
+            Assert.NotNull(methodInfo);
+        }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TestMinimalApiMethod.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TestMinimalApiMethod.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test.Fixtures
+{
+    public class TestMinimalApiMethod
+    {
+        public static Task RequestDelegate(long id)
+        {
+            return Task.FromResult(id);
+        }
+    }
+}


### PR DESCRIPTION
Add the ability to discover MethodInfo for ASP Net Core Minimal API delegates.