### PR TITLE
feat(pathbase): Add support for app.UsePathBase

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,6 @@ app.UseSwaggerUI(c =>
 
 _NOTE: In previous versions of the docs, you may have seen this expressed as a root-relative link (e.g. `/swagger/v1/swagger.json`). This won't work if your app is hosted on an IIS virtual directory or behind a proxy that trims the request path before forwarding. If you switch to the *page-relative* syntax shown above, it should work in all cases._
 
-### Working with PathBase ###
-
 ## Swashbuckle.AspNetCore.SwaggerGen ##
 
 ### Assign Explicit OperationIds ###

--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ app.UseSwaggerUI(c =>
 
 _NOTE: In previous versions of the docs, you may have seen this expressed as a root-relative link (e.g. `/swagger/v1/swagger.json`). This won't work if your app is hosted on an IIS virtual directory or behind a proxy that trims the request path before forwarding. If you switch to the *page-relative* syntax shown above, it should work in all cases._
 
+### Working with PathBase ###
+
 ## Swashbuckle.AspNetCore.SwaggerGen ##
 
 ### Assign Explicit OperationIds ###

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 install:
   - ps: Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile "./dotnet-install.ps1"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,7 @@
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<RepositoryUrl>https://github.com/domaindrivendev/Swashbuckle.AspNetCore.git</RepositoryUrl>
-		<VersionPrefix>6.5.0</VersionPrefix>
+		<VersionPrefix>6.6.0</VersionPrefix>
 		<LangVersion>9</LangVersion>
 	</PropertyGroup>
 

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -10,6 +10,12 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
     public class SwaggerUIOptions
     {
         /// <summary>
+        /// Gets or sets the path base, as in app.UsePathBase()
+        /// </summary>
+        public string PathBase { get; set; } = "";
+
+
+        /// <summary>
         /// Gets or sets a route prefix for accessing the swagger-ui
         /// </summary>
         public string RoutePrefix { get; set; } = "swagger";


### PR DESCRIPTION
This is a minor change to add support for PathBase.

In cases where the API needs to use app.UsePathBase("some/path"), getting Swagger UI to conform to this path with RoutePrefix was a little involved.  This change adds a PathBase property that should be set to the same value defined in app.UsePathBase().

From there, it checks the incoming request to see if path base is defined and the PathBase property is populated.  

If PathBase is populated, but the incoming request path does not contain PathBase, then Swagger UI will not be displayed.

If PathBase is populated and the incoming request path contains the same PathBase value, then Swagger UI will be displayed.

If PathBase is not populated and the incoming request does not contain a PathBase value, then the normal workflow will display the Swagger UI.