### PR TITLE
Add MapSwaggerUI for endpoint routing

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.Builder
             this IApplicationBuilder app,
             Action<SwaggerUIOptions> setupAction = null)
         {
-            SwaggerUIOptions options = FetchAndConfigureOptions(endpoints.ServiceProvider, setupAction);
+            SwaggerUIOptions options = FetchAndConfigureOptions(app.ApplicationServices, setupAction);
 
             return app.UseSwaggerUI(options);
         }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
@@ -8,6 +8,12 @@ using Swashbuckle.AspNetCore.SwaggerUI;
 using IWebHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
 #endif
 
+#if (!NETSTANDARD2_0)
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
+#endif
+
 namespace Microsoft.AspNetCore.Builder
 {
     public static class SwaggerUIBuilderExtensions

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
@@ -21,27 +21,65 @@ namespace Microsoft.AspNetCore.Builder
         }
 
         /// <summary>
-        /// Register the SwaggerUI middleware with optional setup action for DI-injected options
+        /// Register the SwaggerUI middleware with DI-injected options
         /// </summary>
+        /// <param name="setupAction">Optional action to modifiy the DI-injected options</param>
         public static IApplicationBuilder UseSwaggerUI(
             this IApplicationBuilder app,
             Action<SwaggerUIOptions> setupAction = null)
         {
+            SwaggerUIOptions options = FetchAndConfigureOptions(endpoints.ServiceProvider, setupAction);
+
+            return app.UseSwaggerUI(options);
+        }
+
+#if (!NETSTANDARD2_0)
+        /// <summary>
+        /// Register the SwaggerUI middleware with DI-injected options. Uses the endpoint routing syntax.
+        /// </summary>
+        /// <param name="setupAction">Optional action to modifiy the DI-injected options</param>
+        public static IEndpointConventionBuilder MapSwaggerUI(
+            this IEndpointRouteBuilder endpoints,
+            Action<SwaggerUIOptions>? setupAction = null)
+        {
+            SwaggerUIOptions options = FetchAndConfigureOptions(endpoints.ServiceProvider, setupAction);
+
+            var swaggerUiDelegate = endpoints.CreateApplicationBuilder()
+                .Use((context, next) =>
+                {
+                        // workaround for https://github.com/dotnet/aspnetcore/issues/24252
+                    context.SetEndpoint(null);
+                    return next();
+                })
+                .UseSwaggerUI(options)
+                .Build();
+
+            return endpoints.MapGet(options.RoutePrefix + "/{*wildcard}", swaggerUiDelegate);
+        }
+#endif
+
+        /// <summary>
+        /// Fetches the options instance registered with the DI, applies the local setup action and configures some defaults.
+        /// </summary>
+        private static SwaggerUIOptions FetchAndConfigureOptions(IServiceProvider serviceProvider, Action<SwaggerUIOptions>? setupAction = null)
+        {
+            // if a preconfigured instance of SwaggerUIOptions is registered with the DI, 
+            //      use it as a basis and then apply the local setup to it
             SwaggerUIOptions options;
-            using (var scope = app.ApplicationServices.CreateScope())
+            using (var scope = serviceProvider.CreateScope())
             {
                 options = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<SwaggerUIOptions>>().Value;
                 setupAction?.Invoke(options);
             }
 
-            // To simplify the common case, use a default that will work with the SwaggerMiddleware defaults
+            // To simplify the common case, use a default that will work with the SwaggerOptions and SwaggerGenOptions defaults
             if (options.ConfigObject.Urls == null)
             {
-                var hostingEnv = app.ApplicationServices.GetRequiredService<IWebHostEnvironment>();
+                var hostingEnv = serviceProvider.GetRequiredService<IWebHostEnvironment>();
                 options.ConfigObject.Urls = new[] { new UrlDescriptor { Name = $"{hostingEnv.ApplicationName} v1", Url = "v1/swagger.json" } };
             }
 
-            return app.UseSwaggerUI(options);
+            return options;
         }
     }
 }


### PR DESCRIPTION
fixes #2061 
fixes #1726
alternative to #2266 

Has the exact same behavior with regard to options as the `UseSwaggerUI` overload with setupAction. That is it loads any `SwaggerUIOptions` provided via DI and applies the same defaults as said `UseSwaggerUI` overload.

Comparing it to `MapSwagger` the main difference is the avoidance of yet another options type. Which is, as far as I can tell a straight copy of the original one. What was the rationale behind that design?

