### PR TITLE
Update HostFactoryResolver.cs

### DIFF
--- a/src/Swashbuckle.AspNetCore.Cli/HostFactoryResolver.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/HostFactoryResolver.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.Hosting
         public const string CreateHostBuilder = nameof(CreateHostBuilder);
 
         // The amount of time we wait for the diagnostic source events to fire
-        private static readonly TimeSpan s_defaultWaitTimeout = Debugger.IsAttached ? Timeout.InfiniteTimeSpan : TimeSpan.FromSeconds(5);
+        private static readonly TimeSpan s_defaultWaitTimeout = Debugger.IsAttached ? Timeout.InfiniteTimeSpan : TimeSpan.FromSeconds(30);
 
         public static Func<string[], TWebHost> ResolveWebHostFactory<TWebHost>(Assembly assembly)
         {


### PR DESCRIPTION
As per .net 6.0.1 fix, the timeout has been increased from 5 seconds to 30 seconds, in some special circumstances (i.e. Loading Azure App Secret), startup might take longer than 5 seconds which causes Swagger Cli command to fail.

You can find the relevant .net runtime pr here

https://github.com/dotnet/runtime/pull/61621/files

Similar change has been made to NSwag Build as well
https://github.com/RicoSuter/NSwag/pull/3864