### PR TITLE
Added support for enums when a JsonSerializerContext is used

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 install:
   - ps: Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile "./dotnet-install.ps1"

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
@@ -80,7 +80,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 jsonConverter: JsonConverterFunc);
         }
 
-        private string JsonConverterFunc(object value)
+        private string JsonConverterFunc(dynamic value)
         {
             return JsonSerializer.Serialize(value, _serializerOptions);
         }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -165,8 +165,17 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private DataContract GetDataContractFor(Type modelType)
         {
-            var effectiveType = Nullable.GetUnderlyingType(modelType) ?? modelType;
-            return _serializerDataContractResolver.GetDataContractForType(effectiveType);
+            try
+            {
+                var effectiveType = Nullable.GetUnderlyingType(modelType) ?? modelType;
+                return _serializerDataContractResolver.GetDataContractForType(effectiveType);
+            }
+            catch (Exception ex)
+            {
+                throw new SwaggerGeneratorException(
+                    message: $"Failed to generate data contract for type - {modelType}. See inner exception",
+                    innerException: ex);
+            }
         }
 
         private bool IsBaseTypeWithKnownTypesDefined(DataContract dataContract, out IEnumerable<DataContract> knownTypesDataContracts)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/CustomJsonSerializerContext.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/CustomJsonSerializerContext.cs
@@ -1,0 +1,10 @@
+﻿using Swashbuckle.AspNetCore.TestSupport;
+using System.Text.Json.Serialization;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test.SchemaGenerator;
+
+[JsonSerializable(typeof(IntEnum))]
+[JsonSerializable(typeof(LongEnum))]
+public partial class CustomJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -731,11 +731,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal(expectedDefaultAsJson, propertySchema.Default.ToJson());
         }
 
-        [Fact]
-        public void GenerateSchema_HonorsSerializerOption_WorksWithJsonSerializerContext()
-        {
-
-        }
         [Theory]
         [InlineData(typeof(IntEnum), "integer", "int32", "2", "4", "8")]
         [InlineData(typeof(LongEnum), "integer", "int64", "2", "4", "8")]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -1285,7 +1285,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             return new SwaggerGenerator(
                 options ?? DefaultOptions,
                 new FakeApiDescriptionGroupCollectionProvider(apiDescriptions),
-                new SchemaGenerator(new SchemaGeneratorOptions(), new JsonSerializerDataContractResolver(new JsonSerializerOptions())),
+                new SwaggerGen.SchemaGenerator(new SchemaGeneratorOptions(), new JsonSerializerDataContractResolver(new JsonSerializerOptions())),
                 new FakeAuthenticationSchemeProvider(authenticationSchemes ?? Enumerable.Empty<AuthenticationScheme>())
             );
         }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.csproj
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <DocumentationFile>Swashbuckle.AspNetCore.SwaggerGen.Test.xml</DocumentationFile>
     <NoWarn>1701;1702;1591</NoWarn>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.xml
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.xml
@@ -195,6 +195,30 @@
             For ad-hoc serializer testing
             </summary>
         </member>
+        <member name="P:Swashbuckle.AspNetCore.SwaggerGen.Test.SchemaGenerator.CustomJsonSerializerContext.String">
+            <summary>
+            Defines the source generated JSON serialization contract metadata for a given type.
+            </summary>
+        </member>
+        <member name="P:Swashbuckle.AspNetCore.SwaggerGen.Test.SchemaGenerator.CustomJsonSerializerContext.Default">
+            <summary>
+            The default <see cref="T:System.Text.Json.Serialization.JsonSerializerContext"/> associated with a default <see cref="T:System.Text.Json.JsonSerializerOptions"/> instance.
+            </summary>
+        </member>
+        <member name="P:Swashbuckle.AspNetCore.SwaggerGen.Test.SchemaGenerator.CustomJsonSerializerContext.GeneratedSerializerOptions">
+            <summary>
+            The source-generated options associated with this context.
+            </summary>
+        </member>
+        <member name="M:Swashbuckle.AspNetCore.SwaggerGen.Test.SchemaGenerator.CustomJsonSerializerContext.#ctor">
+            <inheritdoc/>
+        </member>
+        <member name="M:Swashbuckle.AspNetCore.SwaggerGen.Test.SchemaGenerator.CustomJsonSerializerContext.#ctor(System.Text.Json.JsonSerializerOptions)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Swashbuckle.AspNetCore.SwaggerGen.Test.SchemaGenerator.CustomJsonSerializerContext.GetTypeInfo(System.Type)">
+            <inheritdoc/>
+        </member>
         <member name="T:Swashbuckle.AspNetCore.SwaggerGen.Test.XmlCommentsTextHelperTests">
             NOTE: Whitespace in these tests is significant and uses a combination of {tabs} and {spaces}
             You should toggle "View White Space" to "on".


### PR DESCRIPTION
1. To make it clearer what Type caused a failure during generation, modified the GetDataContractFor to catch and report more details.
2. Changed JsonConverterFunc(object value) to JsonConverterFunc(dynamic value) so that enums don't cause generation to throw a NotSupportedException when a TypeInfoResolver is used (e.g. - JsonSerializerContext).
3. Added unit tests that have a TypeInfoResolver to demonstrate the fix.

resolves #2722 