### PR TITLE
style: typo succesfully to successfully

### DIFF
--- a/src/Swashbuckle.AspNetCore.Cli/Program.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/Program.cs
@@ -111,7 +111,7 @@ namespace Swashbuckle.AspNetCore.Cli
                             swagger.SerializeAsV3(writer);
 
                         if (outputPath != null)
-                            Console.WriteLine($"Swagger JSON/YAML succesfully written to {outputPath}");
+                            Console.WriteLine($"Swagger JSON/YAML successfully written to {outputPath}");
                     }
 
                     return 0;


### PR DESCRIPTION
There was a typo in the message after generating Swagger. It had "succesfully" with one S instead of two "successfully"