### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+# Issue
+
+## Expected behaviour
+
+<!-- Explain what you expected to happen. -->
+
+## Actual behaviour
+
+<!-- Explain what actually happened. If an exception occurred, please include a stack trace if available. -->
+
+## Steps to reproduce
+
+<!-- A concise, repeatable, example of how to illustrate the issue. -->

--- a/.github/ISSUE_TEMPLATE/10_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/10_bug_report.yml
@@ -1,0 +1,71 @@
+name: 🐛 Bug report
+description: Something not behaving as expected?
+title: '[Bug]: '
+labels: ['bug']
+body:
+- type: markdown
+  attributes:
+    value: |
+      Please check for an existing issue and our documentation before submitting a bug report.
+- type: textarea
+  attributes:
+    label: Describe the bug
+    description: A clear and concise description of what the bug is.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected behavior
+    description: A clear and concise description of what you expected to happen.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Actual behavior
+    description: What actually happens.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps to reproduce
+    description: |
+      We ❤ code! Point us to a [minimalistic project which reproduces this issue (repro)](https://stackoverflow.com/help/minimal-reproducible-example) hosted in a public GitHub repository.
+      Code snippets, such as a failing unit test, which demonstrate the issue wrapped in a codefence are also acceptable.
+
+      We will close this issue if:
+      - We are not able to repro the behavior you're reporting.
+      - The issue is a duplicate of an existing issue.
+      - The behavior you're reporting is by design.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Exception(s) (if any)
+    description: Include any exception(s) and stack trace(s) you get when facing this issue.
+    placeholder:
+  validations:
+    required: false
+- type: input
+  attributes:
+    label: Swashbuckle.AspNetCore version
+    description: |
+      Which version of Swashbuckle.AspNetCore are you facing the issue with?
+  validations:
+    required: false
+- type: input
+  attributes:
+    label: .NET Version
+    description: |
+      Run `dotnet --version` to get the .NET SDK version you're using.
+      Alternatively, which target framework(s) (e.g. `net8.0`) does the project you're using Swashbuckle.AspNetCore in target?
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Anything that will give us more context about the issue you are encountering is useful.
+
+      💡Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/20_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/20_feature_request.yml
@@ -1,0 +1,30 @@
+name: 💡 Feature request
+description: Suggest a feature request or improvement
+title: '[Feature request]: '
+labels: ['feature suggestion']
+body:
+- type: markdown
+  attributes:
+    value: |
+      Please check for an existing issue and our documentation before submitting a feature request.
+- type: textarea
+  attributes:
+    label: Is your feature request related to a specific problem? Or an existing feature?
+    description: A clear and concise description of what the problem is. Motivating examples help us prioritize things.
+    placeholder: I am trying to do [...] but [...]
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Describe the solution you'd like
+    description: |
+      A clear and concise description of what you want to happen. Include any alternative solutions you've considered.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Additional context
+    description: |
+      Add any other context or screenshots about the feature request here.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/30_question.yml
+++ b/.github/ISSUE_TEMPLATE/30_question.yml
@@ -1,0 +1,32 @@
+name: 🤔 Question?
+description: You have something specific to achieve and the existing documentation hasn't covered how.
+title: '[Question]: '
+labels: ['question']
+body:
+- type: markdown
+  attributes:
+    value: |
+      Please check for an existing issue and our documentation before asking a question.
+      Also consider asking your question on [Stack Overflow](https://stackoverflow.com/questions/tagged/swashbuckle) instead.
+- type: textarea
+  attributes:
+    label: What are you wanting to achieve?
+    description: A clear and concise description of what you're trying to do.
+    placeholder: I am trying to do [...] but [...]
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: What code or approach do you have so far?
+    description: |
+      We ❤ code! Point us to a [minimalistic project which shows what you have so far](https://stackoverflow.com/help/minimal-reproducible-example) hosted in a public GitHub repository.
+      Code snippets wrapped in a codefence are also acceptable.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Additional context
+    description: |
+      Add any other context or screenshots related to your question here.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions
+    url: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/discussions
+    about: Start a discussion about Swashbuckle.
+  - name: Stack Overflow
+    url: https://stackoverflow.com/questions/tagged/swashbuckle
+    about: Ask a question about Swashbuckle on Stack Overflow.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->
+
+# Pull Request
+
+## The issue or feature being addressed
+
+<!-- Please include the existing GitHub issue number where relevant, e.g. "Fixes #123" -->
+
+## Details on the issue fix or feature implementation
+
+<!-- Information about your changes -->


### PR DESCRIPTION
Add GitHub issue and pull request templates.

I've based these on the ones used in [Polly](https://github.com/App-vNext/Polly/tree/main/.github).

Feedback/suggestions welcome.
