### PR TITLE
Add support for <ineritdoc cref="" />

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentFilter.cs
@@ -1,9 +1,9 @@
-﻿using System.Xml.XPath;
-using System.Linq;
+﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Xml.XPath;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.OpenApi.Models;
-using System;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
@@ -31,23 +31,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             foreach (var nameAndType in controllerNamesAndTypes)
             {
                 var memberName = XmlCommentsNodeNameHelper.GetMemberNameForType(nameAndType.Value);
-                var typeNode = _xmlNavigator.SelectSingleNode(string.Format(MemberXPath, memberName));
+                var summaryNode = _xmlNavigator.SelectSingleNodeRecursive(memberName, SummaryTag);
+                if (summaryNode == null) continue;
+                swaggerDoc.Tags ??= new List<OpenApiTag>();
 
-                if (typeNode != null)
+                swaggerDoc.Tags.Add(new OpenApiTag
                 {
-                    var summaryNode = typeNode.SelectSingleNode(SummaryTag);
-                    if (summaryNode != null)
-                    {
-                        if (swaggerDoc.Tags == null)
-                            swaggerDoc.Tags = new List<OpenApiTag>();
-
-                        swaggerDoc.Tags.Add(new OpenApiTag
-                        {
-                            Name = nameAndType.Key,
-                            Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml)
-                        });
-                    }
-                }
+                    Name = nameAndType.Key,
+                    Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml)
+                });
             }
         }
     }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
@@ -6,7 +6,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     public class XmlCommentsParameterFilter : IParameterFilter
     {
-        private XPathNavigator _xmlNavigator;
+        private const string SummaryTag = "summary";
+        private const string ExampleTag = "example";
+        private readonly XPathNavigator _xmlNavigator;
 
         public XmlCommentsParameterFilter(XPathDocument xmlDoc)
         {
@@ -16,37 +18,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         public void Apply(OpenApiParameter parameter, ParameterFilterContext context)
         {
             if (context.PropertyInfo != null)
-            {
                 ApplyPropertyTags(parameter, context);
-            }
-            else if (context.ParameterInfo != null)
-            {
-                ApplyParamTags(parameter, context);
-            }
-        }
-
-        private void ApplyPropertyTags(OpenApiParameter parameter, ParameterFilterContext context)
-        {
-            var propertyMemberName = XmlCommentsNodeNameHelper.GetMemberNameForFieldOrProperty(context.PropertyInfo);
-            var propertyNode = _xmlNavigator.SelectSingleNode($"/doc/members/member[@name='{propertyMemberName}']");
-
-            if (propertyNode == null) return;
-
-            var summaryNode = propertyNode.SelectSingleNode("summary");
-            if (summaryNode != null)
-            {
-                parameter.Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml);
-                parameter.Schema.Description = null; // no need to duplicate
-            }
-
-            var exampleNode = propertyNode.SelectSingleNode("example");
-            if (exampleNode == null) return;
-
-            var exampleAsJson = (parameter.Schema?.ResolveType(context.SchemaRepository) == "string")
-                ? $"\"{exampleNode.ToString()}\""
-                : exampleNode.ToString();
-
-            parameter.Example = OpenApiAnyFactory.CreateFromJson(exampleAsJson);
+            else if (context.ParameterInfo != null) ApplyParamTags(parameter, context);
         }
 
         private void ApplyParamTags(OpenApiParameter parameter, ParameterFilterContext context)
@@ -61,22 +34,45 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             if (targetMethod == null) return;
 
             var methodMemberName = XmlCommentsNodeNameHelper.GetMemberNameForMethod(targetMethod);
-            var paramNode = _xmlNavigator.SelectSingleNode(
-                $"/doc/members/member[@name='{methodMemberName}']/param[@name='{context.ParameterInfo.Name}']");
+            var paramNode =
+                _xmlNavigator.SelectSingleNodeRecursive(methodMemberName,
+                    $"param[@name='{context.ParameterInfo.Name}']");
 
-            if (paramNode != null)
+            if (paramNode == null) return;
+            parameter.Description = XmlCommentsTextHelper.Humanize(paramNode.InnerXml);
+
+            var example = paramNode.GetAttribute(ExampleTag, "");
+            if (string.IsNullOrEmpty(example)) return;
+
+            var exampleAsJson = parameter.Schema?.ResolveType(context.SchemaRepository) == "string"
+                ? $"\"{example}\""
+                : example;
+
+            parameter.Example = OpenApiAnyFactory.CreateFromJson(exampleAsJson);
+        }
+
+        private void ApplyPropertyTags(OpenApiParameter parameter, ParameterFilterContext context)
+        {
+            var propertyMemberName = XmlCommentsNodeNameHelper.GetMemberNameForFieldOrProperty(context.PropertyInfo);
+            var propertyNode = _xmlNavigator.SelectSingleNode($"/doc/members/member[@name='{propertyMemberName}']");
+
+            if (propertyNode == null) return;
+
+            var summaryNode = _xmlNavigator.SelectSingleNodeRecursive(propertyMemberName, SummaryTag);
+            if (summaryNode != null)
             {
-                parameter.Description = XmlCommentsTextHelper.Humanize(paramNode.InnerXml);
-
-                var example = paramNode.GetAttribute("example", "");
-                if (string.IsNullOrEmpty(example)) return;
-
-                var exampleAsJson = (parameter.Schema?.ResolveType(context.SchemaRepository) == "string")
-                    ? $"\"{example}\""
-                    : example;
-
-                parameter.Example = OpenApiAnyFactory.CreateFromJson(exampleAsJson);
+                parameter.Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml);
+                parameter.Schema.Description = null; // no need to duplicate
             }
+
+            var exampleNode = _xmlNavigator.SelectSingleNodeRecursive(propertyMemberName, ExampleTag);
+            if (exampleNode == null) return;
+
+            var exampleAsJson = parameter.Schema?.ResolveType(context.SchemaRepository) == "string"
+                ? $"\"{exampleNode}\""
+                : exampleNode.ToString();
+
+            parameter.Example = OpenApiAnyFactory.CreateFromJson(exampleAsJson);
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsRecursion.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsRecursion.cs
@@ -1,0 +1,80 @@
+﻿using System.Xml.XPath;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen
+{
+    /// <summary>
+    ///     Service to handle recursive retrieval of XML comments from an XPathNavigator.
+    /// </summary>
+    internal static class XmlCommentsRecursionService
+    {
+        private const string MemberXPath = "/doc/members/member[@name='{0}']";
+
+        /// <summary>
+        ///     Finds the first node with the specified tag name recursively, starting from the given memberName in the XML
+        ///     document.
+        /// </summary>
+        /// <param name="xmlNavigator">The XPathNavigator representing the XML document.</param>
+        /// <param name="memberName">The name of the member to start the recursive search from.</param>
+        /// <param name="tag">The tag name to find.</param>
+        /// <returns>The XPathNavigator representing the found node or null if the node is not found.</returns>
+        private static XPathNavigator FindNodeRecursive(XPathNavigator xmlNavigator, string memberName, string tag)
+        {
+            while (true)
+            {
+                // Find the node representing the current memberName in the XML document.
+                var memberNode = xmlNavigator.SelectSingleNode(string.Format(MemberXPath, memberName));
+
+                // Try to find the specified tag node within the current member node.
+                var node = memberNode?.SelectSingleNode(tag);
+                if (node != null)
+                    return memberNode;
+
+                // If the specified tag node is not found, check if there is an "inheritdoc" tag.
+                var inheritDocNode = memberNode?.SelectSingleNode("inheritdoc");
+                if (inheritDocNode == null)
+                    return null;
+
+                // If "inheritdoc" tag exists, get the "cref" attribute to find the referenced node in the XML document.
+                var cref = inheritDocNode.GetAttribute("cref", string.Empty);
+                if (string.IsNullOrEmpty(cref))
+                    return null;
+
+                // Update the memberName to the referenced member and continue the recursive search.
+                memberName = cref;
+            }
+        }
+
+        /// <summary>
+        ///     Selects multiple nodes with the specified tag name recursively, starting from the given memberName in the XML
+        ///     document.
+        /// </summary>
+        /// <param name="xmlNavigator">The XPathNavigator representing the XML document.</param>
+        /// <param name="memberName">The name of the member to start the recursive search from.</param>
+        /// <param name="tag">The tag name to find.</param>
+        /// <returns>
+        ///     An XPathNodeIterator representing the collection of nodes with the specified tag, or null if the nodes are not
+        ///     found.
+        /// </returns>
+        public static XPathNodeIterator SelectNodeRecursive(this XPathNavigator xmlNavigator, string memberName,
+            string tag)
+        {
+            var node = FindNodeRecursive(xmlNavigator, memberName, tag);
+            return node?.Select(tag);
+        }
+
+        /// <summary>
+        ///     Selects the first node with the specified tag name recursively, starting from the given memberName in the XML
+        ///     document.
+        /// </summary>
+        /// <param name="xmlNavigator">The XPathNavigator representing the XML document.</param>
+        /// <param name="memberName">The name of the member to start the recursive search from.</param>
+        /// <param name="tag">The tag name to find.</param>
+        /// <returns>An XPathNavigator representing the found node or null if the node is not found.</returns>
+        public static XPathNavigator SelectSingleNodeRecursive(this XPathNavigator xmlNavigator, string memberName,
+            string tag)
+        {
+            var node = FindNodeRecursive(xmlNavigator, memberName, tag);
+            return node?.SelectSingleNode(tag);
+        }
+    }
+}

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
@@ -6,6 +6,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     public class XmlCommentsSchemaFilter : ISchemaFilter
     {
+        private const string SummaryTag = "summary";
+        private const string ExampleTag = "example";
         private readonly XPathNavigator _xmlNavigator;
 
         public XmlCommentsSchemaFilter(XPathDocument xmlDoc)
@@ -17,43 +19,39 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             ApplyTypeTags(schema, context.Type);
 
-            if (context.MemberInfo != null)
-            {
-                ApplyMemberTags(schema, context);
-            }
+            if (context.MemberInfo != null) ApplyMemberTags(schema, context);
+        }
+
+        private void ApplyMemberTags(OpenApiSchema schema, SchemaFilterContext context)
+        {
+            var fieldOrPropertyMemberName =
+                XmlCommentsNodeNameHelper.GetMemberNameForFieldOrProperty(context.MemberInfo);
+            var fieldOrPropertyNode =
+                _xmlNavigator.SelectSingleNode($"/doc/members/member[@name='{fieldOrPropertyMemberName}']");
+
+            if (fieldOrPropertyNode == null) return;
+
+            var summaryNode = _xmlNavigator.SelectSingleNodeRecursive(fieldOrPropertyMemberName, SummaryTag);
+            if (summaryNode != null)
+                schema.Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml);
+
+            var exampleNode = _xmlNavigator.SelectSingleNodeRecursive(fieldOrPropertyMemberName, ExampleTag);
+            if (exampleNode == null) return;
+            var exampleAsJson = schema.ResolveType(context.SchemaRepository) == "string" &&
+                                !exampleNode.Value.Equals("null")
+                ? $"\"{exampleNode}\""
+                : exampleNode.ToString();
+
+            schema.Example = OpenApiAnyFactory.CreateFromJson(exampleAsJson);
         }
 
         private void ApplyTypeTags(OpenApiSchema schema, Type type)
         {
             var typeMemberName = XmlCommentsNodeNameHelper.GetMemberNameForType(type);
-            var typeSummaryNode = _xmlNavigator.SelectSingleNode($"/doc/members/member[@name='{typeMemberName}']/summary");
+            var typeSummaryNode = _xmlNavigator.SelectSingleNodeRecursive(typeMemberName, SummaryTag);
 
-            if (typeSummaryNode != null)
-            {
-                schema.Description = XmlCommentsTextHelper.Humanize(typeSummaryNode.InnerXml);
-            }
-        }
-
-        private void ApplyMemberTags(OpenApiSchema schema, SchemaFilterContext context)
-        {
-            var fieldOrPropertyMemberName = XmlCommentsNodeNameHelper.GetMemberNameForFieldOrProperty(context.MemberInfo);
-            var fieldOrPropertyNode = _xmlNavigator.SelectSingleNode($"/doc/members/member[@name='{fieldOrPropertyMemberName}']");
-
-            if (fieldOrPropertyNode == null) return;
-
-            var summaryNode = fieldOrPropertyNode.SelectSingleNode("summary");
-            if (summaryNode != null)
-                schema.Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml);
-
-            var exampleNode = fieldOrPropertyNode.SelectSingleNode("example");
-            if (exampleNode != null)
-            {
-                var exampleAsJson = (schema.ResolveType(context.SchemaRepository) == "string") && !exampleNode.Value.Equals("null")
-                    ? $"\"{exampleNode.ToString()}\""
-                    : exampleNode.ToString();
-
-                schema.Example = OpenApiAnyFactory.CreateFromJson(exampleAsJson);
-            }
+            if (typeSummaryNode == null) return;
+            schema.Description = XmlCommentsTextHelper.Humanize(typeSummaryNode.InnerXml);
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.Annotations.Test/Swashbuckle.AspNetCore.Annotations.Test.csproj
+++ b/test/Swashbuckle.AspNetCore.Annotations.Test/Swashbuckle.AspNetCore.Annotations.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <LangVersion>10</LangVersion>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+     <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Swashbuckle.AspNetCore.ApiTesting.Test/Swashbuckle.AspNetCore.ApiTesting.Test.csproj
+++ b/test/Swashbuckle.AspNetCore.ApiTesting.Test/Swashbuckle.AspNetCore.ApiTesting.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+     <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Swashbuckle.AspNetCore.Cli.Test/Swashbuckle.AspNetCore.Cli.Test.csproj
+++ b/test/Swashbuckle.AspNetCore.Cli.Test/Swashbuckle.AspNetCore.Cli.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+     <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/Swashbuckle.AspNetCore.IntegrationTests.csproj
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/Swashbuckle.AspNetCore.IntegrationTests.csproj
@@ -4,7 +4,7 @@
     <AssemblyOriginatorKeyFile>Swashbuckle.AspNetCore.IntegrationTests.snk</AssemblyOriginatorKeyFile>
     <NoWarn>$(NoWarn);8002</NoWarn>
     <SignAssembly>true</SignAssembly>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+     <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Swashbuckle.AspNetCore.Newtonsoft.Test.csproj
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Swashbuckle.AspNetCore.Newtonsoft.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+     <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithInheritDoc.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithInheritDoc.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test
+{
+    /// <inheritdoc cref = "FakeControllerWithXmlComments" />
+    public class FakeControllerWithInheritDoc : FakeControllerWithXmlComments
+    {
+        /// <inheritdoc cref = "FakeControllerWithXmlComments.ActionWithSummaryAndRemarksTags"/>
+        public new void ActionWithSummaryAndRemarksTags()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc cref = "FakeControllerWithXmlComments.ActionWithParamTags"/>
+        public new void ActionWithParamTags(string param1, string param2)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc cref = "FakeControllerWithXmlComments.ActionWithResponseTags"/>
+        public new void ActionWithResponseTags()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.csproj
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <DocumentationFile>Swashbuckle.AspNetCore.SwaggerGen.Test.xml</DocumentationFile>
     <NoWarn>1701;1702;1591</NoWarn>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.xml
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.xml
@@ -21,6 +21,18 @@
             <param name="param1" example="Example for param1">Description for param1</param>
             <param name="param2" example="Example for param2">Description for param2</param>
         </member>
+        <member name="T:Swashbuckle.AspNetCore.SwaggerGen.Test.FakeControllerWithInheritDoc">
+            <inheritdoc cref = "T:Swashbuckle.AspNetCore.SwaggerGen.Test.FakeControllerWithXmlComments" />
+        </member>
+        <member name="M:Swashbuckle.AspNetCore.SwaggerGen.Test.FakeControllerWithInheritDoc.ActionWithSummaryAndRemarksTags">
+            <inheritdoc cref = "M:Swashbuckle.AspNetCore.SwaggerGen.Test.FakeControllerWithXmlComments.ActionWithSummaryAndRemarksTags"/>
+        </member>
+        <member name="M:Swashbuckle.AspNetCore.SwaggerGen.Test.FakeControllerWithInheritDoc.ActionWithParamTags(System.String,System.String)">
+            <inheritdoc cref = "M:Swashbuckle.AspNetCore.SwaggerGen.Test.FakeControllerWithXmlComments.ActionWithParamTags(System.String,System.String)"/>
+        </member>
+        <member name="M:Swashbuckle.AspNetCore.SwaggerGen.Test.FakeControllerWithInheritDoc.ActionWithResponseTags">
+            <inheritdoc cref = "M:Swashbuckle.AspNetCore.SwaggerGen.Test.FakeControllerWithXmlComments.ActionWithResponseTags"/>
+        </member>
         <member name="T:Swashbuckle.AspNetCore.SwaggerGen.Test.FakeControllerWithXmlComments">
             <summary>
             Summary for FakeControllerWithXmlComments

--- a/test/Swashbuckle.AspNetCore.TestSupport/Swashbuckle.AspNetCore.TestSupport.csproj
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Swashbuckle.AspNetCore.TestSupport.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+     <TargetFrameworks>net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>

--- a/test/WebSites/Basic/Basic.csproj
+++ b/test/WebSites/Basic/Basic.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/WebSites/CliExample/CliExample.csproj
+++ b/test/WebSites/CliExample/CliExample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <DotNetSwaggerPath>$([System.IO.Path]::Combine("..", "..", "..", "src", "Swashbuckle.AspNetCore.Cli", "bin", $(Configuration), $(TargetFramework), "dotnet-swagger.dll"))</DotNetSwaggerPath>
   </PropertyGroup>
 

--- a/test/WebSites/CliExampleWithFactory/CliExampleWithFactory.csproj
+++ b/test/WebSites/CliExampleWithFactory/CliExampleWithFactory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <DotNetSwaggerPath>$([System.IO.Path]::Combine("..", "..", "..", "src", "Swashbuckle.AspNetCore.Cli", "bin", $(Configuration), $(TargetFramework), "dotnet-swagger.dll"))</DotNetSwaggerPath>
   </PropertyGroup>
 

--- a/test/WebSites/ConfigFromFile/ConfigFromFile.csproj
+++ b/test/WebSites/ConfigFromFile/ConfigFromFile.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/WebSites/CustomUIConfig/CustomUIConfig.csproj
+++ b/test/WebSites/CustomUIConfig/CustomUIConfig.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/WebSites/CustomUIIndex/CustomUIIndex.csproj
+++ b/test/WebSites/CustomUIIndex/CustomUIIndex.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/WebSites/GenericControllers/GenericControllers.csproj
+++ b/test/WebSites/GenericControllers/GenericControllers.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
-    <TargetFramework>net6.0</TargetFramework>
+     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/WebSites/MinimalApp/MinimalApp.csproj
+++ b/test/WebSites/MinimalApp/MinimalApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+     <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DotNetSwaggerPath>$([System.IO.Path]::Combine("..", "..", "..", "src", "Swashbuckle.AspNetCore.Cli", "bin", $(Configuration), $(TargetFramework), "dotnet-swagger"))</DotNetSwaggerPath>

--- a/test/WebSites/MultipleVersions/MultipleVersions.csproj
+++ b/test/WebSites/MultipleVersions/MultipleVersions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/WebSites/NswagClientExample/NswagClientExample.csproj
+++ b/test/WebSites/NswagClientExample/NswagClientExample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+     <TargetFramework>net7.0</TargetFramework>
     <DotNetSwaggerPath>$([System.IO.Path]::Combine("..", "..", "..", "src", "Swashbuckle.AspNetCore.Cli", "bin", $(Configuration), $(TargetFramework), "dotnet-swagger.dll"))</DotNetSwaggerPath>
   </PropertyGroup>
 

--- a/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
+++ b/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/WebSites/ReDoc/ReDoc.csproj
+++ b/test/WebSites/ReDoc/ReDoc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/WebSites/TestFirst.IntegrationTests/TestFirst.IntegrationTests.csproj
+++ b/test/WebSites/TestFirst.IntegrationTests/TestFirst.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/WebSites/TestFirst/TestFirst.csproj
+++ b/test/WebSites/TestFirst/TestFirst.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+     <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In answer to [Issue #2597](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2597), this will recursively scan the XML documentation to gather the first property/attribute that contains the needed value. This change would work automatically without the user having to do anything extra.