### PR TITLE
Generate Enum-Dictionary-Keys (analogous to Newtonsoft)

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
@@ -61,23 +61,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
                 if (keyType.IsEnum)
                 {
-                    var enumValues = keyType.GetEnumValues();
+                    // This is a special case where we know the possible key values
+                    var enumValuesAsJson = keyType.GetEnumValues()
+                        .Cast<object>()
+                        .Select(value => JsonConverterFunc(value));
 
-                    //Test to determine if the serializer will treat as string
-                    var serializeAsString = (enumValues.Length > 0)
-                        && JsonConverterFunc(enumValues.GetValue(0)).StartsWith("\"");
-
-                    if (serializeAsString)
-                    {
-                        // This is a special case where we know the possible key values
-                        var enumValuesAsJson = keyType.GetEnumValues()
-                            .Cast<object>()
-                            .Select(value => JsonConverterFunc(value));
-
-                        keys = enumValuesAsJson.Any(json => json.StartsWith("\""))
-                            ? enumValuesAsJson.Select(json => json.Replace("\"", string.Empty))
-                            : keyType.GetEnumNames();
-                    }
+                    keys = enumValuesAsJson.Any(json => json.StartsWith("\""))
+                        ? enumValuesAsJson.Select(json => json.Replace("\"", string.Empty))
+                        : keyType.GetEnumNames();
                 }
 
                 return DataContract.ForDictionary(

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
@@ -61,14 +61,23 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
                 if (keyType.IsEnum)
                 {
-                    // This is a special case where we know the possible key values
-                    var enumValuesAsJson = keyType.GetEnumValues()
-                        .Cast<object>()
-                        .Select(value => JsonConverterFunc(value));
+                    var enumValues = keyType.GetEnumValues();
 
-                    keys = enumValuesAsJson.Any(json => json.StartsWith("\""))
-                        ? enumValuesAsJson.Select(json => json.Replace("\"", string.Empty))
-                        : keyType.GetEnumNames();
+                    //Test to determine if the serializer will treat as string
+                    var serializeAsString = (enumValues.Length > 0)
+                        && JsonConverterFunc(enumValues.GetValue(0)).StartsWith("\"");
+
+                    if (serializeAsString)
+                    {
+                        // This is a special case where we know the possible key values
+                        var enumValuesAsJson = keyType.GetEnumValues()
+                            .Cast<object>()
+                            .Select(value => JsonConverterFunc(value));
+
+                        keys = enumValuesAsJson.Any(json => json.StartsWith("\""))
+                            ? enumValuesAsJson.Select(json => json.Replace("\"", string.Empty))
+                            : keyType.GetEnumNames();
+                    }
                 }
 
                 return DataContract.ForDictionary(

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
@@ -57,10 +57,24 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             if (IsSupportedDictionary(type, out Type keyType, out Type valueType))
             {
+                IEnumerable<string> keys = null;
+
+                if (keyType.IsEnum)
+                {
+                    // This is a special case where we know the possible key values
+                    var enumValuesAsJson = keyType.GetEnumValues()
+                        .Cast<object>()
+                        .Select(value => JsonConverterFunc(value));
+
+                    keys = enumValuesAsJson.Any(json => json.StartsWith("\""))
+                        ? enumValuesAsJson.Select(json => json.Replace("\"", string.Empty))
+                        : keyType.GetEnumNames();
+                }
+
                 return DataContract.ForDictionary(
                     underlyingType: type,
                     valueType: valueType,
-                    keys: null, // STJ doesn't currently support dictionaries with enum key types
+                    keys: keys,
                     jsonConverter: JsonConverterFunc);
             }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -773,17 +773,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [Fact]
         public void GenerateSchema_HonorsEnumDictionaryKeys_StringEnumConverter()
         {
-            var subjectWithJsonStringEnumConverter = Subject(
-                configureSerializer: c => { c.Converters.Add(new JsonStringEnumConverter()); }
-            );
             var subject = Subject();
             var schemaRepository = new SchemaRepository();
 
-            var referenceSchemaWithJsonStringEnumConverter = subjectWithJsonStringEnumConverter.GenerateSchema(typeof(Dictionary<IntEnum, string>), schemaRepository);
             var referenceSchema = subject.GenerateSchema(typeof(Dictionary<IntEnum, string>), schemaRepository);
 
-            Assert.Equal(typeof(IntEnum).GetEnumValues().Length, referenceSchemaWithJsonStringEnumConverter.Properties.Count);
-            Assert.Empty(referenceSchema.Properties);
+            Assert.Equal(typeof(IntEnum).GetEnumValues().Length, referenceSchema.Properties.Count);
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -770,15 +770,22 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal(expectedDefaultAsJson, propertySchema.Default.ToJson());
         }
 
-        [Fact]
-        public void GenerateSchema_HonorsEnumDictionaryKeys_StringEnumConverter()
+        [Theory]
+        [InlineData(false, new[] { "Value2", "Value4", "Value8" })]
+        [InlineData(true, new[] { "value2", "value4", "value8" })]
+        public void GenerateSchema_HonorsEnumDictionaryKeys_StringEnumConverter(
+            bool camelCaseText,
+            string[] expectedEnumAsJson
+        )
         {
-            var subject = Subject();
+            var subject = Subject(
+                    configureSerializer: c => { c.DictionaryKeyPolicy = camelCaseText ? JsonNamingPolicy.CamelCase : null; }
+                );
             var schemaRepository = new SchemaRepository();
 
             var referenceSchema = subject.GenerateSchema(typeof(Dictionary<IntEnum, string>), schemaRepository);
 
-            Assert.Equal(typeof(IntEnum).GetEnumValues().Length, referenceSchema.Properties.Count);
+            Assert.Equal(expectedEnumAsJson, referenceSchema.Properties.Keys);
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -779,7 +779,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         )
         {
             var subject = Subject(
-                    configureSerializer: c => { c.DictionaryKeyPolicy = camelCaseText ? JsonNamingPolicy.CamelCase : null; }
+                    configureSerializer: c => c.DictionaryKeyPolicy = camelCaseText ? JsonNamingPolicy.CamelCase : null
                 );
             var schemaRepository = new SchemaRepository();
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -770,22 +770,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal(expectedDefaultAsJson, propertySchema.Default.ToJson());
         }
 
-        [Theory]
-        [InlineData(false, new[] { "Value2", "Value4", "Value8" })]
-        [InlineData(true, new[] { "value2", "value4", "value8" })]
-        public void GenerateSchema_HonorsEnumDictionaryKeys_StringEnumConverter(
-            bool camelCaseText,
-            string[] expectedEnumAsJson
-        )
+        [Fact]
+        public void GenerateSchema_HonorsEnumDictionaryKeys_StringEnumConverter()
         {
-            var subject = Subject(
-                    configureSerializer: c => c.DictionaryKeyPolicy = camelCaseText ? JsonNamingPolicy.CamelCase : null
-                );
+            var subject = Subject();
             var schemaRepository = new SchemaRepository();
 
             var referenceSchema = subject.GenerateSchema(typeof(Dictionary<IntEnum, string>), schemaRepository);
 
-            Assert.Equal(expectedEnumAsJson, referenceSchema.Properties.Keys);
+            Assert.Equal(typeof(IntEnum).GetEnumNames(), referenceSchema.Properties.Keys);
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -771,6 +771,22 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
+        public void GenerateSchema_HonorsEnumDictionaryKeys_StringEnumConverter()
+        {
+            var subjectWithJsonStringEnumConverter = Subject(
+                configureSerializer: c => { c.Converters.Add(new JsonStringEnumConverter()); }
+            );
+            var subject = Subject();
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchemaWithJsonStringEnumConverter = subjectWithJsonStringEnumConverter.GenerateSchema(typeof(Dictionary<IntEnum, string>), schemaRepository);
+            var referenceSchema = subject.GenerateSchema(typeof(Dictionary<IntEnum, string>), schemaRepository);
+
+            Assert.Equal(typeof(IntEnum).GetEnumValues().Length, referenceSchemaWithJsonStringEnumConverter.Properties.Count);
+            Assert.Empty(referenceSchema.Properties);
+        }
+
+        [Fact]
         public void GenerateSchema_HonorsSerializerAttribute_StringEnumConverter()
         {
             var schemaRepository = new SchemaRepository();


### PR DESCRIPTION
Fixes https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2820.

Guess that's totally fine since STJ does support enum keys? It probably did not for some time - but I've checked with .Net 6-8