### PR TITLE
Fix msbuild flags for SourceLink

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,8 +8,8 @@
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageProjectUrl>https://github.com/domaindrivendev/Swashbuckle.AspNetCore</PackageProjectUrl>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/domaindrivendev/Swashbuckle.AspNetCore.git</RepositoryUrl>
+		<DebugType>embedded</DebugType>
+		<ContinuousIntegrationBuild Condition="'$(APPVEYOR)' == 'True'">true</ContinuousIntegrationBuild>
 		<VersionPrefix>6.4.0</VersionPrefix>
 		<LangVersion>9</LangVersion>
 	</PropertyGroup>
@@ -19,7 +19,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.*" PrivateAssets="All" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
@domaindrivendev I noticed your SourceLink integration is not quite right so here are the necessary msbuild props that will get all the checkboxes on [NuGet Package Explorer](https://nuget.info/packages/Swashbuckle.AspNetCore.SwaggerGen/6.4.0) to go green.

Since it looks like you use AppVeyor for your CI process I have set the ContinuousIntegrationBuild to toggle on only when AppVeyor does the building.

Note: Setting PublishRepositoryUrl will cause SourceLink to emit the necessary repository properties so I pulled them out as they are not needed.

Let me know if you have any issues.