### PR TITLE
#2426 - Added schema generator option for inline definitions for objects

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
@@ -31,6 +31,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private void DeepCopy(SchemaGeneratorOptions source, SchemaGeneratorOptions target)
         {
             target.CustomTypeMappings = new Dictionary<Type, Func<OpenApiSchema>>(source.CustomTypeMappings);
+            target.UseInlineDefinitionsForObjects = source.UseInlineDefinitionsForObjects;
             target.UseInlineDefinitionsForEnums = source.UseInlineDefinitionsForEnums;
             target.SchemaIdSelector = source.SchemaIdSelector;
             target.IgnoreObsoleteProperties = source.IgnoreObsoleteProperties;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -204,6 +204,15 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Generate inline schema definitions (as opposed to referencing a shared definition) for object parameters and properties
+        /// </summary>
+        /// <param name="swaggerGenOptions"></param>
+        public static void UseInlineDefinitionsForObjects(this SwaggerGenOptions swaggerGenOptions)
+        {
+            swaggerGenOptions.SchemaGeneratorOptions.UseInlineDefinitionsForObjects = true;
+        }
+
+        /// <summary>
         /// Provide a custom strategy for generating the unique Id's that are used to reference object Schema's
         /// </summary>
         /// <param name="swaggerGenOptions"></param>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -242,7 +242,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 case DataType.Object:
                     {
                         schemaFactory = () => CreateObjectSchema(dataContract, schemaRepository);
-                        returnAsReference = true;
+                        returnAsReference = !_generatorOptions.UseInlineDefinitionsForObjects;
                         break;
                     }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -240,11 +240,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     }
 
                 case DataType.Object:
-                    {
-                        schemaFactory = () => CreateObjectSchema(dataContract, schemaRepository);
-                        returnAsReference = !_generatorOptions.UseInlineDefinitionsForObjects;
-                        break;
-                    }
+                {
+                    schemaFactory = () => CreateObjectSchema(dataContract, schemaRepository);
+                    returnAsReference = !_generatorOptions.UseInlineDefinitionsForObjects ||
+                                        dataContract.ObjectProperties.Any(prop =>
+                                            prop.MemberType.IsAssignableFrom(dataContract.UnderlyingType) ||
+                                            prop.MemberType.GenericTypeArguments.Any(type =>
+                                                type.IsAssignableFrom(dataContract.UnderlyingType)));
+                    break;
+                }
 
                 default:
                     {

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
@@ -19,6 +19,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public IDictionary<Type, Func<OpenApiSchema>> CustomTypeMappings { get; set; }
 
+        public bool UseInlineDefinitionsForObjects { get; set; }
+
         public bool UseInlineDefinitionsForEnums { get; set; }
 
         public Func<Type, string> SchemaIdSelector { get; set; }

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
 using System.Net;
+using System.Numerics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.NewtonsoftJson;
@@ -515,6 +516,19 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Assert.Null(schema.Reference);
             Assert.NotNull(schema.AllOf);
             Assert.Equal(1, schema.AllOf.Count);
+        }
+
+        [Fact]
+        public void GenerateSchema_SupportsOption_UseInlineDefinitionsForObjects()
+        {
+            var subject = Subject(
+                configureGenerator: c => c.UseInlineDefinitionsForObjects = true
+            );
+
+            var schema = subject.GenerateSchema(typeof(ComplexType), new SchemaRepository());
+
+            Assert.Equal("object", schema.Type);
+            Assert.NotNull(schema.Properties);
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -562,6 +562,19 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
+        public void GenerateSchema_SupportsOption_UseReferenceForSelfReferenceTypesWhenUseInlineDefinitionsForObjects()
+        {
+            var subject = Subject(
+                configureGenerator: c => c.UseInlineDefinitionsForObjects = true
+            );
+
+            var schema = subject.GenerateSchema(typeof(SelfReferencingType), new SchemaRepository());
+
+            Assert.NotNull(schema.Reference);
+            Assert.Equal("SelfReferencingType", schema.Reference.Id);
+        }
+
+        [Fact]
         public void GenerateSchema_SupportsOption_UseInlineDefinitionsForEnums()
         {
             var subject = Subject(

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -549,6 +549,19 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
+        public void GenerateSchema_SupportsOption_UseInlineDefinitionsForObjects()
+        {
+            var subject = Subject(
+                configureGenerator: c => c.UseInlineDefinitionsForObjects = true
+            );
+
+            var schema = subject.GenerateSchema(typeof(ComplexType), new SchemaRepository());
+
+            Assert.Equal("object", schema.Type);
+            Assert.NotNull(schema.Properties);
+        }
+
+        [Fact]
         public void GenerateSchema_SupportsOption_UseInlineDefinitionsForEnums()
         {
             var subject = Subject(


### PR DESCRIPTION
Fixes #2426 

Similar to the implementation for inline definitions for Enum values, this change allows object definitions to be configured for inline definitions rather than by reference.