### PR TITLE
WIP: Better support for open generic when mapping types

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,6 +839,26 @@ services.AddSwaggerGen(c =>
 };
 ```
 
+As of version v6.6.x, you can easily map generic types dynamically by accessing the underlying type at runtime. In this example, I want to treat `GenericType` as if it was the generic type `T`:
+
+```csharp
+// GenericType.cs
+public class GenericType<T>
+{
+   public T MyProperty { get; set; }
+}
+
+// Startup.cs
+c.MapType(typeof(GenericType<>), mappingContext =>
+{
+    // First, get the type of T:
+    var type = mappingContext.UnderlyingType.GenericTypeArguments[0];
+
+    // Now, autmatically generate a schema for T and return that:
+    return mappingContext.SchemaGenerator.GenerateSchema(type, mappingContext.SchemaRepository);
+});
+```
+
 ### Extend Generator with Operation, Schema & Document Filters ###
 
 Swashbuckle exposes a filter pipeline that hooks into the generation process. Once generated, individual metadata objects are passed into the pipeline where they can be modified further. You can wire up custom filters to enrich the generated "Operations", "Schemas" and "Documents".

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
@@ -30,7 +30,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private void DeepCopy(SchemaGeneratorOptions source, SchemaGeneratorOptions target)
         {
-            target.CustomTypeMappings = new Dictionary<Type, Func<OpenApiSchema>>(source.CustomTypeMappings);
+            target.CustomTypeMappings = new Dictionary<Type, Func<Type[], OpenApiSchema>>(source.CustomTypeMappings);
             target.UseInlineDefinitionsForEnums = source.UseInlineDefinitionsForEnums;
             target.SchemaIdSelector = source.SchemaIdSelector;
             target.IgnoreObsoleteProperties = source.IgnoreObsoleteProperties;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
@@ -30,7 +30,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private void DeepCopy(SchemaGeneratorOptions source, SchemaGeneratorOptions target)
         {
-            target.CustomTypeMappings = new Dictionary<Type, Func<Type[], OpenApiSchema>>(source.CustomTypeMappings);
+            target.CustomTypeMappings = new Dictionary<Type, Func<MappingContext, OpenApiSchema>>(source.CustomTypeMappings);
             target.UseInlineDefinitionsForEnums = source.UseInlineDefinitionsForEnums;
             target.SchemaIdSelector = source.SchemaIdSelector;
             target.IgnoreObsoleteProperties = source.IgnoreObsoleteProperties;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static void MapType(
             this SwaggerGenOptions swaggerGenOptions,
             Type type,
-            Func<MappingContext, OpenApiSchema> schemaFactory)
+            Func<IMappingContext, OpenApiSchema> schemaFactory)
         {
             swaggerGenOptions.SchemaGeneratorOptions.CustomTypeMappings.Add(type, schemaFactory);
         }
@@ -217,7 +217,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="schemaFactory">A factory method that generates Schema's for the provided type</param>
         public static void MapType<T>(
             this SwaggerGenOptions swaggerGenOptions,
-            Func<MappingContext, OpenApiSchema> schemaFactory)
+            Func<IMappingContext, OpenApiSchema> schemaFactory)
         {
             swaggerGenOptions.MapType(typeof(T), schemaFactory);
         }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Extensions.DependencyInjection
             Type type,
             Func<OpenApiSchema> schemaFactory)
         {
-            swaggerGenOptions.SchemaGeneratorOptions.CustomTypeMappings.Add(type, schemaFactory);
+            swaggerGenOptions.MapType(type, _ => schemaFactory());
         }
 
         /// <summary>
@@ -191,6 +191,33 @@ namespace Microsoft.Extensions.DependencyInjection
         public static void MapType<T>(
             this SwaggerGenOptions swaggerGenOptions,
             Func<OpenApiSchema> schemaFactory)
+        {
+            swaggerGenOptions.MapType(typeof(T), schemaFactory);
+        }
+
+        /// <summary>
+        /// Provide a custom mapping, for a given type, to the Swagger-flavored JSONSchema
+        /// </summary>
+        /// <param name="swaggerGenOptions"></param>
+        /// <param name="type">System type</param>
+        /// <param name="schemaFactory">A factory method that generates Schema's for the provided type</param>
+        public static void MapType(
+            this SwaggerGenOptions swaggerGenOptions,
+            Type type,
+            Func<Type[], OpenApiSchema> schemaFactory)
+        {
+            swaggerGenOptions.SchemaGeneratorOptions.CustomTypeMappings.Add(type, schemaFactory);
+        }
+
+        /// <summary>
+        /// Provide a custom mapping, for a given type, to the Swagger-flavored JSONSchema
+        /// </summary>
+        /// <typeparam name="T">System type</typeparam>
+        /// <param name="swaggerGenOptions"></param>
+        /// <param name="schemaFactory">A factory method that generates Schema's for the provided type</param>
+        public static void MapType<T>(
+            this SwaggerGenOptions swaggerGenOptions,
+            Func<Type[], OpenApiSchema> schemaFactory)
         {
             swaggerGenOptions.MapType(typeof(T), schemaFactory);
         }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static void MapType(
             this SwaggerGenOptions swaggerGenOptions,
             Type type,
-            Func<Type[], OpenApiSchema> schemaFactory)
+            Func<MappingContext, OpenApiSchema> schemaFactory)
         {
             swaggerGenOptions.SchemaGeneratorOptions.CustomTypeMappings.Add(type, schemaFactory);
         }
@@ -217,7 +217,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="schemaFactory">A factory method that generates Schema's for the provided type</param>
         public static void MapType<T>(
             this SwaggerGenOptions swaggerGenOptions,
-            Func<Type[], OpenApiSchema> schemaFactory)
+            Func<MappingContext, OpenApiSchema> schemaFactory)
         {
             swaggerGenOptions.MapType(typeof(T), schemaFactory);
         }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -212,14 +212,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private OpenApiSchema GenerateConcreteSchema(DataContract dataContract, SchemaRepository schemaRepository)
         {
-            if (TryGetCustomTypeMapping(dataContract.UnderlyingType, out Func<Type[], OpenApiSchema> customSchemaFactory))
+            if (TryGetCustomTypeMapping(dataContract.UnderlyingType, out Func<MappingContext, OpenApiSchema> customSchemaFactory))
             {
-                if (dataContract.UnderlyingType.IsGenericType)
-                {
-                    return customSchemaFactory(dataContract.UnderlyingType.GenericTypeArguments);
-                }
-
-                return customSchemaFactory(null);
+                return customSchemaFactory(new MappingContext(this, schemaRepository, dataContract.UnderlyingType));
             }
 
             if (dataContract.UnderlyingType.IsAssignableToOneOf(BinaryStringTypes))
@@ -276,7 +271,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 : schemaFactory();
         }
 
-        private bool TryGetCustomTypeMapping(Type modelType, out Func<Type[], OpenApiSchema> schemaFactory)
+        private bool TryGetCustomTypeMapping(Type modelType, out Func<MappingContext, OpenApiSchema> schemaFactory)
         {
             return _generatorOptions.CustomTypeMappings.TryGetValue(modelType, out schemaFactory)
                 || (modelType.IsConstructedGenericType && _generatorOptions.CustomTypeMappings.TryGetValue(modelType.GetGenericTypeDefinition(), out schemaFactory));

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -212,9 +212,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private OpenApiSchema GenerateConcreteSchema(DataContract dataContract, SchemaRepository schemaRepository)
         {
-            if (TryGetCustomTypeMapping(dataContract.UnderlyingType, out Func<OpenApiSchema> customSchemaFactory))
+            if (TryGetCustomTypeMapping(dataContract.UnderlyingType, out Func<Type[], OpenApiSchema> customSchemaFactory))
             {
-                return customSchemaFactory();
+                if (dataContract.UnderlyingType.IsGenericType)
+                {
+                    return customSchemaFactory(dataContract.UnderlyingType.GenericTypeArguments);
+                }
+
+                return customSchemaFactory(null);
             }
 
             if (dataContract.UnderlyingType.IsAssignableToOneOf(BinaryStringTypes))
@@ -271,7 +276,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 : schemaFactory();
         }
 
-        private bool TryGetCustomTypeMapping(Type modelType, out Func<OpenApiSchema> schemaFactory)
+        private bool TryGetCustomTypeMapping(Type modelType, out Func<Type[], OpenApiSchema> schemaFactory)
         {
             return _generatorOptions.CustomTypeMappings.TryGetValue(modelType, out schemaFactory)
                 || (modelType.IsConstructedGenericType && _generatorOptions.CustomTypeMappings.TryGetValue(modelType.GetGenericTypeDefinition(), out schemaFactory));

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
@@ -9,7 +9,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     {
         public SchemaGeneratorOptions()
         {
-            CustomTypeMappings = new Dictionary<Type, Func<Type[], OpenApiSchema>>();
+            CustomTypeMappings = new Dictionary<Type, Func<MappingContext, OpenApiSchema>>();
             SchemaIdSelector = DefaultSchemaIdSelector;
             SubTypesSelector = DefaultSubTypesSelector;
             DiscriminatorNameSelector = DefaultDiscriminatorNameSelector;
@@ -17,7 +17,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             SchemaFilters = new List<ISchemaFilter>();
         }
 
-        public IDictionary<Type, Func<Type[], OpenApiSchema>> CustomTypeMappings { get; set; }
+        public IDictionary<Type, Func<MappingContext, OpenApiSchema>> CustomTypeMappings { get; set; }
 
         public bool UseInlineDefinitionsForEnums { get; set; }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
@@ -9,7 +9,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     {
         public SchemaGeneratorOptions()
         {
-            CustomTypeMappings = new Dictionary<Type, Func<OpenApiSchema>>();
+            CustomTypeMappings = new Dictionary<Type, Func<Type[], OpenApiSchema>>();
             SchemaIdSelector = DefaultSchemaIdSelector;
             SubTypesSelector = DefaultSubTypesSelector;
             DiscriminatorNameSelector = DefaultDiscriminatorNameSelector;
@@ -17,7 +17,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             SchemaFilters = new List<ISchemaFilter>();
         }
 
-        public IDictionary<Type, Func<OpenApiSchema>> CustomTypeMappings { get; set; }
+        public IDictionary<Type, Func<Type[], OpenApiSchema>> CustomTypeMappings { get; set; }
 
         public bool UseInlineDefinitionsForEnums { get; set; }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/MappingContext.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/MappingContext.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen
+{
+    public class MappingContext
+    {
+        public MappingContext(
+            ISchemaGenerator schemaGenerator,
+            SchemaRepository schemaRepository,
+            Type underlyingType)
+        {
+            SchemaGenerator = schemaGenerator;
+            SchemaRepository = schemaRepository;
+            UnderlyingType = underlyingType;
+        }
+
+        public ISchemaGenerator SchemaGenerator { get; }
+
+        public SchemaRepository SchemaRepository { get; }
+
+        public Type UnderlyingType { get; }
+    }
+}

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/MappingContext.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/MappingContext.cs
@@ -1,26 +1,25 @@
 ﻿using System;
 
-namespace Swashbuckle.AspNetCore.SwaggerGen
+namespace Swashbuckle.AspNetCore.SwaggerGen;
+
+public interface IMappingContext
 {
-    public class MappingContext
-    {
-        public MappingContext(
-            ISchemaGenerator schemaGenerator,
-            SchemaRepository schemaRepository,
-            Type underlyingType)
-        {
-            SchemaGenerator = schemaGenerator;
-            SchemaRepository = schemaRepository;
-            UnderlyingType = underlyingType;
-        }
+    ISchemaGenerator SchemaGenerator { get; }
+    SchemaRepository SchemaRepository { get; }
 
-        public readonly ISchemaGenerator SchemaGenerator;
+    /// <summary>
+    /// Actual runtime type that's being mapped.
+    /// </summary>
+    Type UnderlyingType { get;}
+}
 
-        public readonly SchemaRepository SchemaRepository;
-
-        /// <summary>
-        /// Actual runtime type that's being mapped.
-        /// </summary>
-        public readonly Type UnderlyingType;
-    }
+public class MappingContext(
+    ISchemaGenerator schemaGenerator,
+    SchemaRepository schemaRepository,
+    Type underlyingType)
+    : IMappingContext
+{
+    public ISchemaGenerator SchemaGenerator { get; } = schemaGenerator;
+    public SchemaRepository SchemaRepository { get; } = schemaRepository;
+    public Type UnderlyingType { get; } = underlyingType;
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/MappingContext.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/MappingContext.cs
@@ -14,10 +14,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             UnderlyingType = underlyingType;
         }
 
-        public ISchemaGenerator SchemaGenerator { get; }
+        public readonly ISchemaGenerator SchemaGenerator;
 
-        public SchemaRepository SchemaRepository { get; }
+        public readonly SchemaRepository SchemaRepository;
 
-        public Type UnderlyingType { get; }
+        /// <summary>
+        /// Actual runtime type that's being mapped.
+        /// </summary>
+        public readonly Type UnderlyingType;
     }
 }

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -370,7 +370,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             string expectedSchemaType)
         {
             var subject = Subject(
-                configureGenerator: c => c.CustomTypeMappings.Add(mappingType, () => new OpenApiSchema { Type = "string" })
+                configureGenerator: c => c.CustomTypeMappings.Add(mappingType, _ => new OpenApiSchema { Type = "string" })
             );
             var schema = subject.GenerateSchema(type, new SchemaRepository());
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -492,9 +492,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var genericType = typeof(GenericType<string>);
 
             var subject = Subject(
-                configureGenerator: c => c.CustomTypeMappings.Add(genericType, types =>
+                configureGenerator: c => c.CustomTypeMappings.Add(genericType, mappingContext =>
                 {
-                    var type = types.First();
+                    var type = mappingContext.UnderlyingType.GenericTypeArguments.First();
 
                     if (type == typeof(string))
                         return new OpenApiSchema { Type = "string" };

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -487,7 +487,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
-        public void GenerateSchema_()
+        public void GenerateSchema_GeneratesTypeCorrectly_IfTypeTakenFromUnderlyingType()
         {
             var genericType = typeof(GenericType<string>);
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -478,11 +478,33 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             string expectedSchemaType)
         {
             var subject = Subject(
-                configureGenerator: c => c.CustomTypeMappings.Add(mappingType, () => new OpenApiSchema { Type = "string" })
+                configureGenerator: c => c.CustomTypeMappings.Add(mappingType, _ => new OpenApiSchema { Type = "string" })
             );
             var schema = subject.GenerateSchema(type, new SchemaRepository());
 
             Assert.Equal(expectedSchemaType, schema.Type);
+            Assert.Empty(schema.Properties);
+        }
+
+        [Fact]
+        public void GenerateSchema_()
+        {
+            var genericType = typeof(GenericType<string>);
+
+            var subject = Subject(
+                configureGenerator: c => c.CustomTypeMappings.Add(genericType, types =>
+                {
+                    var type = types.First();
+
+                    if (type == typeof(string))
+                        return new OpenApiSchema { Type = "string" };
+
+                    throw new NotImplementedException();
+                })
+            );
+            var schema = subject.GenerateSchema(genericType, new SchemaRepository());
+
+            Assert.Equal("string", schema.Type);
             Assert.Empty(schema.Properties);
         }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -487,7 +487,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
-        public void GenerateSchema_GeneratesTypeCorrectly_IfTypeTakenFromUnderlyingType()
+        public void GenerateSchema_GeneratesSchemaWithCorrectType_IfTypeTakenFromUnderlyingType()
         {
             var genericType = typeof(GenericType<string>);
 

--- a/test/WebSites/Basic/Controllers/GenericsController.cs
+++ b/test/WebSites/Basic/Controllers/GenericsController.cs
@@ -10,8 +10,14 @@ namespace Basic.Controllers
     [Produces("application/json")]
     public class GenericsController
     {
-        [HttpPost(Name = "Createstring")]
-        public string Create([FromBody] GenericType<string> genericString)
+        [HttpPost(Name = "CreateString")]
+        public string CreateString([FromBody] GenericType<string> genericString)
+        {
+            throw new NotImplementedException();
+        }
+
+        [HttpPost(Name = "CreateDateTime")]
+        public string CreateDateTime([FromBody] GenericType<DateTime> genericObject)
         {
             throw new NotImplementedException();
         }

--- a/test/WebSites/Basic/Controllers/GenericsController.cs
+++ b/test/WebSites/Basic/Controllers/GenericsController.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Basic.Controllers
+{
+    /// <summary>
+    /// Summary for GenericsController
+    /// </summary>
+    [Route("/generics")]
+    [Produces("application/json")]
+    public class GenericsController
+    {
+        [HttpPost(Name = "Createstring")]
+        public string Create([FromBody] GenericType<string> genericString)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/WebSites/Basic/Controllers/GenericsController.cs
+++ b/test/WebSites/Basic/Controllers/GenericsController.cs
@@ -10,13 +10,13 @@ namespace Basic.Controllers
     [Produces("application/json")]
     public class GenericsController
     {
-        [HttpPost(Name = "CreateString")]
+        [HttpPost("CreateString")]
         public string CreateString([FromBody] GenericType<string> genericString)
         {
             throw new NotImplementedException();
         }
 
-        [HttpPost(Name = "CreateDateTime")]
+        [HttpPost("CreateDateTime")]
         public string CreateDateTime([FromBody] GenericType<DateTime> genericObject)
         {
             throw new NotImplementedException();

--- a/test/WebSites/Basic/GenericTypes.cs
+++ b/test/WebSites/Basic/GenericTypes.cs
@@ -1,16 +1,7 @@
-﻿using System;
-
-namespace Basic
+﻿namespace Basic
 {
     public class GenericType<T>
     {
         public T Property1 { get; set; }
-    }
-
-    public class GenericType<T,K>
-    {
-        public T Property1 { get; set; }
-
-        public K Property2 { get; set; }
     }
 }

--- a/test/WebSites/Basic/GenericTypes.cs
+++ b/test/WebSites/Basic/GenericTypes.cs
@@ -1,4 +1,6 @@
-﻿namespace Swashbuckle.AspNetCore.TestSupport
+﻿using System;
+
+namespace Basic
 {
     public class GenericType<T>
     {

--- a/test/WebSites/Basic/Startup.cs
+++ b/test/WebSites/Basic/Startup.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 using Microsoft.AspNetCore.Localization;
 using Basic.Swagger;
+using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Basic
 {
@@ -56,14 +57,11 @@ namespace Basic
 
                 c.EnableAnnotations();
 
-                c.MapType(typeof(GenericType<>), types =>
+                c.MapType(typeof(GenericType<>), mappingContext =>
                 {
-                    var type = types[0];
+                    var type = mappingContext.UnderlyingType.GenericTypeArguments[0];
 
-                    if (type == typeof(string))
-                        return new OpenApiSchema { Type = "string" };
-
-                    throw new NotImplementedException();
+                    return mappingContext.SchemaGenerator.GenerateSchema(type, mappingContext.SchemaRepository);
                 });
             });
         }

--- a/test/WebSites/Basic/Startup.cs
+++ b/test/WebSites/Basic/Startup.cs
@@ -55,6 +55,16 @@ namespace Basic
                 c.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, "Basic.xml"));
 
                 c.EnableAnnotations();
+
+                c.MapType(typeof(GenericType<>), types =>
+                {
+                    var type = types[0];
+
+                    if (type == typeof(string))
+                        return new OpenApiSchema { Type = "string" };
+
+                    throw new NotImplementedException();
+                });
             });
         }
 


### PR DESCRIPTION
## Issues

This helps with these issues:

- https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/1810
- https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/1600
- https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2333
- https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2359
- and probably more

## The problem

The issue I'm trying to solve is that there's no way to generically solve all mappings for a type that uses open generics. We can currently do something like this:

```
services.AddSwaggerGen(c =>
{
    c.MapType(typeof(GenericType<string>), () => new OpenApiSchema { Type = "string" });
    c.MapType(typeof(GenericType<int>), () => new OpenApiSchema { Type = "number" });
    // and handle every other type that GenericType could be...
}
```

But writing an exhaustive list is impossible, especially when you need to support custom objects.

## The solution

Provide the user with a `MappingContext` so they can dynamically handle different types:

```
c.MapType(typeof(GenericType<>), mappingContext =>
{
    var type = mappingContext.UnderlyingType.GenericTypeArguments[0];

    return mappingContext.SchemaGenerator.GenerateSchema(type, mappingContext.SchemaRepository);
});
```

The `MappingContext` contains these useful properties:

```
public interface IMappingContext
{
    ISchemaGenerator SchemaGenerator { get; }
    SchemaRepository SchemaRepository { get; }
    Type UnderlyingType { get; }
}
```