### PR TITLE
SwaggerGen isn't calling the configured SchemaComparer

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSwaggerGeneratorOptions.cs
@@ -63,6 +63,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             target.SortKeySelector = source.SortKeySelector;
             target.InferSecuritySchemes = source.InferSecuritySchemes;
             target.DescribeAllParametersInCamelCase = source.DescribeAllParametersInCamelCase;
+            target.SchemaComparer = source.SchemaComparer;
             target.Servers = new List<OpenApiServer>(source.Servers);
             target.SecuritySchemes = new Dictionary<string, OpenApiSecurityScheme>(source.SecuritySchemes);
             target.SecurityRequirements = new List<OpenApiSecurityRequirement>(source.SecurityRequirements);


### PR DESCRIPTION
DeepCopy isn't preserving the SchemaComparer property, therefore custom sorting of Schemas doesn't work.
#2741