### PR TITLE
Support new `UseInlineDefinitionsForObjects` flag

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
@@ -32,6 +32,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             target.CustomTypeMappings = new Dictionary<Type, Func<OpenApiSchema>>(source.CustomTypeMappings);
             target.UseInlineDefinitionsForEnums = source.UseInlineDefinitionsForEnums;
+            target.UseInlineDefinitionsForObjects = source.UseInlineDefinitionsForObjects;
             target.SchemaIdSelector = source.SchemaIdSelector;
             target.IgnoreObsoleteProperties = source.IgnoreObsoleteProperties;
             target.UseAllOfForInheritance = source.UseAllOfForInheritance;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -205,6 +205,14 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Generate inline schema definitions (as opposed to referencing a shared definition) for complex objects
+        /// </summary>
+        public static void UseInlineDefinitionsForObjects(this SwaggerGenOptions swaggerGenOptions)
+        {
+            swaggerGenOptions.SchemaGeneratorOptions.UseInlineDefinitionsForObjects = true;
+        }
+
+        /// <summary>
         /// Provide a custom strategy for generating the unique Id's that are used to reference object Schema's
         /// </summary>
         /// <param name="swaggerGenOptions"></param>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -244,7 +244,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 case DataType.Object:
                     {
                         schemaFactory = () => CreateObjectSchema(dataContract, schemaRepository);
-                        returnAsReference = true;
+                        returnAsReference = !_generatorOptions.UseInlineDefinitionsForObjects;
                         break;
                     }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
@@ -21,6 +21,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public bool UseInlineDefinitionsForEnums { get; set; }
 
+        public bool UseInlineDefinitionsForObjects { get; set; }
+
         public Func<Type, string> SchemaIdSelector { get; set; }
 
         public bool IgnoreObsoleteProperties { get; set; }

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -534,6 +534,19 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         }
 
         [Fact]
+        public void GenerateSchema_SupportsOption_UseInlineDefinitionsForObjects()
+        {
+            var subject = Subject(
+                configureGenerator: c => c.UseInlineDefinitionsForObjects = true
+            );
+
+            var schema = subject.GenerateSchema(typeof(ComplexType), new SchemaRepository());
+
+            Assert.Null(schema.Reference);
+            Assert.Equal("object", schema.Type);
+        }
+
+        [Fact]
         public void GenerateSchema_HandlesTypesWithNestedTypes()
         {
             var schemaRepository = new SchemaRepository();

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -568,6 +568,19 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.NotNull(schema.Enum);
         }
 
+        [Fact]
+        public void GenerateSchema_SupportsOption_UseInlineDefinitionsForObjects()
+        {
+            var subject = Subject(
+                configureGenerator: c => c.UseInlineDefinitionsForObjects = true
+            );
+
+            var schema = subject.GenerateSchema(typeof(ComplexType), new SchemaRepository());
+
+            Assert.Null(schema.Reference);
+            Assert.Equal("object", schema.Type);
+        }
+
         [Theory]
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableInt), true)]
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableInt), false)]


### PR DESCRIPTION
# Problem

When a request/response has a nested object, there are two pieces of information missing from the generated doc file:

1. The property's `summary` is not displayed.
2. The `Nullable` marker is not shown for `nullable` properties.

---

## Here's a screenshot of what it looks like now:

![image](https://user-images.githubusercontent.com/50371646/159804958-c1a446c8-b973-46b1-a198-f7cf603b9bb5.png)

## Here's a screenshot of the source code for the above:

![image](https://user-images.githubusercontent.com/50371646/159805176-f7192116-6b4e-4722-82da-081a5b031fa3.png)

As you can see, this property has a nice `summary`, and is `nullable`.

## Here's a screenshot of what it I would expect:

![image](https://user-images.githubusercontent.com/50371646/159805315-3619e1de-5677-4a94-8e68-3fbb55cda884.png)

# Underlying Cause

It looks to me like the reason it's not generating that properly is because the object is only a reference, and Swagger doesn't support these on references. As [the Swagger specification](https://swagger.io/specification/#reference-object) says, regarding `$ref`s:

> This object cannot be extended with additional properties and any properties added SHALL be ignored.

# Proposed Solution

We have [previously](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/commit/9abdbf99a271de5decb2bd93c5c614632e750b32) introduced an option to `UseInlineDefinitionsForEnums`. Among other things, this will show the summary of a property that is an enum, and will also show the `Nullable` marker accordingly.

This PR adds a similar `UseInlineDefinitionsForObjects` option. When enabled, it'll inline the whole schema, and will properly show the `summary` and whether it's `nullable`:

![image](https://user-images.githubusercontent.com/50371646/159805315-3619e1de-5677-4a94-8e68-3fbb55cda884.png)



> Copied from https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/2384 which was accidentally closed.