### PR TITLE
Fix for #2656 - Add default server

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
@@ -39,15 +39,19 @@ namespace Swashbuckle.AspNetCore.Swagger
                     ? httpContext.Request.PathBase.Value
                     : null;
 
+                var host = httpContext.Request.Host.HasValue
+                    ? $"{httpContext.Request.Scheme}://{httpContext.Request.Host.Value}"
+                    : null;
+
                 var swagger = swaggerProvider switch
                 {
                     IAsyncSwaggerProvider asyncSwaggerProvider => await asyncSwaggerProvider.GetSwaggerAsync(
                         documentName: documentName,
-                        host: null,
+                        host: host,
                         basePath: basePath),
                     _ => swaggerProvider.GetSwagger(
                         documentName: documentName,
-                        host: null,
+                        host: host,
                         basePath: basePath)
                 };
 


### PR DESCRIPTION
This adds host detection in the middleware to populate the default schema/host for the swagger to populate the default Servers instance