### PR TITLE
Throw if unsupported HTTP method used

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -193,7 +193,17 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
                 var apiDescription = (group.Count() > 1) ? _options.ConflictingActionsResolver(group) : group.Single();
 
-                operations.Add(OperationTypeMap[httpMethod.ToUpper()], GenerateOperation(apiDescription, schemaRepository));
+                var normalizedMethod = httpMethod.ToUpperInvariant();
+                if (!OperationTypeMap.TryGetValue(normalizedMethod, out var operationType))
+                {
+                    // See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2600 and
+                    // https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2740.
+                    throw new SwaggerGeneratorException(string.Format(
+                        "The \"{0}\" HTTP method is not supported.",
+                        httpMethod));
+                }
+
+                operations.Add(operationType, GenerateOperation(apiDescription, schemaRepository));
             };
 
             return operations;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -198,9 +198,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 {
                     // See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2600 and
                     // https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2740.
-                    throw new SwaggerGeneratorException(string.Format(
-                        "The \"{0}\" HTTP method is not supported.",
-                        httpMethod));
+                    throw new SwaggerGeneratorException($"The \"{httpMethod}\" HTTP method is not supported.");
                 }
 
                 operations.Add(operationType, GenerateOperation(apiDescription, schemaRepository));


### PR DESCRIPTION
Add an explicit check for supported HTTP methods.

Resolves #2740.
