### PR TITLE
Do not run IHostedService implementations

### DIFF
--- a/Swashbuckle.AspNetCore.sln
+++ b/Swashbuckle.AspNetCore.sln
@@ -92,6 +92,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Swashbuckle.AspNetCore.Test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinimalApp", "test\WebSites\MinimalApp\MinimalApp.csproj", "{3D0126CB-5439-483C-B2D5-4B4BE111D15C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MinimalAppWithHostedService", "test\WebSites\MinimalAppWithHostedService\MinimalAppWithHostedService.csproj", "{DD2A4D91-C071-4767-A4BE-7F3772DA134F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -486,6 +488,18 @@ Global
 		{3D0126CB-5439-483C-B2D5-4B4BE111D15C}.Release|x64.Build.0 = Release|Any CPU
 		{3D0126CB-5439-483C-B2D5-4B4BE111D15C}.Release|x86.ActiveCfg = Release|Any CPU
 		{3D0126CB-5439-483C-B2D5-4B4BE111D15C}.Release|x86.Build.0 = Release|Any CPU
+		{DD2A4D91-C071-4767-A4BE-7F3772DA134F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD2A4D91-C071-4767-A4BE-7F3772DA134F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD2A4D91-C071-4767-A4BE-7F3772DA134F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DD2A4D91-C071-4767-A4BE-7F3772DA134F}.Debug|x64.Build.0 = Debug|Any CPU
+		{DD2A4D91-C071-4767-A4BE-7F3772DA134F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DD2A4D91-C071-4767-A4BE-7F3772DA134F}.Debug|x86.Build.0 = Debug|Any CPU
+		{DD2A4D91-C071-4767-A4BE-7F3772DA134F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD2A4D91-C071-4767-A4BE-7F3772DA134F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DD2A4D91-C071-4767-A4BE-7F3772DA134F}.Release|x64.ActiveCfg = Release|Any CPU
+		{DD2A4D91-C071-4767-A4BE-7F3772DA134F}.Release|x64.Build.0 = Release|Any CPU
+		{DD2A4D91-C071-4767-A4BE-7F3772DA134F}.Release|x86.ActiveCfg = Release|Any CPU
+		{DD2A4D91-C071-4767-A4BE-7F3772DA134F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -524,6 +538,7 @@ Global
 		{76692D68-C38C-4A7D-B3DA-DA78A393E266} = {0ADCB223-F375-45AB-8BC4-834EC9C69554}
 		{66590FBA-5FDD-4AC9-AF91-26ADAB33CCB8} = {0ADCB223-F375-45AB-8BC4-834EC9C69554}
 		{3D0126CB-5439-483C-B2D5-4B4BE111D15C} = {DB3F57FC-1472-4F03-B551-43394DA3C5EB}
+		{DD2A4D91-C071-4767-A4BE-7F3772DA134F} = {DB3F57FC-1472-4F03-B551-43394DA3C5EB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {36FC6A67-247D-4149-8EDD-79FFD1A75F51}

--- a/src/Swashbuckle.AspNetCore.Cli/HostingApplication.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/HostingApplication.cs
@@ -34,6 +34,9 @@ namespace Swashbuckle.AspNetCore.Cli
 
                     for (var i = services.Count - 1; i >= 0; i--)
                     {
+                        // exclude all implementations of IHostedService
+                        // except Microsoft.AspNetCore.Hosting.GenericWebHostService because that one will build/configure
+                        // the WebApplication/Middleware pipeline in the case of the GenericWebHostBuilder.
                         if (typeof(IHostedService).IsAssignableFrom(services[i].ServiceType)
                             && services[i].ImplementationType is not { FullName: "Microsoft.AspNetCore.Hosting.GenericWebHostService" })
                         {

--- a/src/Swashbuckle.AspNetCore.Cli/HostingApplication.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/HostingApplication.cs
@@ -31,6 +31,15 @@ namespace Swashbuckle.AspNetCore.Cli
                 {
                     services.AddSingleton<IServer, NoopServer>();
                     services.AddSingleton<IHostLifetime, NoopHostLifetime>();
+
+                    for (var i = services.Count - 1; i >= 0; i--)
+                    {
+                        if (typeof(IHostedService).IsAssignableFrom(services[i].ServiceType)
+                            && services[i].ImplementationType is not { FullName: "Microsoft.AspNetCore.Hosting.GenericWebHostService" })
+                        {
+                            services.RemoveAt(i);
+                        }
+                    }
                 });
             }
 

--- a/test/Swashbuckle.AspNetCore.Cli.Test/Swashbuckle.AspNetCore.Cli.Test.csproj
+++ b/test/Swashbuckle.AspNetCore.Cli.Test/Swashbuckle.AspNetCore.Cli.Test.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\WebSites\Basic\Basic.csproj" />
+    <ProjectReference Include="..\WebSites\MinimalAppWithHostedService\MinimalAppWithHostedService.csproj" />
     <ProjectReference Include="..\WebSites\MinimalApp\MinimalApp.csproj" />
     <ProjectReference Include="..\..\src\Swashbuckle.AspNetCore.Cli\Swashbuckle.AspNetCore.Cli.csproj" />
   </ItemGroup>

--- a/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
+++ b/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
@@ -57,6 +57,29 @@ namespace Swashbuckle.AspNetCore.Cli.Test
                 dir.Delete(true);
             }
         }
+
+        [Fact]
+        public void Does_Not_Run_Crashing_HostedService()
+        {
+            var dir = Directory.CreateDirectory(Path.Join(Path.GetTempPath(), Path.GetRandomFileName()));
+            try
+            {
+                var args = new string[] { "tofile", "--output", $"{dir}/swagger.json", Path.Combine(Directory.GetCurrentDirectory(), "MinimalAppWithHostedService.dll"), "v1" };
+
+                Assert.Equal(0, Program.Main(args));
+
+                using var document = JsonDocument.Parse(File.ReadAllText(Path.Combine(dir.FullName, "swagger.json")));
+
+                // verify one of the endpoints
+                var paths = document.RootElement.GetProperty("paths");
+                var path = paths.GetProperty("/ShouldContain");
+                Assert.True(path.TryGetProperty("get", out _));
+            }
+            finally
+            {
+                dir.Delete(true);
+            }
+        }
 #endif
     }
 }

--- a/test/WebSites/MinimalAppWithHostedService/MinimalAppWithHostedService.csproj
+++ b/test/WebSites/MinimalAppWithHostedService/MinimalAppWithHostedService.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <DotNetSwaggerPath>$([System.IO.Path]::Combine("..", "..", "..", "src", "Swashbuckle.AspNetCore.Cli", "bin", $(Configuration), $(TargetFramework), "dotnet-swagger"))</DotNetSwaggerPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerGen\Swashbuckle.AspNetCore.SwaggerGen.csproj" />
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerUI\Swashbuckle.AspNetCore.SwaggerUI.csproj" />
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.Swagger\Swashbuckle.AspNetCore.Swagger.csproj" />
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.Cli\Swashbuckle.AspNetCore.Cli.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/WebSites/MinimalAppWithHostedService/Program.cs
+++ b/test/WebSites/MinimalAppWithHostedService/Program.cs
@@ -1,0 +1,34 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new() { Title = "MinimalApp", Version = "v1" });
+});
+
+builder.Services.AddHostedService<HostedService>();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "MinimalApp v1"));
+}
+
+app.MapGet("/ShouldContain", () => "Hello World!");
+
+app.Run();
+
+class HostedService : IHostedService
+{
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        throw new Exception("Crash!");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/test/WebSites/MinimalAppWithHostedService/Properties/launchSettings.json
+++ b/test/WebSites/MinimalAppWithHostedService/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+﻿{
+  "profiles": {
+    "MinimalAppWithHostedService": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7128;http://localhost:5201",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Currently the CLI is running all registered Hosted Services (`IHostedService`). I see that it's needed to start the application because otherwise the `app.Use*`/`app.Map*` configuration is not run. Because it's starting the application (with a NoopServer) it is running all registered HostedServices.

Because the CLI is almost always run in the context of a build it would be nice to not run those registered hosted services. This would also solve instances of for example HangFire or other things which start an IHostedService.

Please let me know if you want to have this change or if I need to modify something.

Related issue: #2712