### PR TITLE
Fix empty index.html if default serializer options are changed

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -126,7 +126,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
                 { "%(HeadContent)", _options.HeadContent },
                 { "%(ConfigObject)", JsonSerializer.Serialize(_options.ConfigObject, _jsonSerializerOptions) },
                 { "%(OAuthConfigObject)", JsonSerializer.Serialize(_options.OAuthConfigObject, _jsonSerializerOptions) },
-                { "%(Interceptors)", JsonSerializer.Serialize(_options.Interceptors) },
+                { "%(Interceptors)", JsonSerializer.Serialize(_options.Interceptors, _jsonSerializerOptions) },
             };
         }
     }


### PR DESCRIPTION
`Index.html` is generated incorrectly if `System.Text.Json`'s default serializer options are changed, e.g. if `WriteIndented` is `true` and `DefaultIgnoreCondition` is `JsonIgnoreCondition.Never`, it produces the following text inside `index.html`:

```
var interceptors = JSON.parse('{
  "requestInterceptorFunction": null,
  "responseInterceptorFunction": null
}');
```

... which will generate `index.html:100 Uncaught SyntaxError: Invalid or unexpected token` error and show blank document in the browser.