### PR TITLE
Updates Microsoft.AspNetCore.Mvc.NewtonsoftJson from pre-release .Net 6 package

### DIFF
--- a/src/Swashbuckle.AspNetCore.Newtonsoft/Swashbuckle.AspNetCore.Newtonsoft.csproj
+++ b/src/Swashbuckle.AspNetCore.Newtonsoft/Swashbuckle.AspNetCore.Newtonsoft.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0-rc.1.21452.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updates Microsoft.AspNetCore.Mvc.NewtonsoftJson from pre-release .Net 6 (6.0.0-rc.1.21452.15) to release .Net 6 package (6.0.0)

fixes #2471

### Dependencies
New: **[6.0.0](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.NewtonsoftJson/6.0.0#dependencies-body-tab)**

net6.0
[Microsoft.AspNetCore.JsonPatch](https://www.nuget.org/packages/Microsoft.AspNetCore.JsonPatch/) (>= 6.0.0)
[Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/) (>= 13.0.1)
[Newtonsoft.Json.Bson](https://www.nuget.org/packages/Newtonsoft.Json.Bson/) (>= 1.0.2)

Previous: **[6.0.0-rc.1.21452.15](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.NewtonsoftJson/6.0.0-rc.1.21452.15#dependencies-body-tab)**

net6.0
[Microsoft.AspNetCore.JsonPatch](https://www.nuget.org/packages/Microsoft.AspNetCore.JsonPatch/) (>= 6.0.0-rc.1.21452.15)
[Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json/) (>= 13.0.1)
[Newtonsoft.Json.Bson](https://www.nuget.org/packages/Newtonsoft.Json.Bson/) (>= 1.0.2)



