### PR TITLE
Improve IncludeXmlComments performance

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -413,13 +413,15 @@ namespace Microsoft.Extensions.DependencyInjection
             bool includeControllerXmlComments = false)
         {
             var xmlDoc = xmlDocFactory();
-            swaggerGenOptions.ParameterFilter<XmlCommentsParameterFilter>(xmlDoc);
-            swaggerGenOptions.RequestBodyFilter<XmlCommentsRequestBodyFilter>(xmlDoc);
-            swaggerGenOptions.OperationFilter<XmlCommentsOperationFilter>(xmlDoc);
-            swaggerGenOptions.SchemaFilter<XmlCommentsSchemaFilter>(xmlDoc);
+            var xmlDocMembers = XmlCommentsDocumentHelper.GetMemberDictionary(xmlDoc);
+
+            swaggerGenOptions.ParameterFilter<XmlCommentsParameterFilter>(xmlDocMembers);
+            swaggerGenOptions.RequestBodyFilter<XmlCommentsRequestBodyFilter>(xmlDocMembers);
+            swaggerGenOptions.OperationFilter<XmlCommentsOperationFilter>(xmlDocMembers);
+            swaggerGenOptions.SchemaFilter<XmlCommentsSchemaFilter>(xmlDocMembers);
 
             if (includeControllerXmlComments)
-                swaggerGenOptions.DocumentFilter<XmlCommentsDocumentFilter>(xmlDoc);
+                swaggerGenOptions.DocumentFilter<XmlCommentsDocumentFilter>(xmlDocMembers);
         }
 
         /// <summary>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentHelper.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Xml.XPath;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen
+{
+    public static class XmlCommentsDocumentHelper
+    {
+        public static IReadOnlyDictionary<string, XPathNavigator> GetMemberDictionary(XPathDocument xmlDoc)
+        {
+            return xmlDoc.CreateNavigator()
+                .Select("/doc/members/member")
+                .OfType<XPathNavigator>()
+                .ToDictionary(memberNode => memberNode.GetAttribute("name", ""));
+        }
+    }
+}

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.OpenApi.Models;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Xml.XPath;
 
@@ -8,14 +7,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     public class XmlCommentsParameterFilter : IParameterFilter
     {
-        private readonly Dictionary<string, XPathNavigator> _docMembers;
+        private readonly IReadOnlyDictionary<string, XPathNavigator> _xmlDocMembers;
 
-        public XmlCommentsParameterFilter(XPathDocument xmlDoc)
+        public XmlCommentsParameterFilter(XPathDocument xmlDoc) : this(XmlCommentsDocumentHelper.GetMemberDictionary(xmlDoc))
         {
-            _docMembers = xmlDoc.CreateNavigator()
-                .Select("/doc/members/member")
-                .OfType<XPathNavigator>()
-                .ToDictionary(memberNode => memberNode.GetAttribute("name", ""));
+        }
+
+        public XmlCommentsParameterFilter(IReadOnlyDictionary<string, XPathNavigator> xmlDocMembers)
+        {
+            _xmlDocMembers = xmlDocMembers;
         }
 
         public void Apply(OpenApiParameter parameter, ParameterFilterContext context)
@@ -34,7 +34,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             var propertyMemberName = XmlCommentsNodeNameHelper.GetMemberNameForFieldOrProperty(context.PropertyInfo);
 
-            if (!_docMembers.TryGetValue(propertyMemberName, out var propertyNode)) return;
+            if (!_xmlDocMembers.TryGetValue(propertyMemberName, out var propertyNode)) return;
 
             var summaryNode = propertyNode.SelectSingleNode("summary");
             if (summaryNode != null)
@@ -66,7 +66,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             var methodMemberName = XmlCommentsNodeNameHelper.GetMemberNameForMethod(targetMethod);
 
-            if (!_docMembers.TryGetValue(methodMemberName, out var propertyNode)) return;
+            if (!_xmlDocMembers.TryGetValue(methodMemberName, out var propertyNode)) return;
 
             var paramNode = propertyNode.SelectSingleNode($"param[@name='{context.ParameterInfo.Name}']");
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
@@ -1,16 +1,21 @@
-﻿using System.Reflection;
+﻿using Microsoft.OpenApi.Models;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using System.Xml.XPath;
-using Microsoft.OpenApi.Models;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     public class XmlCommentsParameterFilter : IParameterFilter
     {
-        private XPathNavigator _xmlNavigator;
+        private readonly Dictionary<string, XPathNavigator> _docMembers;
 
         public XmlCommentsParameterFilter(XPathDocument xmlDoc)
         {
-            _xmlNavigator = xmlDoc.CreateNavigator();
+            _docMembers = xmlDoc.CreateNavigator()
+                .Select("/doc/members/member")
+                .OfType<XPathNavigator>()
+                .ToDictionary(memberNode => memberNode.GetAttribute("name", ""));
         }
 
         public void Apply(OpenApiParameter parameter, ParameterFilterContext context)
@@ -28,9 +33,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private void ApplyPropertyTags(OpenApiParameter parameter, ParameterFilterContext context)
         {
             var propertyMemberName = XmlCommentsNodeNameHelper.GetMemberNameForFieldOrProperty(context.PropertyInfo);
-            var propertyNode = _xmlNavigator.SelectSingleNode($"/doc/members/member[@name='{propertyMemberName}']");
 
-            if (propertyNode == null) return;
+            if (!_docMembers.TryGetValue(propertyMemberName, out var propertyNode)) return;
 
             var summaryNode = propertyNode.SelectSingleNode("summary");
             if (summaryNode != null)
@@ -61,8 +65,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             if (targetMethod == null) return;
 
             var methodMemberName = XmlCommentsNodeNameHelper.GetMemberNameForMethod(targetMethod);
-            var paramNode = _xmlNavigator.SelectSingleNode(
-                $"/doc/members/member[@name='{methodMemberName}']/param[@name='{context.ParameterInfo.Name}']");
+
+            if (!_docMembers.TryGetValue(methodMemberName, out var propertyNode)) return;
+
+            var paramNode = propertyNode.SelectSingleNode($"param[@name='{context.ParameterInfo.Name}']");
 
             if (paramNode != null)
             {


### PR DESCRIPTION
This PR seeks to address the performance issues highlighted in https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2164

The slow performance mainly stems from the use of SelectSingleNode to search for member nodes. By creating a dictionary of all the member nodes once, the nodes can later be looked up against this dictionary much more efficiently.

In one app I work on - with a few hundred endpoints and lots of XML comments - this took swagger generation down from 25 seconds to 4 seconds.

I've tried to keep changes to a minimum and backwards compatible to increase chances of an early patch or minor release. For example, the existing set of constructors on the filters remain for external backwards compatibility but are no longer used within swashbuckle itself. The new set of constructors take a dictionary instead, which allows one to be created in the extension method and shared between all of the filters. 

You may also get some further gains by fully parsing the XML document into a model of some kind, but I think that would be unnecessary as it was really the search for member nodes that was the killer.