### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To privately report a security vulnerability, please create a security advisory in the [repository's Security tab](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/security/advisories).
+
+Further details can be found in the [GitHub documentation](https://docs.github.com/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).


### PR DESCRIPTION
Add security policy to resolve https://github.com/domaindrivendev/Swashbuckle.AspNetCore/security/code-scanning/6.

@domaindrivendev if this isn't turned on in the repo settings, could you do so?
