### PR TITLE
Replacing thread-safe version dictionary objects for SchemaRepository

### DIFF
--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -442,7 +442,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 
             var schema = subject.GenerateSchema(typeof(BaseType), schemaRepository);
 
-            Assert.Equal(new[] { "SubType1", "BaseType" }, schemaRepository.Schemas.Keys);
+            Assert.Equal(new[] { "SubType1", "BaseType" }, schemaRepository.Schemas.Keys.OrderByDescending(t=>t).ToArray());
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -473,7 +473,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var schema = subject.GenerateSchema(typeof(BaseType), schemaRepository);
 
-            Assert.Equal(new[] { "SubType1", "BaseType" }, schemaRepository.Schemas.Keys);
+            Assert.Equal(new[] { "SubType1", "BaseType" }, schemaRepository.Schemas.Keys.OrderByDescending(t => t).ToArray());
         }
 
         [Fact]


### PR DESCRIPTION
I am trying to replace the GeneratePaths part of the logic of SwaggerGenerator with concurrent execution. I accidentally found that the dictionary storage structure in the SchemaRepository object is not thread-safe, which causes the logic of concurrent construction to not proceed normally, prompting an exception when adding a dictionary, here by replacing the storage structure solves this problem