### PR TITLE
Support prebuilt OpenApiOperation in EndpointMetadata

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -132,6 +132,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private OpenApiOperation GenerateOperation(ApiDescription apiDescription, SchemaRepository schemaRepository)
         {
+#if NET6_0_OR_GREATER
+            var metadata = apiDescription.ActionDescriptor?.EndpointMetadata;
+            var existingOperation = metadata?.OfType<OpenApiOperation>().SingleOrDefault();
+            if (existingOperation != null)
+            {
+                return existingOperation;
+            }
+#endif
             try
             {
                 var operation = new OpenApiOperation

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -142,6 +142,44 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
+        public void GetSwagger_UseProvidedOpenApiOperation_IfExistsInMetadata()
+        {
+            var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = new List<object>()
+                { 
+                    new OpenApiOperation 
+                    {
+                        OperationId = "OperationIdSetInMetadata",
+                        Parameters = new List<OpenApiParameter>()
+                        {
+                            new OpenApiParameter
+                            {
+                                Name = "ParameterInMetadata"
+                            }
+                        }
+                    }
+                },
+                RouteValues = new Dictionary<string, string>
+                {
+                    ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
+                }
+            };
+            var subject = Subject(
+                apiDescriptions: new[]
+                {
+                    ApiDescriptionFactory.Create(actionDescriptor, methodInfo, groupName: "v1", httpMethod: "POST", relativePath: "resource"),
+                }
+            );
+
+            var document = subject.GetSwagger("v1");
+
+            Assert.Equal("OperationIdSetInMetadata", document.Paths["/resource"].Operations[OperationType.Post].OperationId);
+            Assert.Equal("ParameterInMetadata", document.Paths["/resource"].Operations[OperationType.Post].Parameters[0].Name);
+        }
+
+        [Fact]
         public void GetSwagger_SetsOperationIdToNull_IfActionHasNoEndpointMetadata()
         {
             var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));


### PR DESCRIPTION
As part of the work outlined in https://github.com/dotnet/aspnetcore/issues/40676 and implemented in https://github.com/dotnet/aspnetcore/pull/41238, we're experimenting with providing a package that allows users to generate and modify `OpenApiOperation` metadata directly on endpoints.

In this new workflow, a user can annotate their endpoint like so:

```csharp
app.MapGet("/foo", () => ...)
  .WithOpenApi();
```

Which will generate the `OpenApiOperation` directly and add it to the endpoint metadata. Users can also do:

```csharp
app.MapGet("/foo", () => ...)
  .WithOpenApi(operation => {
     return modifyMyOperation(operation)
  });
```

Which will add an `OpenApiOperation` to metadata with the modifications that the user provides.

This PR checks to see if there already exists `OpenApiOperation` metadata for an endpoint and uses that over the generated variety.
