### PR TITLE
#2428 set minLength for RequiredAttribute.AllowEmptyStrings=false

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -66,12 +66,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 // Nullable, ReadOnly & WriteOnly are only relevant for Schema "properties" (i.e. where dataProperty is non-null)
                 if (dataProperty != null)
                 {
+                    var requiredAttribute = customAttributes.OfType<RequiredAttribute>().FirstOrDefault();
                     schema.Nullable = _generatorOptions.SupportNonNullableReferenceTypes
-                        ? dataProperty.IsNullable && !customAttributes.OfType<RequiredAttribute>().Any() && !memberInfo.IsNonNullableReferenceType()
-                        : dataProperty.IsNullable && !customAttributes.OfType<RequiredAttribute>().Any();
+                        ? dataProperty.IsNullable && requiredAttribute==null && !memberInfo.IsNonNullableReferenceType()
+                        : dataProperty.IsNullable && requiredAttribute==null;
 
                     schema.ReadOnly = dataProperty.IsReadOnly;
                     schema.WriteOnly = dataProperty.IsWriteOnly;
+                    schema.MinLength = modelType == typeof(string) && requiredAttribute is { AllowEmptyStrings: false } ? 1 : null;
                 }
 
                 var defaultValueAttribute = customAttributes.OfType<DefaultValueAttribute>().FirstOrDefault();

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -306,8 +306,11 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Assert.Equal("^[3-6]?\\d{12,15}$", schema.Properties["StringWithRegularExpression"].Pattern);
             Assert.Equal(5, schema.Properties["StringWithStringLength"].MinLength);
             Assert.Equal(10, schema.Properties["StringWithStringLength"].MaxLength);
+            Assert.Equal(1, schema.Properties["StringWithRequired"].MinLength);
             Assert.False(schema.Properties["StringWithRequired"].Nullable);
-            Assert.Equal(new[] { "StringWithRequired" }, schema.Required.ToArray());
+            Assert.False(schema.Properties["StringWithRequiredAllowEmptyTrue"].Nullable);
+            Assert.Null(schema.Properties["StringWithRequiredAllowEmptyTrue"].MinLength);
+            Assert.Equal(new[] { "StringWithRequired", "StringWithRequiredAllowEmptyTrue" }, schema.Required.ToArray());
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -316,8 +316,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal("^[3-6]?\\d{12,15}$", schema.Properties["StringWithRegularExpression"].Pattern);
             Assert.Equal(5, schema.Properties["StringWithStringLength"].MinLength);
             Assert.Equal(10, schema.Properties["StringWithStringLength"].MaxLength);
+            Assert.Equal(1, schema.Properties["StringWithRequired"].MinLength);
             Assert.False(schema.Properties["StringWithRequired"].Nullable);
-            Assert.Equal(new[] { "StringWithRequired" }, schema.Required.ToArray());
+            Assert.False(schema.Properties["StringWithRequiredAllowEmptyTrue"].Nullable);
+            Assert.Null(schema.Properties["StringWithRequiredAllowEmptyTrue"].MinLength);
+            Assert.Equal(new[] { "StringWithRequired", "StringWithRequiredAllowEmptyTrue" }, schema.Required.ToArray());
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributes.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributes.cs
@@ -24,5 +24,8 @@ namespace Swashbuckle.AspNetCore.TestSupport
 
         [Required]
         public string StringWithRequired { get; set; }
+
+        [Required(AllowEmptyStrings = true)]
+        public string StringWithRequiredAllowEmptyTrue { get; set; }
     }
 }

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributesViaMetadataType.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributesViaMetadataType.cs
@@ -18,8 +18,9 @@ namespace Swashbuckle.AspNetCore.TestSupport
 
         public string StringWithStringLength { get; set; }
 
-        [Required]
         public string StringWithRequired { get; set; }
+
+        public string StringWithRequiredAllowEmptyTrue { get; set; }
     }
 
     public class MetadataType
@@ -42,7 +43,10 @@ namespace Swashbuckle.AspNetCore.TestSupport
         [StringLength(10, MinimumLength = 5)]
         public string StringWithStringLength { get; set; }
 
-        // NOTE: RequiredAttribute for this is applied in the actual type
+        [Required]
         public string StringWithRequired { get; set; }
+
+        [Required(AllowEmptyStrings = true)]
+        public string StringWithRequiredAllowEmptyTrue { get; set; }
     }
 }


### PR DESCRIPTION
Potentially fixes #2428
When using RequiredAttribute with AllowEmptyStrings=false on a string, a minLength:1 will be added to the schema to inform that the string must not be empty. If any MinLength attributes are set, they will override this value.