### PR TITLE
Added Swashbuckle.AspNetCore.Annotations.SwaggerIgnoreAttribute

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/SwaggerIgnoreAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/SwaggerIgnoreAttribute.cs
@@ -1,0 +1,16 @@
+using System;
+
+// ReSharper disable once CheckNamespace
+namespace Swashbuckle.AspNetCore.Annotations
+{
+    /// <summary>
+    /// Causes the annotated member to be ignored during schema generation.
+    /// Does not alter serialization behavior.
+    /// </summary>
+    /// <remarks>
+    /// Can be used in combination with <see cref="System.Text.Json.Serialization.JsonExtensionDataAttribute"/>
+    /// to capture and invalidate unsupported properties.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class SwaggerIgnoreAttribute : Attribute { }
+}

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/SwaggerIgnoreAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/SwaggerIgnoreAttribute.cs
@@ -11,6 +11,6 @@ namespace Swashbuckle.AspNetCore.Annotations
     /// Can be used in combination with <see cref="System.Text.Json.Serialization.JsonExtensionDataAttribute"/>
     /// to capture and invalidate unsupported properties.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property)]
     public class SwaggerIgnoreAttribute : Attribute { }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/SwaggerIgnoreAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/SwaggerIgnoreAttribute.cs
@@ -12,5 +12,5 @@ namespace Swashbuckle.AspNetCore.Annotations
     /// to capture and invalidate unsupported properties.
     /// </remarks>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Parameter | AttributeTargets.Property)]
-    public class SwaggerIgnoreAttribute : Attribute { }
+    public sealed class SwaggerIgnoreAttribute : Attribute { }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/SwaggerIgnoreAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/Annotations/SwaggerIgnoreAttribute.cs
@@ -11,6 +11,6 @@ namespace Swashbuckle.AspNetCore.Annotations
     /// Can be used in combination with <see cref="System.Text.Json.Serialization.JsonExtensionDataAttribute"/>
     /// to capture and invalidate unsupported properties.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property)]
     public class SwaggerIgnoreAttribute : Attribute { }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
@@ -166,6 +167,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                         (property.IsPubliclyReadable() || property.IsPubliclyWritable()) &&
                         !(property.GetIndexParameters().Any()) &&
                         !(property.HasAttribute<JsonIgnoreAttribute>() && isIgnoredViaNet5Attribute) &&
+                        !(property.HasAttribute<SwaggerIgnoreAttribute>()) &&
                         !(_serializerOptions.IgnoreReadOnlyProperties && !property.IsPubliclyWritable());
                 })
                 .OrderBy(property => property.DeclaringType.GetInheritanceChain().Length);

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -321,6 +321,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 {
                     return (!apiParam.IsFromBody() && !apiParam.IsFromForm())
                         && (!apiParam.CustomAttributes().OfType<BindNeverAttribute>().Any())
+                        && (!apiParam.CustomAttributes().OfType<SwaggerIgnoreAttribute>().Any())
                         && (apiParam.ModelMetadata == null || apiParam.ModelMetadata.IsBindingAllowed);
                 });
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.Annotations;
 using Swashbuckle.AspNetCore.Swagger;
 #if NET7_0_OR_GREATER
 using Microsoft.AspNetCore.Http.Metadata;
@@ -86,6 +87,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             var applicableApiDescriptions = _apiDescriptionsProvider.ApiDescriptionGroups.Items
                 .SelectMany(group => group.Items)
                 .Where(apiDesc => !(_options.IgnoreObsoleteActions && apiDesc.CustomAttributes().OfType<ObsoleteAttribute>().Any()))
+                .Where(apiDesc => !apiDesc.CustomAttributes().OfType<SwaggerIgnoreAttribute>().Any())
                 .Where(apiDesc => _options.DocInclusionPredicate(documentName, apiDesc));
 
             var schemaRepository = new SchemaRepository(documentName);

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeController.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeController.cs
@@ -50,6 +50,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void ActionWithIntParameterWithRequiredAttribute([Required]int param)
         { }
 
+        public void ActionWithIntParameterWithSwaggerIgnoreAttribute([SwaggerIgnore] int param)
+        { }
+
         public void ActionWithObjectParameter(XmlAnnotatedType param)
         { }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeController.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeController.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
@@ -66,5 +67,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         {
             throw new NotImplementedException();
         }
+
+        [SwaggerIgnore]
+        public void ActionWithSwaggerIgnoreAttribute()
+        { }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/SwaggerIngoreAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/SwaggerIngoreAnnotatedType.cs
@@ -3,7 +3,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Swashbuckle.AspNetCore.Annotations;
 
-namespace Swashbuckle.AspNetCore.SwaggerGen.Test.Fixtures {
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test.Fixtures
+{
     public class SwaggerIngoreAnnotatedType
     {
         public string NotIgnoredString { get; set; }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/SwaggerIngoreAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/SwaggerIngoreAnnotatedType.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test.Fixtures {
+    public class SwaggerIngoreAnnotatedType
+    {
+        public string NotIgnoredString { get; set; }
+
+        [SwaggerIgnore]
+        public string IgnoredString { get; set; }
+
+        [SwaggerIgnore]
+        [JsonExtensionData]
+        public IDictionary<string, JsonElement> IgnoredExtensionData { get; set; }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -788,7 +788,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
-        public void GenerateSchema_HonorsAttribute_SwaggerIgnore() {
+        public void GenerateSchema_HonorsAttribute_SwaggerIgnore()
+        {
             var schemaRepository = new SchemaRepository();
 
             var referenceSchema = Subject().GenerateSchema(typeof(SwaggerIngoreAnnotatedType), schemaRepository);

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -15,6 +15,7 @@ using Microsoft.OpenApi.Models;
 using Xunit;
 using Swashbuckle.AspNetCore.TestSupport;
 using Microsoft.OpenApi.Any;
+using Swashbuckle.AspNetCore.SwaggerGen.Test.Fixtures;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
@@ -784,6 +785,21 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.True(schema.AdditionalPropertiesAllowed);
             Assert.NotNull(schema.AdditionalProperties);
             Assert.Null(schema.AdditionalProperties.Type);
+        }
+
+        [Fact]
+        public void GenerateSchema_HonorsAttribute_SwaggerIgnore() {
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = Subject().GenerateSchema(typeof(SwaggerIngoreAnnotatedType), schemaRepository);
+
+            var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
+
+            Assert.True(schema.Properties.ContainsKey(nameof(SwaggerIngoreAnnotatedType.NotIgnoredString)));
+            Assert.False(schema.Properties.ContainsKey(nameof(SwaggerIngoreAnnotatedType.IgnoredString)));
+            Assert.False(schema.Properties.ContainsKey(nameof(SwaggerIngoreAnnotatedType.IgnoredExtensionData)));
+            Assert.False(schema.AdditionalPropertiesAllowed);
+            Assert.Null(schema.AdditionalProperties);
         }
 
         [Theory]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -474,6 +474,35 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
+        public void GetSwagger_IgnoresParameters_IfActionParameterHasSwaggerIgnoreAttribute()
+        {
+            var subject = Subject(
+                new[]
+                {
+                    ApiDescriptionFactory.Create<FakeController>(
+                        c => nameof(c.ActionWithIntParameterWithSwaggerIgnoreAttribute),
+                        groupName: "v1",
+                        httpMethod: "POST",
+                        relativePath: "resource",
+                        parameterDescriptions: new[]
+                        {
+                            new ApiParameterDescription
+                            {
+                                Name = "param",
+                                Source = BindingSource.Query
+                            }
+                        }
+                    )
+                }
+            );
+
+            var document = subject.GetSwagger("v1");
+
+            var operation = document.Paths["/resource"].Operations[OperationType.Post];
+            Assert.Empty(operation.Parameters);
+        }
+
+        [Fact]
         public void GetSwagger_SetsParameterRequired_IfApiParameterIsBoundToPath()
         {
             var subject = Subject(

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -425,6 +425,27 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
+        public void GetSwagger_IgnoresOperations_IfOperationHasSwaggerIgnoreAttribute()
+        {
+            var subject = Subject(
+                apiDescriptions: new[]
+                {
+                    ApiDescriptionFactory.Create<FakeController>(
+                        c => nameof(c.ActionWithSwaggerIgnoreAttribute),
+                        groupName: "v1",
+                        httpMethod: "POST",
+                        relativePath: "ignored",
+                        parameterDescriptions: Array.Empty<ApiParameterDescription>()
+                    )
+                }
+            );
+
+            var document = subject.GetSwagger("v1");
+
+            Assert.Empty(document.Paths);
+        }
+
+        [Fact]
         public void GetSwagger_IgnoresParameters_IfActionParameterHasBindNeverAttribute()
         {
             var subject = Subject(


### PR DESCRIPTION
Application of the SwaggerIgnoreAttribute suppresses the annotated property during schema generation, without altering the serialization behavior as with JsonIgnoreAttribute.

This is useful in a scenario where you want to capture and reject unhandled properties, without advertising that you accept `additionalProperties` (which is the opposite of what is intended):

```cs
public abstract class RequestBase : IValidatableObject {
    [SwaggerIgnore]
    [JsonExtensionData]
    public IDictionary<string, JsonElement>? UnsupportedProperties { get; set; }

    public virtual IEnumerable<ValidationResult> Validate(ValidationContext validationContext) {
        if(UnsupportedProperties is { Count: not 0 })
            foreach(var entry in UnsupportedProperties)
                yield return new ValidationResult($"Unsupported property: {entry.Key}.", new[] { entry.Key });
    }
}
```

I added the annotation to the Swashbuckle.AspNetCore.SwaggerGen project as it is much easier to filter the properties in the JsonSerializerDataContractResolver than after the fact in a filter, as you would need to regenerate the data contract for the type and then remove all of the annotated properties and derived side effects.