### PR TITLE
Resolves a null pointer exception when returning a Dictionary containing known keys

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -88,7 +88,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 }
 
                 // NullableAttribute behaves diffrently for Dictionaries
-                if (modelType.IsGenericType && modelType.GetGenericTypeDefinition() == typeof(Dictionary<,>))
+                if (schema.AdditionalPropertiesAllowed && modelType.IsGenericType && modelType.GetGenericTypeDefinition() == typeof(Dictionary<,>))
                 {
                     schema.AdditionalProperties.Nullable = !memberInfo.IsDictionaryValueNonNullable();
                 }


### PR DESCRIPTION
This PR fixes a null pointer exception when having a API returning av Dictionary containing known keys
(ie a Dictionary<Enum, string>).

The problem was that the code tried to set `schema.AdditionalProperties.Nullable` without first checking if `schema.AdditionalPropertiesAllowed` was true. This resulted in a null point exception since `schema.AdditionalProperties` is null when `schema.AdditionalPropertiesAllowed` is false.

Fixes #2368