### PR TITLE
Fixes #1661 - Make IDocumentFilter async compatible 

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSwaggerGeneratorOptions.cs
@@ -46,6 +46,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             _swaggerGenOptions.DocumentFilterDescriptors.ForEach(
                 filterDescriptor => options.DocumentFilters.Add(CreateFilter<IDocumentFilter>(filterDescriptor)));
 
+            _swaggerGenOptions.DocumentAsyncFilterDescriptors.ForEach(
+                filterDescriptor => options.DocumentAsyncFilters.Add(CreateFilter<IDocumentAsyncFilter>(filterDescriptor)));
+
             if (!options.SwaggerDocs.Any())
             {
                 options.SwaggerDocs.Add("v1", new OpenApiInfo { Title = _hostingEnv.ApplicationName, Version = "1.0" });
@@ -69,6 +72,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             target.ParameterFilters = new List<IParameterFilter>(source.ParameterFilters);
             target.OperationFilters = new List<IOperationFilter>(source.OperationFilters);
             target.DocumentFilters = new List<IDocumentFilter>(source.DocumentFilters);
+            target.DocumentAsyncFilters = new List<IDocumentAsyncFilter>(source.DocumentAsyncFilters);
         }
 
         private TFilter CreateFilter<TFilter>(FilterDescriptor filterDescriptor)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptions.cs
@@ -22,6 +22,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public List<FilterDescriptor> DocumentFilterDescriptors { get; set; } = new List<FilterDescriptor>();
 
+        public List<FilterDescriptor> DocumentAsyncFilterDescriptors { get; set; } = new List<FilterDescriptor>();
+
         public List<FilterDescriptor> SchemaFilterDescriptors { get; set; } = new List<FilterDescriptor>();
     }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -416,6 +416,24 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Extend the Swagger Generator with async "filters" that can modify SwaggerDocuments after they're initially generated
+        /// </summary>
+        /// <typeparam name="TFilter">A type that derives from IDocumentAsyncFilter</typeparam>
+        /// <param name="swaggerGenOptions"></param>
+        /// <param name="arguments">Optionally inject parameters through filter constructors</param>
+        public static void DocumentAsyncFilter<TFilter>(
+            this SwaggerGenOptions swaggerGenOptions,
+            params object[] arguments)
+            where TFilter : IDocumentAsyncFilter
+        {
+            swaggerGenOptions.DocumentFilterDescriptors.Add(new FilterDescriptor
+            {
+                Type = typeof(TFilter),
+                Arguments = arguments
+            });
+        }
+
+        /// <summary>
         /// Inject human-friendly descriptions for Operations, Parameters and Schemas based on XML Comment files
         /// </summary>
         /// <param name="swaggerGenOptions"></param>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/IDocumentFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/IDocumentFilter.cs
@@ -1,12 +1,20 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi.Models;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
+
     public interface IDocumentFilter
     {
         void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context);
+    }
+
+    public interface IDocumentAsyncFilter
+    {
+        Task Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context);
     }
 
     public class DocumentFilterContext

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -52,6 +52,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 filter.Apply(swaggerDoc, filterContext);
             }
 
+            foreach (var filter in _options.DocumentAsyncFilters)
+            {
+                await filter.Apply(swaggerDoc, filterContext);
+            }
+
             swaggerDoc.Components.Schemas = new SortedDictionary<string, OpenApiSchema>(swaggerDoc.Components.Schemas, _options.SchemaComparer);
 
             return swaggerDoc;
@@ -70,8 +75,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 filter.Apply(swaggerDoc, filterContext);
             }
 
-            swaggerDoc.Components.Schemas = new SortedDictionary<string, OpenApiSchema>(swaggerDoc.Components.Schemas, _options.SchemaComparer);
+            if (_options.DocumentAsyncFilters?.Any() ?? false)
+            {
+                throw new SwaggerGeneratorException("DocumentAsyncFilters are configured but not using GetSwaggerAsync(). " +
+                        "Use GetSwaggerAsync() instead of GetSwagger()");
+            }
 
+
+            swaggerDoc.Components.Schemas = new SortedDictionary<string, OpenApiSchema>(swaggerDoc.Components.Schemas, _options.SchemaComparer);
+            
             return swaggerDoc;
         }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
@@ -29,6 +29,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             RequestBodyFilters = new List<IRequestBodyFilter>();
             OperationFilters = new List<IOperationFilter>();
             DocumentFilters = new List<IDocumentFilter>();
+            DocumentAsyncFilters = new List<IDocumentAsyncFilter>();
         }
 
         public IDictionary<string, OpenApiInfo> SwaggerDocs { get; set; }
@@ -66,6 +67,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         public List<IOperationFilter> OperationFilters { get; set; }
 
         public IList<IDocumentFilter> DocumentFilters { get; set; }
+
+        public IList<IDocumentAsyncFilter> DocumentAsyncFilters { get; set; }
+        
 
         private bool DefaultDocInclusionPredicate(string documentName, ApiDescription apiDescription)
         {

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TestDocumentAsyncFilter.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TestDocumentAsyncFilter.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.TestSupport;
+using System.Threading.Tasks;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test
+{
+    public class TestDocumentAsyncFilter : IDocumentAsyncFilter
+    {
+        public Task Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+        {
+            swaggerDoc.Extensions.Add("X-foo", new OpenApiString("bar"));
+            swaggerDoc.Extensions.Add("X-docName", new OpenApiString(context.DocumentName));
+            context.SchemaGenerator.GenerateSchema(typeof(ComplexType), context.SchemaRepository);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -1277,6 +1277,32 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Contains("ComplexType", document.Components.Schemas.Keys);
         }
 
+        [Fact]
+        public async Task GetSwagger_SupportsOption_AsyncDocumentFilters()
+        {
+            var subject = Subject(
+                apiDescriptions: new ApiDescription[] { },
+                options: new SwaggerGeneratorOptions
+                {
+                    SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                    {
+                        ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                    },
+                    DocumentAsyncFilters = new List<IDocumentAsyncFilter>
+                    {
+                        new TestDocumentAsyncFilter()
+                    }
+                }
+            );
+
+            var document = await subject.GetSwaggerAsync("v1");
+
+            Assert.Equal(2, document.Extensions.Count);
+            Assert.Equal("bar", ((OpenApiString)document.Extensions["X-foo"]).Value);
+            Assert.Equal("v1", ((OpenApiString)document.Extensions["X-docName"]).Value);
+            Assert.Contains("ComplexType", document.Components.Schemas.Keys);
+        }
+
         private SwaggerGenerator Subject(
             IEnumerable<ApiDescription> apiDescriptions,
             SwaggerGeneratorOptions options = null,


### PR DESCRIPTION
This is my take on the fix for this.  Rather than extending IDocumentFilter, I created a new IDocumentAsyncFilter that is configured separately.   I chosen to name IDocumentAsyncFilter to help make it clearer for developers.   It continues to use a method named "Apply" like other filters, and since they Type itself makes it clear that it is for Async, I did not name the method "ApplyAsync".  In cases where GetSwaggerAsync() is called, the IDocumentFilters will run first and then the IDocumentAsyncFilters.  For GetSwagger(), only the IDocumentFilters are run. If IDocumentAsyncFilters are configured, it will throw an exception stating to use GetSwaggerAsync() instead.

I had also considered just extending the IDocumentFilter to interface to have an async ApplyAsync() method with a default implementation, but that was not possible with the targeted runtimes.