### PR TITLE
Fix that XML comment examples do not show up if the type is string and the example contains quotation marks

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
@@ -1,0 +1,27 @@
+﻿using System.Text.Json;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen
+{
+    public static class XmlCommentsExampleHelper
+    {
+        public static IOpenApiAny Create(
+            SchemaRepository schemaRepository,
+            OpenApiSchema schema,
+            string exampleString)
+        {
+            var isStringType =
+                (schema.ResolveType(schemaRepository) == "string") &&
+                !exampleString.Equals("null");
+
+            var exampleAsJson = isStringType
+                    ? JsonSerializer.Serialize(exampleString)
+                    : exampleString;
+
+            var example = OpenApiAnyFactory.CreateFromJson(exampleAsJson);
+
+            return example;
+        }
+    }
+}

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
@@ -4,7 +4,7 @@ using Microsoft.OpenApi.Models;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
-    public static class XmlCommentsExampleHelper
+    internal static class XmlCommentsExampleHelper
     {
         public static IOpenApiAny Create(
             SchemaRepository schemaRepository,

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
@@ -13,7 +13,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             var isStringType =
                 (schema?.ResolveType(schemaRepository) == "string") &&
-                !exampleString.Equals("null");
+                !string.Equals(exampleString, "null");
 
             var exampleAsJson = isStringType
                     ? JsonSerializer.Serialize(exampleString)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
@@ -12,7 +12,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             string exampleString)
         {
             var isStringType =
-                (schema.ResolveType(schemaRepository) == "string") &&
+                (schema?.ResolveType(schemaRepository) == "string") &&
                 !exampleString.Equals("null");
 
             var exampleAsJson = isStringType

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
@@ -67,7 +67,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 var example = paramNode.GetAttribute("example", "");
                 if (string.IsNullOrEmpty(example)) return;
 
-                parameter.Example = XmlCommentsExampleHelper.Create(context.SchemaRepository, parameter.Schema, example.ToString());
+                parameter.Example = XmlCommentsExampleHelper.Create(context.SchemaRepository, parameter.Schema, example);
             }
         }
     }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
@@ -42,11 +42,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             var exampleNode = propertyNode.SelectSingleNode("example");
             if (exampleNode == null) return;
 
-            var exampleAsJson = (parameter.Schema?.ResolveType(context.SchemaRepository) == "string")
-                ? $"\"{exampleNode.ToString()}\""
-                : exampleNode.ToString();
-
-            parameter.Example = OpenApiAnyFactory.CreateFromJson(exampleAsJson);
+            parameter.Example = XmlCommentsExampleHelper.Create(context.SchemaRepository, parameter.Schema, exampleNode.ToString());
         }
 
         private void ApplyParamTags(OpenApiParameter parameter, ParameterFilterContext context)
@@ -71,11 +67,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 var example = paramNode.GetAttribute("example", "");
                 if (string.IsNullOrEmpty(example)) return;
 
-                var exampleAsJson = (parameter.Schema?.ResolveType(context.SchemaRepository) == "string")
-                    ? $"\"{example}\""
-                    : example;
-
-                parameter.Example = OpenApiAnyFactory.CreateFromJson(exampleAsJson);
+                parameter.Example = XmlCommentsExampleHelper.Create(context.SchemaRepository, parameter.Schema, example.ToString());
             }
         }
     }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsRequestBodyFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsRequestBodyFilter.cs
@@ -50,11 +50,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             foreach (var mediaType in requestBody.Content.Values)
             {
-                var exampleAsJson = (mediaType.Schema?.ResolveType(context.SchemaRepository) == "string")
-                    ? $"\"{exampleNode.ToString()}\""
-                    : exampleNode.ToString();
-
-                mediaType.Example = OpenApiAnyFactory.CreateFromJson(exampleAsJson);
+                mediaType.Example = XmlCommentsExampleHelper.Create(context.SchemaRepository, mediaType.Schema, exampleNode.ToString());
             }
         }
 
@@ -82,11 +78,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
                 foreach (var mediaType in requestBody.Content.Values)
                 {
-                    var exampleAsJson = (mediaType.Schema?.ResolveType(context.SchemaRepository) == "string")
-                        ? $"\"{example}\""
-                        : example;
-
-                    mediaType.Example = OpenApiAnyFactory.CreateFromJson(exampleAsJson);
+                    mediaType.Example = XmlCommentsExampleHelper.Create(context.SchemaRepository, mediaType.Schema, example);
                 }
             }
         }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
@@ -69,11 +69,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             if (example == null)
                 return;
 
-            var exampleAsJson = (schema.ResolveType(context.SchemaRepository) == "string") && !example.Equals("null")
-                ? $"\"{example}\""
-                : example;
-
-            schema.Example = OpenApiAnyFactory.CreateFromJson(exampleAsJson);
+            schema.Example = XmlCommentsExampleHelper.Create(context.SchemaRepository, schema, example);
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeConstructedControllerWithXmlComments.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeConstructedControllerWithXmlComments.cs
@@ -17,8 +17,8 @@
         public void ActionWithSummaryAndResponseTags(T param)
         { }
 
-        /// <param name="param1" example="Example for param1">Description for param1</param>
-        /// <param name="param2" example="Example for param2">Description for param2</param>
+        /// <param name="param1" example="Example for &quot;param1&quot;">Description for param1</param>
+        /// <param name="param2" example="Example for &quot;param2&quot;">Description for param2</param>
         public void ActionWithParamTags(T param1, T param2)
         { }
     }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithXmlComments.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithXmlComments.cs
@@ -18,7 +18,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void ActionWithSummaryAndRemarksTags()
         { }
 
-        /// <param name="param1" example="Example for param1">Description for param1</param>
+        /// <param name="param1" example="Example for &quot;param1&quot;">Description for param1</param>
         /// <param name="param2" example="http://test.com/?param1=1&amp;param2=2">Description for param2</param>
         public void ActionWithParamTags(string param1, string param2)
         { }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsExampleHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsExampleHelperTests.cs
@@ -11,7 +11,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [Fact]
         public void Create_BuildsOpenApiArrayJson__When_NotStringTypeAndDataIsArray()
         {
-            OpenApiSchema schema = new OpenApiSchema();
+            var schema = new OpenApiSchema();
 
             IOpenApiAny example = XmlCommentsExampleHelper.Create(
                 schemaRepository,
@@ -19,6 +19,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 "[\"one\",\"two\",\"three\"]");
 
 
+            Assert.NotNull(example);
+            Assert.IsType<OpenApiArray>(example);
             var output = (OpenApiArray)example;
             Assert.Equal(3, output.Count);
             Assert.Equal("one",   ((OpenApiString)output[0]).Value);
@@ -36,6 +38,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             IOpenApiAny example = XmlCommentsExampleHelper.Create(
                 schemaRepository, schema, exampleString);
 
+            Assert.NotNull(example);
+            Assert.IsType<OpenApiString>(example);
             Assert.Equal(((OpenApiString)example).Value, exampleString);
         }
 
@@ -48,6 +52,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             IOpenApiAny example = XmlCommentsExampleHelper.Create(
                 schemaRepository, schema, "null");
 
+            Assert.NotNull(example);
+            Assert.IsType<OpenApiNull>(example);
             Assert.Equal(AnyType.Null, ((OpenApiNull)example).AnyType);
         }
 
@@ -58,6 +64,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             IOpenApiAny example = XmlCommentsExampleHelper.Create(schemaRepository, schema, "[]");
 
+            Assert.NotNull(example);
+            Assert.IsType<OpenApiArray>(example);
             Assert.Empty((OpenApiArray)example);
         }
     }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsExampleHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsExampleHelperTests.cs
@@ -50,5 +50,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal(AnyType.Null, ((OpenApiNull)example).AnyType);
         }
+
+        [Fact]
+        public void Create_AllowsSchemaToBeNull()
+        {
+            OpenApiSchema schema = null;
+
+            IOpenApiAny example = XmlCommentsExampleHelper.Create(schemaRepository, schema, "[]");
+
+            Assert.Empty((OpenApiArray)example);
+        }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsExampleHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsExampleHelperTests.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Xunit;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test
+{
+    public class XmlCommentsExampleHelperTests
+    {
+        private readonly SchemaRepository schemaRepository = new SchemaRepository();
+
+        [Fact]
+        public void Create_BuildsOpenApiArrayJson__When_NotStringTypeAndDataIsArray()
+        {
+            OpenApiSchema schema = new OpenApiSchema();
+
+            IOpenApiAny example = XmlCommentsExampleHelper.Create(
+                schemaRepository,
+                schema,
+                "[\"one\",\"two\",\"three\"]");
+
+
+            var output = (OpenApiArray)example;
+            Assert.Equal(3, output.Count);
+            Assert.Equal("one",   ((OpenApiString)output[0]).Value);
+            Assert.Equal("two",   ((OpenApiString)output[1]).Value);
+            Assert.Equal("three", ((OpenApiString)output[2]).Value);
+        }
+
+        [Fact]
+        public void Create_BuildsOpenApiString_When_TypeString()
+        {
+            string exampleString = "example string with special characters\"<>\r\n\"";
+            OpenApiSchema schema = new OpenApiSchema { Type = "string" };
+            schemaRepository.AddDefinition("test", schema);
+            
+            IOpenApiAny example = XmlCommentsExampleHelper.Create(
+                schemaRepository, schema, exampleString);
+
+            Assert.Equal(((OpenApiString)example).Value, exampleString);
+        }
+
+        [Fact]
+        public void Create_ReturnsNull_When_TypeString_and_ValueNull()
+        {
+            OpenApiSchema schema = new OpenApiSchema { Type = "string" };
+            schemaRepository.AddDefinition("test", schema);
+
+            IOpenApiAny example = XmlCommentsExampleHelper.Create(
+                schemaRepository, schema, "null");
+
+            Assert.Equal(AnyType.Null, ((OpenApiNull)example).AnyType);
+        }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsExampleHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsExampleHelperTests.cs
@@ -18,7 +18,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 schema,
                 "[\"one\",\"two\",\"three\"]");
 
-
             Assert.NotNull(example);
             var actual = Assert.IsType<OpenApiArray>(example);
             Assert.Equal(3, actual.Count);

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsExampleHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsExampleHelperTests.cs
@@ -20,12 +20,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
 
             Assert.NotNull(example);
-            Assert.IsType<OpenApiArray>(example);
-            var output = (OpenApiArray)example;
-            Assert.Equal(3, output.Count);
-            Assert.Equal("one",   ((OpenApiString)output[0]).Value);
-            Assert.Equal("two",   ((OpenApiString)output[1]).Value);
-            Assert.Equal("three", ((OpenApiString)output[2]).Value);
+            var actual = Assert.IsType<OpenApiArray>(example);
+            Assert.Equal(3, actual.Count);
+
+            var item1 = Assert.IsType<OpenApiString>(actual[0]);
+            var item2 = Assert.IsType<OpenApiString>(actual[1]);
+            var item3 = Assert.IsType<OpenApiString>(actual[2]);
+            Assert.Equal("one",   item1.Value);
+            Assert.Equal("two",   item2.Value);
+            Assert.Equal("three", item3.Value);
         }
 
         [Fact]
@@ -39,8 +42,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 schemaRepository, schema, exampleString);
 
             Assert.NotNull(example);
-            Assert.IsType<OpenApiString>(example);
-            Assert.Equal(((OpenApiString)example).Value, exampleString);
+            var actual = Assert.IsType<OpenApiString>(example);
+            Assert.Equal(actual.Value, exampleString);
         }
 
         [Fact]
@@ -53,8 +56,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 schemaRepository, schema, "null");
 
             Assert.NotNull(example);
-            Assert.IsType<OpenApiNull>(example);
-            Assert.Equal(AnyType.Null, ((OpenApiNull)example).AnyType);
+            var actual = Assert.IsType<OpenApiNull>(example);
+            Assert.Equal(AnyType.Null, actual.AnyType);
         }
 
         [Fact]
@@ -65,8 +68,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             IOpenApiAny example = XmlCommentsExampleHelper.Create(schemaRepository, schema, "[]");
 
             Assert.NotNull(example);
-            Assert.IsType<OpenApiArray>(example);
-            Assert.Empty((OpenApiArray)example);
+            var actual = Assert.IsType<OpenApiArray>(example);
+            Assert.Empty(actual);
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsParameterFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsParameterFilterTests.cs
@@ -23,7 +23,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal("Description for param1", parameter.Description);
             Assert.NotNull(parameter.Example);
-            Assert.Equal("\"Example for param1\"", parameter.Example.ToJson());
+            Assert.Equal("\"Example for \\\"param1\\\"\"", parameter.Example.ToJson());
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal("Description for param1", parameter.Description);
             Assert.NotNull(parameter.Example);
-            Assert.Equal("\"Example for param1\"", parameter.Example.ToJson());
+            Assert.Equal("\"Example for \\\"param1\\\"\"", parameter.Example.ToJson());
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsRequestBodyFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsRequestBodyFilterTests.cs
@@ -34,7 +34,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal("Description for param1", requestBody.Description);
             Assert.NotNull(requestBody.Content["application/json"].Example);
-            Assert.Equal("\"Example for param1\"", requestBody.Content["application/json"].Example.ToJson());
+            Assert.Equal("\"Example for \\\"param1\\\"\"", requestBody.Content["application/json"].Example.ToJson());
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal("Description for param1", requestBody.Description);
             Assert.NotNull(requestBody.Content["application/json"].Example);
-            Assert.Equal("\"Example for param1\"", requestBody.Content["application/json"].Example.ToJson());
+            Assert.Equal("\"Example for \\\"param1\\\"\"", requestBody.Content["application/json"].Example.ToJson());
         }
 
         [Fact]


### PR DESCRIPTION
Fix that XML comment examples do not show up if the type is string and the example contains quotation marks

Resolves #2088