### PR TITLE
Replace <see href="link">text</see> with Markdown link format

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
@@ -11,6 +11,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private static Regex CodeTagPattern = new Regex(@"<c>(?<display>.+?)</c>");
         private static Regex MultilineCodeTagPattern = new Regex(@"<code>(?<display>.+?)</code>", RegexOptions.Singleline);
         private static Regex ParaTagPattern = new Regex(@"<para>(?<display>.+?)</para>", RegexOptions.Singleline);
+        private static Regex HrefPattern = new(@"<see href=\""(.*)\"">(.*)<\/see>");
 
         public static string Humanize(string text)
         {
@@ -22,6 +23,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             return text
                 .NormalizeIndentation()
                 .HumanizeRefTags()
+                .HumanizeHrefTags()
                 .HumanizeCodeTags()
                 .HumanizeMultilineCodeTags()
                 .HumanizeParaTags()
@@ -90,6 +92,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private static string HumanizeRefTags(this string text)
         {
             return RefTagPattern.Replace(text, (match) => match.Groups["display"].Value);
+        }
+
+        private static string HumanizeHrefTags(this string text)
+        {
+            return HrefPattern.Replace(text, m => $"[{m.Groups[2].Value}]({m.Groups[1].Value})");
         }
 
         private static string HumanizeCodeTags(this string text)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
@@ -131,6 +131,7 @@ A line of text",
         [InlineData("<para>This is a paragraph</para>.", "<br>This is a paragraph.")]
         [InlineData("GET /Todo?iscomplete=true&amp;owner=mike", "GET /Todo?iscomplete=true&owner=mike")]
         [InlineData(@"Returns a <see langword=""null""/> item.", "Returns a null item.")]
+        [InlineData(@"<see href=""https://www.iso.org/iso-4217-currency-codes.html"">ISO currency code</see>", "[ISO currency code](https://www.iso.org/iso-4217-currency-codes.html)")]
         public void Humanize_HumanizesInlineTags(
             string input,
             string expectedOutput)


### PR DESCRIPTION
`<see href="link">text</see>` tags are currently not replaced. The expected format for descriptions in OpenAPI/Swagger is markdown. Redoc does not generate a link for `<see href="link">text</see>` but instead displays the inner text as-is.

This PR changes the behaviour to use GitHub-flavoured markdown, instead - <see href="link">text</see> tags are replaced with a clickable link. Redoc supports this style of links out of the box.

Fixes: #2577 