### PR TITLE
Enabled Deterministic Build

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,4 +22,10 @@
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 	</ItemGroup>
 
+	<PropertyGroup Condition="'$(CI)' == 'True'">
+		<!-- Deterministic Build settings -->
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+	</PropertyGroup>
+
 </Project>


### PR DESCRIPTION
This PR enables Deterministic Build.

## Why
To be sure that the produced binary on nuget.org is really made from this Github Source

I've also configured deterministic builds for other open-source projects, e.g. https://github.com/nunit/nunit/pull/3810, https://github.com/App-vNext/Polly/pull/839


## More info
- https://github.com/clairernovotny/DeterministicBuilds


## Before
![image](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/assets/5808377/25e581b7-9563-4d00-9597-69a3348fbe63)

See https://nuget.info/packages/Swashbuckle.AspNetCore.Swagger/6.5.0

## After
- [ ] TODO