### PR TITLE
Improve IsRequiredSpecified performance

### DIFF
--- a/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/JsonPropertyExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/JsonPropertyExtensions.cs
@@ -23,10 +23,8 @@ namespace Swashbuckle.AspNetCore.Newtonsoft
             if (memberInfo.GetCustomAttribute<JsonRequiredAttribute>() != null)
                 return true;
 
-            var jsonPropertyAttributeData = memberInfo.GetCustomAttributesData()
-                .FirstOrDefault(attrData => attrData.AttributeType == typeof(JsonPropertyAttribute));
-
-            return (jsonPropertyAttributeData != null) && jsonPropertyAttributeData.NamedArguments.Any(arg => arg.MemberName == "Required");
+            var jsonPropertyAttribute = memberInfo.GetCustomAttribute<JsonPropertyAttribute>();
+            return jsonPropertyAttribute != null && jsonPropertyAttribute.Required != Required.Default;
         }
     }
 }


### PR DESCRIPTION
The `IsRequiredSpecified` method isn't _slow_ by itself but with how frequently it can be called, it kinda still is. For example in the code I'm working on, the total time within `IsRequiredSpecified` is 3 seconds:

![image](https://user-images.githubusercontent.com/904226/168738180-a0436d52-7e18-4f78-8ae8-06821557ef9b.png)

When you look at the memory allocations too, it gets kinda crazy:

![image](https://user-images.githubusercontent.com/904226/168739755-a7ff8b14-a8af-4fb2-b3d8-e408bdd1fd47.png)

The problem here is that calling `GetCustomAttributesData` is expensive. How expensive depends on the member itself but here is the results for a basic benchmark:

![image](https://user-images.githubusercontent.com/904226/168737898-f1b1eef1-4ae7-47b7-842b-e4fbe3d59c22.png)

Now, while the original code specifically checked if the user specified a `Required` value at all, this new code only checks that it isn't the default value (the default value is that it is not required). The original code also has a mistake here as it treats setting the `Required` value to anything means it is required which isn't true (as you _can_ set it to `Required.Default` which is to _not_ require something).

Technically `DisallowNull`, according to the Newtonsoft docs says "The property is not required..." but I'm not really wanting to modify that type of behaviour. It is a lot more clear cut that `Required.Default` means it _isn't_ required.
