### PR TITLE
Add doc comments for IServiceCollection extensions

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenServiceCollectionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenServiceCollectionExtensions.cs
@@ -9,8 +9,17 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
+    /// <summary>
+    /// Extension methods for configuring Swagger generation on <see cref="IServiceCollection" />.
+    /// </summary>
     public static class SwaggerGenServiceCollectionExtensions
     {
+        /// <summary>
+        /// Add services required by the Swagger generation middleware.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" />.</param>
+        /// <param name="setupAction">A lambda that configures Swagger generation options.</param>
+        /// <returns>The <see cref="IServiceCollection" />.</returns>
         public static IServiceCollection AddSwaggerGen(
             this IServiceCollection services,
             Action<SwaggerGenOptions> setupAction = null)
@@ -50,6 +59,12 @@ namespace Microsoft.Extensions.DependencyInjection
             return services;
         }
 
+        /// <summary>
+        /// Configure options for Swagger generation.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection" />.</param>
+        /// <param name="setupAction">A lambda that configures Swagger generation options.</param>
+        /// <returns>The <see cref="IServiceCollection" />.</returns>
         public static void ConfigureSwaggerGen(
             this IServiceCollection services,
             Action<SwaggerGenOptions> setupAction)


### PR DESCRIPTION
Noticed the `builder.Services.AddSwaggerGen()` calls were missing statement help in IntelliSense;
<img width="825" alt="image" src="https://user-images.githubusercontent.com/249088/179632605-c0ae8dac-4ab2-4a93-a44f-d5120b3119d5.png">
