### PR TITLE
Add support for `WithSummary` and `WithDescription` metadata

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -216,7 +216,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     RequestBody = GenerateRequestBody(apiDescription, schemaRepository),
                     Responses = GenerateResponses(apiDescription, schemaRepository),
                     Deprecated = apiDescription.CustomAttributes().OfType<ObsoleteAttribute>().Any(),
-                    Summary = GenerateSummary(apiDescription)
+                    Summary = GenerateSummary(apiDescription),
+                    Description = GenerateDescription(apiDescription),
                 };
 
                 apiDescription.TryGetMethodInfo(out MethodInfo methodInfo);
@@ -656,7 +657,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         };
         private string GenerateSummary(ApiDescription apiDescription)
         {
-            string apiSummary = null;
+            string operationSummary = null;
 #if NET7_0_OR_GREATER
             apiSummary = apiDescription
                 .ActionDescriptor
@@ -665,7 +666,21 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 .Select(s => s.Summary)
                 .LastOrDefault();
 #endif
-            return apiSummary;
+            return operationSummary;
+        }
+
+        private string GenerateDescription(ApiDescription apiDescription)
+        {
+            string operationDescription = null;
+#if NET7_0_OR_GREATER
+            operationDescription = apiDescription
+                .ActionDescriptor
+                ?.EndpointMetadata
+                ?.OfType<IEndpointDescriptionMetadata>()
+                .Select(s => s.Summary)
+                .LastOrDefault();
+#endif
+            return operationDescription;
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -216,8 +216,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     RequestBody = GenerateRequestBody(apiDescription, schemaRepository),
                     Responses = GenerateResponses(apiDescription, schemaRepository),
                     Deprecated = apiDescription.CustomAttributes().OfType<ObsoleteAttribute>().Any(),
+#if NET7_0_OR_GREATER
                     Summary = GenerateSummary(apiDescription),
                     Description = GenerateDescription(apiDescription),
+#endif
                 };
 
                 apiDescription.TryGetMethodInfo(out MethodInfo methodInfo);
@@ -656,32 +658,18 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             new KeyValuePair<string, string>("default", "Error")
         };
 
-        private string GenerateSummary(ApiDescription apiDescription)
-        {
-            string operationSummary = null;
 #if NET7_0_OR_GREATER
-            operationSummary = apiDescription
-                .ActionDescriptor
-                ?.EndpointMetadata
+        private string GenerateSummary(ApiDescription apiDescription) =>
+            apiDescription.ActionDescriptor?.EndpointMetadata
                 ?.OfType<IEndpointSummaryMetadata>()
                 .Select(s => s.Summary)
                 .LastOrDefault();
-#endif
-            return operationSummary;
-        }
 
-        private string GenerateDescription(ApiDescription apiDescription)
-        {
-            string operationDescription = null;
-#if NET7_0_OR_GREATER
-            operationDescription = apiDescription
-                .ActionDescriptor
-                ?.EndpointMetadata
+        private string GenerateDescription(ApiDescription apiDescription) =>
+            apiDescription.ActionDescriptor?.EndpointMetadata
                 ?.OfType<IEndpointDescriptionMetadata>()
                 .Select(s => s.Description)
                 .LastOrDefault();
 #endif
-            return operationDescription;
-        }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -656,15 +656,16 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         };
         private string GenerateSummary(ApiDescription apiDescription)
         {
+            string apiSummary = null;
 #if NET7_0_OR_GREATER
-            return apiDescription
+            apiSummary = apiDescription
                 .ActionDescriptor
                 ?.EndpointMetadata
                 ?.OfType<IEndpointSummaryMetadata>()
                 .Select(s => s.Summary)
                 .LastOrDefault();
 #endif
-            return null;
+            return apiSummary;
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -10,6 +10,9 @@ using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
+#if NET7_0_OR_GREATER
+using Microsoft.AspNetCore.Http.Metadata;
+#endif
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
@@ -212,7 +215,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     Parameters = GenerateParameters(apiDescription, schemaRepository),
                     RequestBody = GenerateRequestBody(apiDescription, schemaRepository),
                     Responses = GenerateResponses(apiDescription, schemaRepository),
-                    Deprecated = apiDescription.CustomAttributes().OfType<ObsoleteAttribute>().Any()
+                    Deprecated = apiDescription.CustomAttributes().OfType<ObsoleteAttribute>().Any(),
+                    Summary = GenerateSummary(apiDescription)
                 };
 
                 apiDescription.TryGetMethodInfo(out MethodInfo methodInfo);
@@ -650,5 +654,17 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             new KeyValuePair<string, string>("5\\d{2}", "Server Error"),
             new KeyValuePair<string, string>("default", "Error")
         };
+        private string GenerateSummary(ApiDescription apiDescription)
+        {
+#if NET7_0_OR_GREATER
+            return apiDescription
+                .ActionDescriptor
+                ?.EndpointMetadata
+                ?.OfType<IEndpointSummaryMetadata>()
+                .Select(s => s.Summary)
+                .LastOrDefault();
+#endif
+            return null;
+        }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -659,7 +659,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             string operationSummary = null;
 #if NET7_0_OR_GREATER
-            apiSummary = apiDescription
+            operationSummary = apiDescription
                 .ActionDescriptor
                 ?.EndpointMetadata
                 ?.OfType<IEndpointSummaryMetadata>()
@@ -677,7 +677,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 .ActionDescriptor
                 ?.EndpointMetadata
                 ?.OfType<IEndpointDescriptionMetadata>()
-                .Select(s => s.Summary)
+                .Select(s => s.Description)
                 .LastOrDefault();
 #endif
             return operationDescription;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -655,6 +655,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             new KeyValuePair<string, string>("5\\d{2}", "Server Error"),
             new KeyValuePair<string, string>("default", "Error")
         };
+
         private string GenerateSummary(ApiDescription apiDescription)
         {
             string operationSummary = null;

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -966,6 +966,30 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
+        public void GetSwagger_CanReadEndpointSummaryFromMetadata()
+        {
+            var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = new List<object>() { new EndpointSummaryAttribute("A Test Summary") },
+                RouteValues = new Dictionary<string, string>
+                {
+                    ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
+                }
+            };
+            var subject = Subject(
+                apiDescriptions: new[]
+                {
+                    ApiDescriptionFactory.Create(actionDescriptor, methodInfo, groupName: "v1", httpMethod: "POST", relativePath: "resource"),
+                }
+            );
+
+            var document = subject.GetSwagger("v1");
+
+            Assert.Equal("A Test Summary", document.Paths["/resource"].Operations[OperationType.Post].Summary);
+        }
+
+        [Fact]
         public void GetSwagger_SupportsOption_ConflictingActionsResolver()
         {
             var subject = Subject(

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -990,6 +990,30 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
+        public void GetSwagger_CanReadEndpointDescriptionFromMetadata()
+        {
+            var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));
+            var actionDescriptor = new ActionDescriptor
+            {
+                EndpointMetadata = new List<object>() { new EndpointDescriptionAttribute("A Test Description") },
+                RouteValues = new Dictionary<string, string>
+                {
+                    ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
+                }
+            };
+            var subject = Subject(
+                apiDescriptions: new[]
+                {
+                    ApiDescriptionFactory.Create(actionDescriptor, methodInfo, groupName: "v1", httpMethod: "POST", relativePath: "resource"),
+                }
+            );
+
+            var document = subject.GetSwagger("v1");
+
+            Assert.Equal("A Test Description", document.Paths["/resource"].Operations[OperationType.Post].Description);
+        }
+
+        [Fact]
         public void GetSwagger_SupportsOption_ConflictingActionsResolver()
         {
             var subject = Subject(

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -151,8 +151,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var actionDescriptor = new ActionDescriptor
             {
                 EndpointMetadata = new List<object>()
-                { 
-                    new OpenApiOperation 
+                {
+                    new OpenApiOperation
                     {
                         OperationId = "OperationIdSetInMetadata",
                         Parameters = new List<OpenApiParameter>()
@@ -199,7 +199,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                             {
                                 Content = new Dictionary<string, OpenApiMediaType>()
                                 {
-                                    ["application/someMediaType"] = new() 
+                                    ["application/someMediaType"] = new()
                                 }
                             }
                         }
@@ -965,6 +965,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal(new[] { "Some", "Tags", "Here" }, document.Paths["/resource"].Operations[OperationType.Post].Tags.Select(t => t.Name));
         }
 
+#if NET7_0_OR_GREATER
         [Fact]
         public void GetSwagger_CanReadEndpointSummaryFromMetadata()
         {
@@ -1012,6 +1013,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal("A Test Description", document.Paths["/resource"].Operations[OperationType.Post].Description);
         }
+#endif
 
         [Fact]
         public void GetSwagger_SupportsOption_ConflictingActionsResolver()

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.csproj
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1701;1702;1591</NoWarn>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.csproj
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1701;1702;1591</NoWarn>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
fixes https://github.com/dotnet/aspnetcore/issues/40753
fixes https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2548

Adds support for the MinimalAPI operation metadata functions, `WithSummary` and `WithDescription`, including CI changes. 