### PR TITLE
Add support for SecuritySchemesSelector and default implementation

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/IAsyncSwaggerProvider.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/IAsyncSwaggerProvider.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using Microsoft.OpenApi.Models;
+
+namespace Swashbuckle.AspNetCore.Swagger
+{
+    public interface IAsyncSwaggerProvider
+    {
+        Task<OpenApiDocument> GetSwaggerAsync(
+            string documentName,
+            string host = null,
+            string basePath = null);
+    }
+}

--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
@@ -39,10 +39,17 @@ namespace Swashbuckle.AspNetCore.Swagger
                     ? httpContext.Request.PathBase.Value
                     : null;
 
-                var swagger = swaggerProvider.GetSwagger(
-                    documentName: documentName,
-                    host: null,
-                    basePath: basePath);
+                var swagger = swaggerProvider switch
+                {
+                    IAsyncSwaggerProvider asyncSwaggerProvider => await asyncSwaggerProvider.GetSwaggerAsync(
+                        documentName: documentName,
+                        host: null,
+                        basePath: basePath),
+                    _ => swaggerProvider.GetSwagger(
+                        documentName: documentName,
+                        host: null,
+                        basePath: basePath)
+                };
 
                 // One last opportunity to modify the Swagger Document - this time with request context
                 foreach (var filter in _options.PreSerializeFilters)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/DocumentProvider.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/DocumentProvider.cs
@@ -23,12 +23,12 @@ namespace Microsoft.Extensions.ApiDescriptions
     {
         private readonly SwaggerGeneratorOptions _generatorOptions;
         private readonly SwaggerOptions _options;
-        private readonly ISwaggerProvider _swaggerProvider;
+        private readonly IAsyncSwaggerProvider _swaggerProvider;
 
         public DocumentProvider(
             IOptions<SwaggerGeneratorOptions> generatorOptions,
             IOptions<SwaggerOptions> options,
-            ISwaggerProvider swaggerProvider)
+            IAsyncSwaggerProvider swaggerProvider)
         {
             _generatorOptions = generatorOptions.Value;
             _options = options.Value;
@@ -40,10 +40,10 @@ namespace Microsoft.Extensions.ApiDescriptions
             return _generatorOptions.SwaggerDocs.Keys;
         }
 
-        public Task GenerateAsync(string documentName, TextWriter writer)
+        public async Task GenerateAsync(string documentName, TextWriter writer)
         {
             // Let UnknownSwaggerDocument or other exception bubble up to caller.
-            var swagger = _swaggerProvider.GetSwagger(documentName, host: null, basePath: null);
+            var swagger = await _swaggerProvider.GetSwaggerAsync(documentName, host: null, basePath: null);
             var jsonWriter = new OpenApiJsonWriter(writer);
             if (_options.SerializeAsV2)
             {
@@ -53,8 +53,6 @@ namespace Microsoft.Extensions.ApiDescriptions
             {
                 swagger.SerializeAsV3(jsonWriter);
             }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenServiceCollectionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenServiceCollectionExtensions.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // Register generator and it's dependencies
             services.TryAddTransient<ISwaggerProvider, SwaggerGenerator>();
+            services.TryAddTransient<IAsyncSwaggerProvider, SwaggerGenerator>();
             services.TryAddTransient(s => s.GetRequiredService<IOptions<SwaggerGeneratorOptions>>().Value);
             services.TryAddTransient<ISchemaGenerator, SchemaGenerator>();
             services.TryAddTransient(s => s.GetRequiredService<IOptions<SchemaGeneratorOptions>>().Value);

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http.Metadata;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi.Models;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Authentication;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
@@ -19,6 +20,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             OperationIdSelector = DefaultOperationIdSelector;
             TagsSelector = DefaultTagsSelector;
             SortKeySelector = DefaultSortKeySelector;
+            SecuritySchemesSelector = DefaultSecuritySchemeSelector;
             SchemaComparer = StringComparer.Ordinal;
             Servers = new List<OpenApiServer>();
             SecuritySchemes = new Dictionary<string, OpenApiSecurityScheme>();
@@ -61,6 +63,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public IList<IDocumentFilter> DocumentFilters { get; set; }
 
+        public Func<IEnumerable<AuthenticationScheme>,
+            Dictionary<string, OpenApiSecurityScheme>,
+            Dictionary<string, OpenApiSecurityScheme>> SecuritySchemesSelector { get; set;}
+
         private bool DefaultDocInclusionPredicate(string documentName, ApiDescription apiDescription)
         {
             return apiDescription.GroupName == null || apiDescription.GroupName == documentName;
@@ -101,6 +107,29 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private string DefaultSortKeySelector(ApiDescription apiDescription)
         {
             return TagsSelector(apiDescription).First();
+        }
+
+        private Dictionary<string, OpenApiSecurityScheme> DefaultSecuritySchemeSelector(
+            IEnumerable<AuthenticationScheme> schemes,
+            Dictionary<string, OpenApiSecurityScheme> securitySchemes)
+        {
+#if (NET6_0_OR_GREATER)
+            foreach (var scheme in schemes)
+            {
+                if (scheme.Name == "Bearer" && !securitySchemes.ContainsKey("Bearer"))
+                {
+                    securitySchemes[scheme.Name] = new OpenApiSecurityScheme
+                    {
+                        Type = SecuritySchemeType.Http,
+                        Scheme = "bearer", // "bearer" refers to the header name here
+                        In = ParameterLocation.Header,
+                        BearerFormat = "Json Web Token"
+                    };
+                }
+            }
+#endif
+
+            return securitySchemes;
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
@@ -63,9 +63,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public IList<IDocumentFilter> DocumentFilters { get; set; }
 
-        public Func<IEnumerable<AuthenticationScheme>,
-            Dictionary<string, OpenApiSecurityScheme>,
-            Dictionary<string, OpenApiSecurityScheme>> SecuritySchemesSelector { get; set;}
+        public Func<IEnumerable<AuthenticationScheme>, Dictionary<string, OpenApiSecurityScheme>> SecuritySchemesSelector { get; set;}
 
         private bool DefaultDocInclusionPredicate(string documentName, ApiDescription apiDescription)
         {
@@ -109,14 +107,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             return TagsSelector(apiDescription).First();
         }
 
-        private Dictionary<string, OpenApiSecurityScheme> DefaultSecuritySchemeSelector(
-            IEnumerable<AuthenticationScheme> schemes,
-            Dictionary<string, OpenApiSecurityScheme> securitySchemes)
+        private Dictionary<string, OpenApiSecurityScheme> DefaultSecuritySchemeSelector(IEnumerable<AuthenticationScheme> schemes)
         {
+            Dictionary<string, OpenApiSecurityScheme> securitySchemes = new();
 #if (NET6_0_OR_GREATER)
             foreach (var scheme in schemes)
             {
-                if (scheme.Name == "Bearer" && !securitySchemes.ContainsKey("Bearer"))
+                if (scheme.Name == "Bearer")
                 {
                     securitySchemes[scheme.Name] = new OpenApiSecurityScheme
                     {
@@ -128,7 +125,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 }
             }
 #endif
-
             return securitySchemes;
         }
     }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -928,7 +928,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                     {
                         ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
                     },
-                    SecuritySchemesSelector = (schemes, generatedSchemes) => new Dictionary<string, OpenApiSecurityScheme>
+                    SecuritySchemesSelector = (schemes) => new Dictionary<string, OpenApiSecurityScheme>
                     {
                         ["basic"] = new OpenApiSecurityScheme { Type = SecuritySchemeType.Http, Scheme = "basic" }
                     }
@@ -983,6 +983,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var securityScheme = Assert.Single(document.Components.SecuritySchemes);
             Assert.Equal("Bearer", securityScheme.Key);
             Assert.Equal(SecuritySchemeType.ApiKey, securityScheme.Value.Type);
+            Assert.Equal("someSpecialOne", securityScheme.Value.Scheme);
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -12,6 +12,9 @@ using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.TestSupport;
 using Xunit;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Server.HttpSys;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
@@ -911,7 +914,75 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var document = subject.GetSwagger("v1");
 
+            Assert.Equal(new[] { "basic", "Bearer" }, document.Components.SecuritySchemes.Keys);
+        }
+
+        [Fact]
+        public async Task GetSwagger_SupportsSecuritySchemesSelector()
+        {
+            var subject = Subject(
+                apiDescriptions: new ApiDescription[] { },
+                options: new SwaggerGeneratorOptions
+                {
+                    SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                    {
+                        ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                    },
+                    SecuritySchemesSelector = (schemes, generatedSchemes) => new Dictionary<string, OpenApiSecurityScheme>
+                    {
+                        ["basic"] = new OpenApiSecurityScheme { Type = SecuritySchemeType.Http, Scheme = "basic" }
+                    }
+                }
+            );
+
+            var document = await subject.GetSwaggerAsync("v1");
+
+            // Overrides the default set of [basic, bearer] with just [basic]
             Assert.Equal(new[] { "basic" }, document.Components.SecuritySchemes.Keys);
+        }
+
+        [Fact]
+        public async Task GetSwagger_DefaultSecuritySchemeSelectorAddsBearerByDefault()
+        {
+            var subject = Subject(
+                apiDescriptions: new ApiDescription[] { },
+                options: new SwaggerGeneratorOptions
+                {
+                    SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                    {
+                        ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                    },
+                }
+            );
+
+            var document = await subject.GetSwaggerAsync("v1");
+
+            Assert.Equal(new[] { "Bearer" }, document.Components.SecuritySchemes.Keys);
+        }
+
+        [Fact]
+        public async Task GetSwagger_DefaultSecuritySchemesSelectorDoesNotOverrideBearer()
+        {
+            var subject = Subject(
+                apiDescriptions: new ApiDescription[] { },
+                options: new SwaggerGeneratorOptions
+                {
+                    SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                    {
+                        ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                    },
+                    SecuritySchemes = new Dictionary<string, OpenApiSecurityScheme>
+                    {
+                        ["Bearer"] = new OpenApiSecurityScheme { Type = SecuritySchemeType.ApiKey, Scheme = "someSpecialOne" }
+                    }
+                }
+            );
+
+            var document = await subject.GetSwaggerAsync("v1");
+
+            var securityScheme = Assert.Single(document.Components.SecuritySchemes);
+            Assert.Equal("Bearer", securityScheme.Key);
+            Assert.Equal(SecuritySchemeType.ApiKey, securityScheme.Value.Type);
         }
 
         [Fact]
@@ -1049,7 +1120,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             return new SwaggerGenerator(
                 options ?? DefaultOptions,
                 new FakeApiDescriptionGroupCollectionProvider(apiDescriptions),
-                new SchemaGenerator(new SchemaGeneratorOptions(), new JsonSerializerDataContractResolver(new JsonSerializerOptions()))
+                new SchemaGenerator(new SchemaGeneratorOptions(), new JsonSerializerDataContractResolver(new JsonSerializerOptions())),
+                new TestAuthenticationSchemeProvider()
             );
         }
 
@@ -1060,5 +1132,42 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
             }
         };
+    }
+
+    class TestAuthenticationSchemeProvider : IAuthenticationSchemeProvider
+    {
+        private readonly IEnumerable<AuthenticationScheme> _authenticationSchemes = new AuthenticationScheme[]
+        {
+            new AuthenticationScheme("Bearer", null, typeof(IAuthenticationHandler))
+        };
+
+        public void AddScheme(AuthenticationScheme scheme)
+            => throw new NotImplementedException();
+        public Task<IEnumerable<AuthenticationScheme>> GetAllSchemesAsync()
+            => Task.FromResult(_authenticationSchemes);
+
+        public Task<AuthenticationScheme> GetDefaultAuthenticateSchemeAsync()
+            => Task.FromResult(_authenticationSchemes.First());
+
+        public Task<AuthenticationScheme> GetDefaultChallengeSchemeAsync()
+            => Task.FromResult(_authenticationSchemes.First());
+
+        public Task<AuthenticationScheme> GetDefaultForbidSchemeAsync()
+            => Task.FromResult(_authenticationSchemes.First());
+
+        public Task<AuthenticationScheme> GetDefaultSignInSchemeAsync()
+            => Task.FromResult(_authenticationSchemes.First());
+
+        public Task<AuthenticationScheme> GetDefaultSignOutSchemeAsync()
+            => Task.FromResult(_authenticationSchemes.First());
+
+        public Task<IEnumerable<AuthenticationScheme>> GetRequestHandlerSchemesAsync()
+            => throw new NotImplementedException();
+
+        public Task<AuthenticationScheme> GetSchemeAsync(string name)
+            => Task.FromResult(_authenticationSchemes.First());
+
+        public void RemoveScheme(string name)
+            => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
Addresses part of https://github.com/dotnet/aspnetcore/issues/39761 and part of https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/1661.

We've been exploring the possibility of automatically generating `OpenApiSecuritySchemes` by examining authentication/authorization state in an ASP.NET Core app and auto-generating the appropriate annotations. 

- Adds an `IAsyncSwaggerProvider` interface and implementations of `GetSwaggerAsync` to `SwaggerGenerator` to support making async calls to the authentication system
- Adds a new `SecuritySchemesSelector` to `SwaggerGeneratorOptions` for deriving `OpenApiSecuritySchemes` from `AuthenticationSchemes`