### PR TITLE
Add possibility to hook into the config initialization.

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
@@ -102,6 +102,11 @@
             if (interceptors.ResponseInterceptorFunction)
                 configObject.responseInterceptor = parseFunction(interceptors.ResponseInterceptorFunction);
 
+            // Allow adjusting config through injected JavaScript files
+            if(typeof initConfig === "function") {
+                initConfig(configObject, oauthConfigObject);
+            }
+            
             // Begin Swagger UI call region
 
             const ui = SwaggerUIBundle(configObject);


### PR DESCRIPTION
To register custom plugins and customize the Swagger UI it is currently required to provide an own `index.html`. This has the negative impact of keeping it up-to-date with Swashbuckle. 

This PR extends the default index.html with a new way of hooking into the Swagger UI setup allowing devs to register plugins and change settings within a custom injected JavaScript acting as entry point. 

I extended also the docs to show some basics on how the Plugin API and React can be used in such a setup to customize the UI even further. We have been doing this for quite a while using a custom `index.html` but having such a feature by-default would bring benefit to everyone (and we do not need to maintain it once per API 😁). 