### PR TITLE
Support for associating XML Comments with custom tags defined using TagsAttribute

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -422,7 +422,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="xmlDocFactory">A factory method that returns XML Comments as an XPathDocument</param>
         /// <param name="includeControllerXmlComments">
         /// Flag to indicate if controller XML comments (i.e. summary) should be used to assign Tag descriptions.
-        /// Don't set this flag if you're customizing the default tag for operations via TagActionsBy.
+        /// If customizing the default tag for operations via TagsAttribute, only the first Tag per controller will be
+        /// associated with the description.
+        /// However, don't set this flag if you're customizing the default tag for operations via TagActionsBy.
         /// </param>
         public static void IncludeXmlComments(
             this SwaggerGenOptions swaggerGenOptions,
@@ -446,7 +448,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="filePath">An absolute path to the file that contains XML Comments</param>
         /// <param name="includeControllerXmlComments">
         /// Flag to indicate if controller XML comments (i.e. summary) should be used to assign Tag descriptions.
-        /// Don't set this flag if you're customizing the default tag for operations via TagActionsBy.
+        /// If customizing the default tag for operations via TagsAttribute, only the first Tag per controller will be
+        /// associated with the description.
+        /// However, don't set this flag if you're customizing the default tag for operations via TagActionsBy.
         /// </param>
         public static void IncludeXmlComments(
             this SwaggerGenOptions swaggerGenOptions,

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/KeyValuePairExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/KeyValuePairExtensions.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen
+{
+    public static class KeyValuePairExtensions
+    {
+        // Explicit deconstruct required for older .NET frameworks
+        public static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> kvp, out TKey key, out TValue value)
+        {
+            key = kvp.Key;
+            value = kvp.Value;
+        }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithCustomTagAndXmlSummary.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithCustomTagAndXmlSummary.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test
+{
+    /// <summary>
+    /// Summary for FakeControllerWithCustomTag
+    /// </summary>
+    [Tags("fake controller custom tag")]
+    public class FakeControllerWithCustomTag
+    {
+        public void ActionAny()
+        { }
+
+        public void ActionAnother()
+        { }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithXmlComments.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithXmlComments.cs
@@ -1,7 +1,4 @@
-﻿using Swashbuckle.AspNetCore.TestSupport;
-using System;
-
-namespace Swashbuckle.AspNetCore.SwaggerGen.Test
+﻿namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
     /// <summary>
     /// Summary for FakeControllerWithXmlComments

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsDocumentFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsDocumentFilterTests.cs
@@ -23,7 +23,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                         ActionDescriptor = new ControllerActionDescriptor
                         {
                             ControllerTypeInfo = typeof(FakeControllerWithXmlComments).GetTypeInfo(),
-                            ControllerName = nameof(FakeControllerWithXmlComments)
+                            ControllerName = nameof(FakeControllerWithXmlComments),
+                            MethodInfo = typeof(FakeControllerWithXmlComments).GetMethod(nameof(FakeControllerWithXmlComments.ActionWithParamTags))!
                         }
                     },
                     new ApiDescription
@@ -31,7 +32,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                         ActionDescriptor = new ControllerActionDescriptor
                         {
                             ControllerTypeInfo = typeof(FakeControllerWithXmlComments).GetTypeInfo(),
-                            ControllerName = nameof(FakeControllerWithXmlComments)
+                            ControllerName = nameof(FakeControllerWithXmlComments),
+                            MethodInfo = typeof(FakeControllerWithXmlComments).GetMethod(nameof(FakeControllerWithXmlComments.ActionWithParamTags))!
                         }
                     }
                 },
@@ -41,7 +43,89 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Subject().Apply(document, filterContext);
 
             var tag = Assert.Single(document.Tags);
+            Assert.Equal("FakeControllerWithXmlComments", tag.Name);
             Assert.Equal("Summary for FakeControllerWithXmlComments", tag.Description);
+        }
+
+        [Fact]
+        public void Apply_SetsCustomTagNameAndDescription_FromControllerAttributesAndSummaryTags()
+        {
+            var document = new OpenApiDocument();
+            var filterContext = new DocumentFilterContext(
+                new[]
+                {
+                    new ApiDescription
+                    {
+                        ActionDescriptor = new ControllerActionDescriptor
+                        {
+                            ControllerTypeInfo = typeof(FakeControllerWithCustomTag).GetTypeInfo(),
+                            ControllerName = nameof(FakeControllerWithCustomTag),
+                            MethodInfo = typeof(FakeControllerWithCustomTag).GetMethod(nameof(FakeControllerWithCustomTag.ActionAny))!
+                        }
+                    },
+                    new ApiDescription
+                    {
+                        ActionDescriptor = new ControllerActionDescriptor
+                        {
+                            ControllerTypeInfo = typeof(FakeControllerWithCustomTag).GetTypeInfo(),
+                            ControllerName = nameof(FakeControllerWithCustomTag),
+                            MethodInfo = typeof(FakeControllerWithCustomTag).GetMethod(nameof(FakeControllerWithCustomTag.ActionAnother))!
+                        }
+                    }
+                },
+                null,
+                null);
+
+            Subject().Apply(document, filterContext);
+
+            Assert.Equal(1, document.Tags.Count);
+            Assert.Equal("fake controller custom tag", document.Tags[0].Name);
+            Assert.Equal("Summary for FakeControllerWithCustomTag", document.Tags[0].Description);
+        }
+
+        [Fact]
+        public void Apply_SetsTagNameWithNoDescription_ForControllerWithoutSummaryTags()
+        {
+            var document = new OpenApiDocument();
+            var filterContext = new DocumentFilterContext(
+                new[]
+                {
+                    new ApiDescription
+                    {
+                        ActionDescriptor = new ControllerActionDescriptor
+                        {
+                            ControllerTypeInfo = typeof(FakeController).GetTypeInfo(),
+                            ControllerName = nameof(FakeController),
+                            MethodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter))!
+                        }
+                    },
+                    new ApiDescription
+                    {
+                        ActionDescriptor = new ControllerActionDescriptor
+                        {
+                            ControllerTypeInfo = typeof(FakeControllerWithCustomTag).GetTypeInfo(),
+                            ControllerName = nameof(FakeControllerWithCustomTag),
+                            MethodInfo = typeof(FakeControllerWithCustomTag).GetMethod(nameof(FakeControllerWithCustomTag.ActionAny))!
+                        }
+                    }
+                },
+                null,
+                null);
+
+            Subject().Apply(document, filterContext);
+
+            Assert.Equal(2, document.Tags.Count);
+            Assert.Collection(document.Tags,
+                tag1 =>
+                {
+                    Assert.Equal("fake controller custom tag", tag1.Name);
+                    Assert.Equal("Summary for FakeControllerWithCustomTag", tag1.Description);
+                },
+                tag2 =>
+                {
+                    Assert.Equal("FakeController", tag2.Name);
+                    Assert.Null(tag2.Description);
+                });
         }
 
         private static XmlCommentsDocumentFilter Subject()


### PR DESCRIPTION
## Description & reference issues

As of .NET 6.0, Swagger/OpenAPI supports using [TagsAttribute](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.tagsattribute?view=aspnetcore-7.0) to rename each group of endpoints, overriding the default value of the controller name. (See also e.g. [the top voted answer by Raul on this SO question](https://stackoverflow.com/questions/37076173/is-there-a-way-change-the-controllers-name-in-the-swagger-ui-page))

The existing implementation of Swashbuckle's XmlCommentsDocumentFilter associates the controller's `<summary>` XML comment with the controller name. It currently has two limitations:

1. It does not support using TagsAttribute - it only links the summary node with the controller name. See the last four comments on #467, these last comments refer to the new TagsAttribute instead of TagActionsBy.

2. It only adds tags for controllers with a summary node. If the user has summary nodes for some controllers but not others, then the root tags object will only include a partial list of tags. This results in the side-effect that tags are not displayed in alphabetical order. Instead, tags with descriptions are displayed first, followed by tags without descriptons. Related issues:
    - #2162  
    - #1757

Another linked issue #2530  is a result of both these limitations.

This PR fixes both these issues. If IncludeXmlComments is true: 
 - then the resulting tag names & descriptions will support the new TagsAttribute, falling back to the default (controller name) if TagsAttribute is not used.
 - then the resulting root tags object will contain all controller-level tags, regardless of whether they have an XML summary node or not. Those without a summary node will not have any "description" field.

## Tests

Tests are included for the target framework .NET 6.0, which supports TagsAttribute. The SwaggerGen.Tests project currently only targets .NET 6.0, so I did not add unit tests for earlier frameworks. I built the project in .NET 5.0 and did a manual test of this case to check it works.

## Potential improvements

This PR still has some limitations:
 - TagsAttribute theoretically allows you to specify more than one custom tag e.g. by `[Tags("first tag", "second tag")]` however I don't see this as a primary use case in generating the swagger file, and there is no way of providing separate XML summaries for the two tags, so this is not supported in this PR - only the first tag is supported.
 - TagsAttribute can be specified at the method level, if so, such tags would still be omitted from the root tags object.

If it's actually useful, I would be happy to add support for these cases.