### PR TITLE
Extend built-in supported types

### DIFF
--- a/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/NewtonsoftDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/NewtonsoftDataContractResolver.cs
@@ -49,7 +49,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft
             {
                 var enumValues = jsonContract.UnderlyingType.GetEnumValues();
 
-                //Test to determine if the serializer will treat as string
+                // Test to determine if the serializer will treat as string
                 var serializeAsString = (enumValues.Length > 0)
                     && JsonConverterFunc(enumValues.GetValue(0)).StartsWith("\"");
 
@@ -84,7 +84,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft
                     // This is a special case where we know the possible key values
                     var enumValuesAsJson = keyType.GetEnumValues()
                         .Cast<object>()
-                        .Select(value => JsonConverterFunc(value));
+                        .Select(JsonConverterFunc);
 
                     keys = enumValuesAsJson.Any(json => json.StartsWith("\""))
                         ? enumValuesAsJson.Select(json => json.Replace("\"", string.Empty))
@@ -197,7 +197,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft
             return dataProperties;
         }
 
-        private static readonly Dictionary<Type, Tuple<DataType, string>> PrimitiveTypesAndFormats = new Dictionary<Type, Tuple<DataType, string>>
+        private static readonly Dictionary<Type, Tuple<DataType, string>> PrimitiveTypesAndFormats = new()
         {
             [ typeof(bool) ] = Tuple.Create(DataType.Boolean, (string)null),
             [ typeof(byte) ] = Tuple.Create(DataType.Integer, "int32"),

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
@@ -240,11 +240,17 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             [ typeof(char) ] = Tuple.Create(DataType.String, (string)null),
             [ typeof(DateTime) ] = Tuple.Create(DataType.String, "date-time"),
             [ typeof(DateTimeOffset) ] = Tuple.Create(DataType.String, "date-time"),
+            [ typeof(TimeSpan) ] = Tuple.Create(DataType.String, "date-span"),
             [ typeof(Guid) ] = Tuple.Create(DataType.String, "uuid"),
             [ typeof(Uri) ] = Tuple.Create(DataType.String, "uri"),
+            [ typeof(Version) ] = Tuple.Create(DataType.String, (string)null),
 #if NET6_0_OR_GREATER
             [ typeof(DateOnly) ] = Tuple.Create(DataType.String, "date"),
-            [ typeof(TimeOnly) ] = Tuple.Create(DataType.String, "time")
+            [ typeof(TimeOnly) ] = Tuple.Create(DataType.String, "time"),
+#endif
+#if NET7_0_OR_GREATER
+            [ typeof(Int128) ] = Tuple.Create(DataType.Integer, "int128"),
+            [ typeof(UInt128) ] = Tuple.Create(DataType.Integer, "int128"),
 #endif
         };
     }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
@@ -27,12 +27,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     jsonConverter: JsonConverterFunc);
             }
 
-            if (PrimitiveTypesAndFormats.TryGetValue(type, out var primitiveTypeAndFormat1))
+            if (PrimitiveTypesAndFormats.TryGetValue(type, out var primitiveTypeAndFormat))
             {
                 return DataContract.ForPrimitive(
                     underlyingType: type,
-                    dataType: primitiveTypeAndFormat1.Item1,
-                    dataFormat: primitiveTypeAndFormat1.Item2,
+                    dataType: primitiveTypeAndFormat.Item1,
+                    dataFormat: primitiveTypeAndFormat.Item2,
                     jsonConverter: JsonConverterFunc);
             }
 
@@ -44,7 +44,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 var serializeAsString = (enumValues.Length > 0)
                     && JsonConverterFunc(enumValues.GetValue(0)).StartsWith("\"");
 
-                var primitiveTypeAndFormat = serializeAsString
+                primitiveTypeAndFormat = serializeAsString
                     ? PrimitiveTypesAndFormats[typeof(string)]
                     : PrimitiveTypesAndFormats[type.GetEnumUnderlyingType()];
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
@@ -9,6 +9,26 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     public static class OpenApiSchemaExtensions
     {
+        private static readonly Dictionary<AnnotationsDataType, string> DataFormatMappings = new()
+        {
+            [AnnotationsDataType.DateTime] = "date-time",
+            [AnnotationsDataType.Date] = "date",
+            [AnnotationsDataType.Time] = "time",
+            [AnnotationsDataType.Duration] = "duration",
+            [AnnotationsDataType.PhoneNumber] = "tel",
+            [AnnotationsDataType.Currency] = "currency",
+            [AnnotationsDataType.Text] = "string",
+            [AnnotationsDataType.Html] = "html",
+            [AnnotationsDataType.MultilineText] = "multiline",
+            [AnnotationsDataType.EmailAddress] = "email",
+            [AnnotationsDataType.Password] = "password",
+            [AnnotationsDataType.Url] = "uri",
+            [AnnotationsDataType.ImageUrl] = "uri",
+            [AnnotationsDataType.CreditCard] = "credit-card",
+            [AnnotationsDataType.PostalCode] = "postal-code",
+            [AnnotationsDataType.Upload] = "binary",
+        };
+
         public static void ApplyValidationAttributes(this OpenApiSchema schema, IEnumerable<object> customAttributes)
         {
             foreach (var attribute in customAttributes)
@@ -88,26 +108,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private static void ApplyDataTypeAttribute(OpenApiSchema schema, DataTypeAttribute dataTypeAttribute)
         {
-            var formats = new Dictionary<AnnotationsDataType, string>
-            {
-                { AnnotationsDataType.DateTime, "date-time" },
-                { AnnotationsDataType.Date, "date" },
-                { AnnotationsDataType.Time, "time" },
-                { AnnotationsDataType.Duration, "duration" },
-                { AnnotationsDataType.PhoneNumber, "tel" },
-                { AnnotationsDataType.Currency, "currency" },
-                { AnnotationsDataType.Text, "string" },
-                { AnnotationsDataType.Html, "html" },
-                { AnnotationsDataType.MultilineText, "multiline" },
-                { AnnotationsDataType.EmailAddress, "email" },
-                { AnnotationsDataType.Password, "password" },
-                { AnnotationsDataType.Url, "uri" },
-                { AnnotationsDataType.ImageUrl, "uri" },
-                { AnnotationsDataType.CreditCard, "credit-card" },
-                { AnnotationsDataType.PostalCode, "postal-code" }
-            };
-
-            if (formats.TryGetValue(dataTypeAttribute.DataType, out string format))
+            if (DataFormatMappings.TryGetValue(dataTypeAttribute.DataType, out string format))
             {
                 schema.Format = format;
             }

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -32,6 +32,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         }
 
         [Theory]
+        [InlineData(typeof(bool), "boolean", null)]
         [InlineData(typeof(byte), "integer", "int32")]
         [InlineData(typeof(sbyte), "integer", "int32")]
         [InlineData(typeof(short), "integer", "int32")]
@@ -48,12 +49,24 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         [InlineData(typeof(byte[]), "string", "byte")]
         [InlineData(typeof(DateTime), "string", "date-time")]
         [InlineData(typeof(DateTimeOffset), "string", "date-time")]
-        [InlineData(typeof(Guid), "string", "uuid")]
         [InlineData(typeof(TimeSpan), "string", "date-span")]
+        [InlineData(typeof(Guid), "string", "uuid")]
+        [InlineData(typeof(Uri), "string", "uri")]
         [InlineData(typeof(Version), "string", null)]
+        [InlineData(typeof(DateOnly), "string", "date")]
+        [InlineData(typeof(TimeOnly), "string", "time")]
         [InlineData(typeof(bool?), "boolean", null)]
         [InlineData(typeof(int?), "integer", "int32")]
         [InlineData(typeof(DateTime?), "string", "date-time")]
+        [InlineData(typeof(Guid?), "string", "uuid")]
+        [InlineData(typeof(DateOnly?), "string", "date")]
+        [InlineData(typeof(TimeOnly?), "string", "time")]
+#if NET7_0_OR_GREATER
+        [InlineData(typeof(Int128), "integer", "int128")]
+        [InlineData(typeof(Int128?), "integer", "int128")]
+        [InlineData(typeof(UInt128), "integer", "int128")]
+        [InlineData(typeof(UInt128?), "integer", "int128")]
+#endif
         public void GenerateSchema_GeneratesPrimitiveSchema_IfPrimitiveOrNullablePrimitiveType(
             Type type,
             string expectedSchemaType,

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -51,8 +51,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [InlineData(typeof(byte[]), "string", "byte")]
         [InlineData(typeof(DateTime), "string", "date-time")]
         [InlineData(typeof(DateTimeOffset), "string", "date-time")]
+        [InlineData(typeof(TimeSpan), "string", "date-span")]
         [InlineData(typeof(Guid), "string", "uuid")]
         [InlineData(typeof(Uri), "string", "uri")]
+        [InlineData(typeof(Version), "string", null)]
         [InlineData(typeof(DateOnly), "string", "date")]
         [InlineData(typeof(TimeOnly), "string", "time")]
         [InlineData(typeof(bool?), "boolean", null)]
@@ -61,6 +63,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [InlineData(typeof(Guid?), "string", "uuid")]
         [InlineData(typeof(DateOnly?), "string", "date")]
         [InlineData(typeof(TimeOnly?), "string", "time")]
+#if NET7_0_OR_GREATER
+        [InlineData(typeof(Int128), "integer", "int128")]
+        [InlineData(typeof(Int128?), "integer", "int128")]
+        [InlineData(typeof(UInt128), "integer", "int128")]
+        [InlineData(typeof(UInt128?), "integer", "int128")]
+#endif
         public void GenerateSchema_GeneratesPrimitiveSchema_IfPrimitiveOrNullablePrimitiveType(
             Type type,
             string expectedSchemaType,


### PR DESCRIPTION
- Ensure `DateOnly` and `TimeOnly` with for Newtonsoft.Json.
- Add System.Text.Json support for `TimeSpan` and `Version`.
- Add Int128 and UInt128 support.
- Handle `AnnotationsDataType.Upload`.
- Create `AnnotationsDataType` mapping dictionary only once.

Resolves #2611
Relates to #2500
