### PR TITLE
Handle Stream and PipeReader content types correctly

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -203,6 +203,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             typeof(IFormFile),
             typeof(FileResult),
+            typeof(System.IO.Stream),
+#if NETCOREAPP3_0_OR_GREATER
+            typeof(System.IO.Pipelines.PipeReader),
+#endif
         };
 
         private OpenApiSchema GenerateConcreteSchema(DataContract dataContract, SchemaRepository schemaRepository)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -199,6 +199,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             };
         }
 
+        private static readonly Type[] BinaryStringTypes = new[]
+        {
+            typeof(IFormFile),
+            typeof(FileResult),
+        };
+
         private OpenApiSchema GenerateConcreteSchema(DataContract dataContract, SchemaRepository schemaRepository)
         {
             if (TryGetCustomTypeMapping(dataContract.UnderlyingType, out Func<OpenApiSchema> customSchemaFactory))
@@ -206,7 +212,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 return customSchemaFactory();
             }
 
-            if (dataContract.UnderlyingType.IsAssignableToOneOf(typeof(IFormFile), typeof(FileResult)))
+            if (dataContract.UnderlyingType.IsAssignableToOneOf(BinaryStringTypes))
             {
                 return new OpenApiSchema { Type = "string", Format = "binary" };
             }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -50,7 +50,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             var dataContract = GetDataContractFor(modelType);
 
             var schema = _generatorOptions.UseOneOfForPolymorphism && IsBaseTypeWithKnownTypesDefined(dataContract, out var knownTypesDataContracts)
-                ? GeneratePolymorphicSchema(dataContract, schemaRepository, knownTypesDataContracts)
+                ? GeneratePolymorphicSchema(schemaRepository, knownTypesDataContracts)
                 : GenerateConcreteSchema(dataContract, schemaRepository);
 
             if (_generatorOptions.UseAllOfToExtendReferenceSchemas && schema.Reference != null)
@@ -112,7 +112,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             var dataContract = GetDataContractFor(modelType);
 
             var schema = _generatorOptions.UseOneOfForPolymorphism && IsBaseTypeWithKnownTypesDefined(dataContract, out var knownTypesDataContracts)
-                ? GeneratePolymorphicSchema(dataContract, schemaRepository, knownTypesDataContracts)
+                ? GeneratePolymorphicSchema(schemaRepository, knownTypesDataContracts)
                 : GenerateConcreteSchema(dataContract, schemaRepository);
 
             if (_generatorOptions.UseAllOfToExtendReferenceSchemas && schema.Reference != null)
@@ -152,7 +152,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             var dataContract = GetDataContractFor(modelType);
 
             var schema = _generatorOptions.UseOneOfForPolymorphism && IsBaseTypeWithKnownTypesDefined(dataContract, out var knownTypesDataContracts)
-                ? GeneratePolymorphicSchema(dataContract, schemaRepository, knownTypesDataContracts)
+                ? GeneratePolymorphicSchema(schemaRepository, knownTypesDataContracts)
                 : GenerateConcreteSchema(dataContract, schemaRepository);
 
             if (schema.Reference == null)
@@ -188,7 +188,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         }
 
         private OpenApiSchema GeneratePolymorphicSchema(
-            DataContract dataContract,
             SchemaRepository schemaRepository,
             IEnumerable<DataContract> knownTypesDataContracts)
         {

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -23,7 +23,8 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         [Theory]
         [InlineData(typeof(IFormFile))]
         [InlineData(typeof(FileResult))]
-        public void GenerateSchema_GeneratesFileSchema_IfFormFileOrFileResultType(Type type)
+        [InlineData(typeof(System.IO.Stream))]
+        public void GenerateSchema_GeneratesFileSchema_BinaryStringResultType(Type type)
         {
             var schema = Subject().GenerateSchema(type, new SchemaRepository());
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -23,7 +23,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [Theory]
         [InlineData(typeof(IFormFile))]
         [InlineData(typeof(FileResult))]
-        public void GenerateSchema_GeneratesFileSchema_IfFormFileOrFileResultType(Type type)
+        [InlineData(typeof(System.IO.Stream))]
+        [InlineData(typeof(System.IO.Pipelines.PipeReader))]
+        public void GenerateSchema_GeneratesFileSchema_BinaryStringResultType(Type type)
         {
             var schema = Subject().GenerateSchema(type, new SchemaRepository());
 


### PR DESCRIPTION
- Do not generate schema models for `Stream` and `PipeReader`.
- Only allocate the array once, rather than on every call.
- Fix warning by removing unused parameter from private method.

Relates to item 3 in https://github.com/dotnet/aspnetcore/issues/44677.
