### PR TITLE
Update SchemaGenerator to fix #2514 and #2052

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -379,7 +379,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                         {
                             schema.Properties.Add(discriminator.PropertyName, new OpenApiSchema { Type = "string" });
                             schema.Required.Add(discriminator.PropertyName);
-                            schema.Discriminator = discriminator;
                         }
                     }
                 }


### PR DESCRIPTION
This pull request fixes (reverts) the placement of the discriminator to the polymorphic oneOf element. Fixes #2052.

This pull request also fixes #2514 and the bug where enabling UseOneOfForPolymorphism forces UseAllOfForInheritance=true (when UseAllOfForInheritance=false).