### PR TITLE
Fix configuration properties not being copied

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSwaggerGeneratorOptions.cs
@@ -63,12 +63,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             target.SortKeySelector = source.SortKeySelector;
             target.InferSecuritySchemes = source.InferSecuritySchemes;
             target.DescribeAllParametersInCamelCase = source.DescribeAllParametersInCamelCase;
+            target.SchemaComparer = source.SchemaComparer;
             target.Servers = new List<OpenApiServer>(source.Servers);
             target.SecuritySchemes = new Dictionary<string, OpenApiSecurityScheme>(source.SecuritySchemes);
             target.SecurityRequirements = new List<OpenApiSecurityRequirement>(source.SecurityRequirements);
             target.ParameterFilters = new List<IParameterFilter>(source.ParameterFilters);
             target.OperationFilters = new List<IOperationFilter>(source.OperationFilters);
             target.DocumentFilters = new List<IDocumentFilter>(source.DocumentFilters);
+            target.InferSecuritySchemes = source.InferSecuritySchemes;
+            target.SecuritySchemesSelector = source.SecuritySchemesSelector;
         }
 
         private TFilter CreateFilter<TFilter>(FilterDescriptor filterDescriptor)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenServiceCollectionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenServiceCollectionExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 c.Conventions.Add(new SwaggerApplicationConvention()));
 
             // Register custom configurators that takes values from SwaggerGenOptions (i.e. high level config)
-            // and applies them to SwaggerGeneratorOptions and SchemaGeneratorOptoins (i.e. lower-level config)
+            // and applies them to SwaggerGeneratorOptions and SchemaGeneratorOptions (i.e. lower-level config)
             services.AddTransient<IConfigureOptions<SwaggerGeneratorOptions>, ConfigureSwaggerGeneratorOptions>();
             services.AddTransient<IConfigureOptions<SchemaGeneratorOptions>, ConfigureSchemaGeneratorOptions>();
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSchemaGeneratorOptionsTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSchemaGeneratorOptionsTests.cs
@@ -1,0 +1,18 @@
+﻿using System.Reflection;
+using Xunit;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test;
+
+public static class ConfigureSchemaGeneratorOptionsTests
+{
+    [Fact]
+    public static void DeepCopy_Copies_All_Properties()
+    {
+        var type = typeof(SchemaGeneratorOptions);
+        var publicProperties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        // If this assertion fails, it means that a new property has been added
+        // to SwaggerGeneratorOptions and ConfigureSchemaGeneratorOptions.DeepCopy() needs to be updated
+        Assert.Equal(12, publicProperties.Length);
+    }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSwaggerGeneratorOptionsTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSwaggerGeneratorOptionsTests.cs
@@ -1,0 +1,18 @@
+﻿using System.Reflection;
+using Xunit;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test;
+
+public static class ConfigureSwaggerGeneratorOptionsTests
+{
+    [Fact]
+    public static void DeepCopy_Copies_All_Properties()
+    {
+        var type = typeof(SwaggerGeneratorOptions);
+        var publicProperties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        // If this assertion fails, it means that a new property has been added
+        // to SwaggerGeneratorOptions and ConfigureSwaggerGeneratorOptions.DeepCopy() needs to be updated
+        Assert.Equal(18, publicProperties.Length);
+    }
+}


### PR DESCRIPTION
Fix properties not being copied during clone.

I looked into testing the method directly, but that involved what I thought was too much complication to get `[InternalsVisibleTo]` working. Instead I've added a test which will fail if new properties are added to act as a signpost to update the `DeepCopy()` methods.

- Resolves #2540.
- Resolves #2741.
