### PR TITLE
Fix bug in the extension method 'InferSecuritySchemes' so it will actually enable it

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSwaggerGeneratorOptions.cs
@@ -68,6 +68,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             target.ParameterFilters = new List<IParameterFilter>(source.ParameterFilters);
             target.OperationFilters = new List<IOperationFilter>(source.OperationFilters);
             target.DocumentFilters = new List<IDocumentFilter>(source.DocumentFilters);
+            target.InferSecuritySchemes = source.InferSecuritySchemes;
+            target.SecuritySchemesSelector = source.SecuritySchemesSelector;
         }
 
         private TFilter CreateFilter<TFilter>(FilterDescriptor filterDescriptor)


### PR DESCRIPTION
When using the extension method `InferSecuritySchemes` it wont actually do anything because its not being deepcopied to the new object

```cs
options.InferSecuritySchemes(schemes => new Dictionary<string, OpenApiSecurityScheme>
{
    ["OAuth2"] = new OpenApiSecurityScheme
    {
        Type = SecuritySchemeType.OAuth2,
        Name = "OAuth2",
    },
});
```