### PR TITLE
Correctly respect interfaces in `GetInheritanceChain`

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/TypeExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/TypeExtensions.cs
@@ -45,6 +45,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public static Type[] GetInheritanceChain(this Type type)
         {
+            if (type.IsInterface) { return type.GetInterfaces(); }
+
             var inheritanceChain = new List<Type>();
 
             var current = type;

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -237,6 +237,17 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
+        public void GenerateSchema_KeepMostDerivedType_IfTypeIsAnInterface()
+        {
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = Subject().GenerateSchema(typeof(INewBaseInterface), schemaRepository);
+
+            var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
+            Assert.Equal("integer", schema.Properties["BaseProperty"].Type);
+        }
+
+        [Fact]
         public void GenerateSchema_ExcludesIndexerProperties_IfComplexTypeIsIndexed()
         {
             var schemaRepository = new SchemaRepository();

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/BaseInterface.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/BaseInterface.cs
@@ -19,4 +19,9 @@
     {
         public int Property3 { get; set; }
     }
+
+    public interface INewBaseInterface : IBaseInterface
+    {
+        public new int BaseProperty { get; set; }
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2821. Interfaces weren't respected here.