### PR TITLE
Update M.E.ApiDescription.Server version to 6.x release

### DIFF
--- a/src/Swashbuckle.AspNetCore/Swashbuckle.AspNetCore.csproj
+++ b/src/Swashbuckle.AspNetCore/Swashbuckle.AspNetCore.csproj
@@ -8,7 +8,7 @@
     <IncludeContentInPack>false</IncludeContentInPack>
     <IncludeSource>false</IncludeSource>
     <IncludeSymbols>false</IncludeSymbols>
-    <MicrosoftExtensionsApiDescriptionServerPackageVersion>3.0.0</MicrosoftExtensionsApiDescriptionServerPackageVersion>
+    <MicrosoftExtensionsApiDescriptionServerPackageVersion>6.0.5</MicrosoftExtensionsApiDescriptionServerPackageVersion>
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
     <PackageId>Swashbuckle.AspNetCore</PackageId>
     <PackageTags>swagger;documentation;discovery;help;webapi;aspnet;aspnetcore</PackageTags>


### PR DESCRIPTION
Update to the latest release of M.E.ApiDescription.Server package to:

- Address issues with resolving the ServiceProvider in the new host model like https://github.com/dotnet/aspnetcore/issues/40577
- Bring in bug fixes like https://github.com/dotnet/aspnetcore/pull/36355 and https://github.com/dotnet/aspnetcore/pull/39293