### PR TITLE
Add customized document serialization support

### DIFF
--- a/src/Swashbuckle.AspNetCore.Cli/Program.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/Program.cs
@@ -87,6 +87,7 @@ namespace Swashbuckle.AspNetCore.Cli
 
                     // 3) Retrieve Swagger via configured provider
                     var swaggerProvider = serviceProvider.GetRequiredService<ISwaggerProvider>();
+                    var swaggerDocumentSerializer = serviceProvider.GetService<ISwaggerDocumentSerializer>();
                     var swagger = swaggerProvider.GetSwagger(
                         namedArgs["swaggerdoc"],
                         namedArgs.ContainsKey("--host") ? namedArgs["--host"] : null,
@@ -106,9 +107,24 @@ namespace Swashbuckle.AspNetCore.Cli
                             writer = new OpenApiJsonWriter(streamWriter);
 
                         if (namedArgs.ContainsKey("--serializeasv2"))
-                            swagger.SerializeAsV2(writer);
+                        {
+                            if (swaggerDocumentSerializer != null)
+                            {
+                                swaggerDocumentSerializer.SerializeDocument(swagger, writer, Microsoft.OpenApi.OpenApiSpecVersion.OpenApi2_0);
+                            }
+                            else
+                            {
+                                swagger.SerializeAsV2(writer);
+                            }
+                        }
+                        else if (swaggerDocumentSerializer != null)
+                        {
+                            swaggerDocumentSerializer.SerializeDocument(swagger, writer, Microsoft.OpenApi.OpenApiSpecVersion.OpenApi3_0);
+                        }
                         else
+                        {
                             swagger.SerializeAsV3(writer);
+                        }
 
                         if (outputPath != null)
                             Console.WriteLine($"Swagger JSON/YAML successfully written to {outputPath}");

--- a/src/Swashbuckle.AspNetCore.Swagger/ISwaggerDocumentSerializer.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/ISwaggerDocumentSerializer.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.OpenApi;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Writers;
+
+namespace Swashbuckle.AspNetCore.Swagger
+{
+    public interface ISwaggerDocumentSerializer
+    {
+		void SerializeDocument(OpenApiDocument document, IOpenApiWriter writer, OpenApiSpecVersion specVersion);
+	}
+}

--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,14 +16,19 @@ namespace Swashbuckle.AspNetCore.Swagger
         private readonly RequestDelegate _next;
         private readonly SwaggerOptions _options;
         private readonly TemplateMatcher _requestMatcher;
+        private readonly ISwaggerDocumentSerializer _swaggerDocumentSerializer;
 
         public SwaggerMiddleware(
             RequestDelegate next,
-            SwaggerOptions options)
+            SwaggerOptions options,
+            IServiceProvider serviceProvider)
         {
             _next = next;
             _options = options ?? new SwaggerOptions();
             _requestMatcher = new TemplateMatcher(TemplateParser.Parse(_options.RouteTemplate), new RouteValueDictionary());
+
+            // Use IServiceProvider to retrieve the ISwaggerDocumentSerializer, because it is an optional service
+            _swaggerDocumentSerializer = serviceProvider.GetService(typeof(ISwaggerDocumentSerializer)) as ISwaggerDocumentSerializer;
         }
 
         public async Task Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)
@@ -97,7 +103,20 @@ namespace Swashbuckle.AspNetCore.Swagger
             using (var textWriter = new StringWriter(CultureInfo.InvariantCulture))
             {
                 var jsonWriter = new OpenApiJsonWriter(textWriter);
-                if (_options.SerializeAsV2) swagger.SerializeAsV2(jsonWriter); else swagger.SerializeAsV3(jsonWriter);
+                if (_options.SerializeAsV2)
+                {
+                    if (_swaggerDocumentSerializer != null)
+                        _swaggerDocumentSerializer.SerializeDocument(swagger, jsonWriter, Microsoft.OpenApi.OpenApiSpecVersion.OpenApi2_0);
+                    else
+                        swagger.SerializeAsV2(jsonWriter);
+                }
+                else
+                {
+                    if (_swaggerDocumentSerializer != null)
+                        _swaggerDocumentSerializer.SerializeDocument(swagger, jsonWriter, Microsoft.OpenApi.OpenApiSpecVersion.OpenApi3_0);
+                    else
+                        swagger.SerializeAsV3(jsonWriter);
+                }
 
                 await response.WriteAsync(textWriter.ToString(), new UTF8Encoding(false));
             }
@@ -111,7 +130,20 @@ namespace Swashbuckle.AspNetCore.Swagger
             using (var textWriter = new StringWriter(CultureInfo.InvariantCulture))
             {
                 var yamlWriter = new OpenApiYamlWriter(textWriter);
-                if (_options.SerializeAsV2) swagger.SerializeAsV2(yamlWriter); else swagger.SerializeAsV3(yamlWriter);
+                if (_options.SerializeAsV2)
+                {
+                    if (_swaggerDocumentSerializer != null)
+                        _swaggerDocumentSerializer.SerializeDocument(swagger, yamlWriter, Microsoft.OpenApi.OpenApiSpecVersion.OpenApi2_0);
+                    else
+                        swagger.SerializeAsV2(yamlWriter);
+                }
+                else
+                {
+                    if (_swaggerDocumentSerializer != null)
+                        _swaggerDocumentSerializer.SerializeDocument(swagger, yamlWriter, Microsoft.OpenApi.OpenApiSpecVersion.OpenApi3_0);
+                    else
+                        swagger.SerializeAsV3(yamlWriter);
+                }
 
                 await response.WriteAsync(textWriter.ToString(), new UTF8Encoding(false));
             }


### PR DESCRIPTION
Added support to inject a ISwaggerDocumentSerializer implementation, which can be called to manually serialize an OpenAPIDocument object.

Zee also https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2668