### PR TITLE
Support [DataMember] IsRequired in NewtonsoftDataContractResolver

### DIFF
--- a/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/JsonPropertyExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/JsonPropertyExtensions.cs
@@ -14,5 +14,10 @@ namespace Swashbuckle.AspNetCore.Newtonsoft
 
             return (memberInfo != null);
         }
+
+        public static bool IsRequiredSpecified(this JsonProperty jsonProperty)
+        {
+            return jsonProperty.Required != Required.Default;
+        }
     }
 }

--- a/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/JsonPropertyExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/JsonPropertyExtensions.cs
@@ -14,19 +14,5 @@ namespace Swashbuckle.AspNetCore.Newtonsoft
 
             return (memberInfo != null);
         }
-
-        public static bool IsRequiredSpecified(this JsonProperty jsonProperty)
-        {
-            if (!jsonProperty.TryGetMemberInfo(out MemberInfo memberInfo))
-                return false;
-
-            if (memberInfo.GetCustomAttribute<JsonRequiredAttribute>() != null)
-                return true;
-
-            var jsonPropertyAttributeData = memberInfo.GetCustomAttributesData()
-                .FirstOrDefault(attrData => attrData.AttributeType == typeof(JsonPropertyAttribute));
-
-            return (jsonPropertyAttributeData != null) && jsonPropertyAttributeData.NamedArguments.Any(arg => arg.MemberName == "Required");
-        }
     }
 }

--- a/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/NewtonsoftDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/NewtonsoftDataContractResolver.cs
@@ -152,7 +152,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft
             {
                 if (jsonProperty.Ignored) continue;
 
-                var required = jsonProperty.IsRequiredSpecified()
+                var required = jsonProperty.Required != Required.Default
                     ? jsonProperty.Required
                     : jsonObjectContract.ItemRequired ?? Required.Default;
 

--- a/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/NewtonsoftDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/NewtonsoftDataContractResolver.cs
@@ -152,7 +152,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft
             {
                 if (jsonProperty.Ignored) continue;
 
-                var required = jsonProperty.Required != Required.Default
+                var required = jsonProperty.IsRequiredSpecified()
                     ? jsonProperty.Required
                     : jsonObjectContract.ItemRequired ?? Required.Default;
 

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/DataMemberAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/DataMemberAnnotatedType.cs
@@ -1,0 +1,20 @@
+﻿using System.Runtime.Serialization;
+
+namespace Swashbuckle.AspNetCore.Newtonsoft.Test
+{
+    [DataContract(Name = "CustomNameFromDataContract")]
+    public class DataMemberAnnotatedType
+    {
+        [DataMember(IsRequired = true)]
+        public string StringWithDataMemberRequired { get; set; }
+
+        [DataMember(IsRequired = false)]
+        public string StringWithDataMemberNonRequired { get; set; }
+
+        [DataMember(IsRequired = true, Name = "RequiredWithCustomNameFromDataMember")]
+        public string StringWithDataMemberRequiredWithCustomName { get; set; }
+
+        [DataMember(IsRequired = false, Name = "NonRequiredWithCustomNameFromDataMember")]
+        public string StringWithDataMemberNonRequiredWithCustomName { get; set; }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/JsonObjectAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/JsonObjectAnnotatedType.cs
@@ -1,8 +1,10 @@
-﻿using Newtonsoft.Json;
+﻿using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 {
     [JsonObject(ItemRequired = Required.Always)]
+    [DataContract]
     public class JsonObjectAnnotatedType
     {
         public string StringWithNoAnnotation { get; set; }
@@ -12,5 +14,8 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 
         [JsonProperty(Required = Required.AllowNull)]
         public string StringWithRequiredAllowNull { get; set; }
+
+        [DataMember(IsRequired = false)]
+        public string StringWithDataMemberRequiredFalse { get; set; }
     }
 }

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/JsonPropertyAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/JsonPropertyAnnotatedType.cs
@@ -24,11 +24,11 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         [JsonProperty(Required = Required.AllowNull)]
         public string StringWithRequiredAllowNull { get; set; }
 
-        [DataMember(IsRequired = false)] //As the support for DataMember has been implemented later, JsonRequired should take precedence
+        [DataMember(IsRequired = false)] //As the support for DataMember has been implemented later, JsonProperty.Required should take precedence
         [JsonProperty(Required = Required.Always)]
         public string StringWithRequiredAlwaysButConflictingDataMember { get; set; }
 
-        [DataMember(IsRequired = true)] //As the support for DataMember has been implemented later, JsonRequired should take precedence
+        [DataMember(IsRequired = true)] //As the support for DataMember has been implemented later, JsonProperty.Required should take precedence
         [JsonProperty(Required = Required.Default)]
         public string StringWithRequiredDefaultButConflictingDataMember { get; set; }
     }

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/JsonPropertyAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/JsonPropertyAnnotatedType.cs
@@ -1,7 +1,9 @@
-﻿using Newtonsoft.Json;
+﻿using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 {
+    [DataContract]
     public class JsonPropertyAnnotatedType
     {
         [JsonProperty("string-with-json-property-name")]
@@ -21,5 +23,13 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 
         [JsonProperty(Required = Required.AllowNull)]
         public string StringWithRequiredAllowNull { get; set; }
+
+        [DataMember(IsRequired = false)] //As the support for DataMember has been implemented later, JsonRequired should take precedence
+        [JsonProperty(Required = Required.Always)]
+        public string StringWithRequiredAlwaysButConflictingDataMember { get; set; }
+
+        [DataMember(IsRequired = true)] //As the support for DataMember has been implemented later, JsonRequired should take precedence
+        [JsonProperty(Required = Required.Default)]
+        public string StringWithRequiredDefaultButConflictingDataMember { get; set; }
     }
 }

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/JsonRequiredAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/JsonRequiredAnnotatedType.cs
@@ -1,10 +1,16 @@
-﻿using Newtonsoft.Json;
+﻿using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 {
+    [DataContract]
     public class JsonRequiredAnnotatedType
     {
         [JsonRequired]
         public string StringWithJsonRequired { get; set; }
+
+        [DataMember(IsRequired = false)] //As the support for DataMember has been implemented later, JsonRequired should take precedence
+        [JsonRequired]
+        public string StringWithConflictingRequired { get; set; }
     }
 }

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -755,6 +755,8 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
                     "StringWithRequiredDisallowNull",
                     "StringWithRequiredAlways",
                     "StringWithRequiredAllowNull",
+                    "StringWithRequiredAlwaysButConflictingDataMember",
+                    "StringWithRequiredDefaultButConflictingDataMember"
                 },
                 schema.Properties.Keys.ToArray()
             );
@@ -762,7 +764,8 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
                 new[]
                 {
                     "StringWithRequiredAllowNull",
-                    "StringWithRequiredAlways"
+                    "StringWithRequiredAlways",
+                    "StringWithRequiredAlwaysButConflictingDataMember"
                 },
                 schema.Required.ToArray()
             );
@@ -772,6 +775,8 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Assert.False(schema.Properties["StringWithRequiredDisallowNull"].Nullable);
             Assert.False(schema.Properties["StringWithRequiredAlways"].Nullable);
             Assert.True(schema.Properties["StringWithRequiredAllowNull"].Nullable);
+            Assert.False(schema.Properties["StringWithRequiredAlwaysButConflictingDataMember"].Nullable);
+            Assert.True(schema.Properties["StringWithRequiredDefaultButConflictingDataMember"].Nullable);
         }
 
         [Fact]
@@ -782,7 +787,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             var referenceSchema = Subject().GenerateSchema(typeof(JsonRequiredAnnotatedType), schemaRepository);
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal(new[] { "StringWithJsonRequired" }, schema.Required.ToArray());
+            Assert.Equal(new[] { "StringWithConflictingRequired", "StringWithJsonRequired"}, schema.Required.ToArray());
             Assert.False(schema.Properties["StringWithJsonRequired"].Nullable);
         }
 
@@ -797,6 +802,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Assert.Equal(
                 new[]
                 {
+                    "StringWithDataMemberRequiredFalse",
                     "StringWithNoAnnotation",
                     "StringWithRequiredAllowNull",
                     "StringWithRequiredUnspecified"
@@ -806,6 +812,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Assert.False(schema.Properties["StringWithNoAnnotation"].Nullable);
             Assert.False(schema.Properties["StringWithRequiredUnspecified"].Nullable);
             Assert.True(schema.Properties["StringWithRequiredAllowNull"].Nullable);
+            Assert.False(schema.Properties["StringWithDataMemberRequiredFalse"].Nullable);
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -828,6 +828,43 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Assert.Null(schema.AdditionalProperties.Type);
         }
 
+        [Fact]
+        public void GenerateSchema_HonorsDataMemberAttribute()
+        {
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = Subject().GenerateSchema(typeof(DataMemberAnnotatedType), schemaRepository);
+
+            var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
+
+
+            Assert.True(schema.Properties["StringWithDataMemberRequired"].Nullable);
+            Assert.True(schema.Properties["StringWithDataMemberNonRequired"].Nullable);
+            Assert.True(schema.Properties["RequiredWithCustomNameFromDataMember"].Nullable);
+            Assert.True(schema.Properties["NonRequiredWithCustomNameFromDataMember"].Nullable);
+
+            Assert.Equal(
+                new[]
+                {
+
+                    "StringWithDataMemberRequired",
+                    "StringWithDataMemberNonRequired",
+                    "RequiredWithCustomNameFromDataMember",
+                    "NonRequiredWithCustomNameFromDataMember"
+                },
+                schema.Properties.Keys.ToArray()
+            );
+
+            Assert.Equal(
+                new[]
+                {
+                    "RequiredWithCustomNameFromDataMember",
+                    "StringWithDataMemberRequired"
+                },
+                schema.Required.ToArray()
+            );
+        }
+
         [Theory]
         [InlineData(typeof(ProblemDetails))]
         [InlineData(typeof(ValidationProblemDetails))]


### PR DESCRIPTION
Resolves #2383

- Add non-regression tests to ensure [DataMember(IsRequired)] do not bypass existing [JsonObject], [JsonProperty] or [JsonRequired] attributes.
- Add tests for [DataMember(IsRequired)] and [DataMember(name)]
- Update NewtonsoftDataContractResolver to directly leverage jsonProperty.Required, instead of using the IsRequiredSpecifed extension method