### PR TITLE
Updating build to use latest GA'd version of 6.0.1xx and 7.0.1xx

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,10 @@ image: Visual Studio 2019
 
 install:
   - ps: Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile "./dotnet-install.ps1"
-  - ps: ./dotnet-install.ps1 -JsonFile global.json
+  - ps: ./dotnet-install.ps1 -Channel 7.0.1xx -Quality GA
 
 init:
 - git config --global core.autocrlf true
-
-environment:
-  DOTNET_VERSION: "7.0.100"
 
 build_script:
 - ps: dotnet pack -c Release -o artifacts

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ image: Visual Studio 2019
 
 install:
   - ps: Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile "./dotnet-install.ps1"
+  - ps: ./dotnet-install.ps1 -Channel 6.0.1xx -Quality GA
   - ps: ./dotnet-install.ps1 -Channel 7.0.1xx -Quality GA
 
 init:


### PR DESCRIPTION
The builds have been failing for some time.  It doesn't appear the rollForward within global.json is working as 7.0.100 is installed by this script despite 7.0.112 being available.  This likely indicates security updates aren't getting incorporated into the build.

This also installs sdk v6.0.1xx which isn't installed on the appveyor build agents (any longer?), but is required by the unit tests.