### PR TITLE
Added missing bracket in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1437,7 +1437,7 @@ The `SwaggerGen` package provides several extension points, including Schema Fil
 
 ```csharp
 // Product.cs
-[SwaggerSchemaFilter(typeof(ProductSchemaFilter))
+[SwaggerSchemaFilter(typeof(ProductSchemaFilter))]
 public class Product
 {
     ...


### PR DESCRIPTION
Minor update in one of the examples in the readme. 