### PR TITLE
Fix handling of FileResult's with content types

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,13 +508,12 @@ public void UploadFile([FromForm]string description, [FromForm]DateTime clientDa
 > Important note: As per the [ASP.NET Core docs](https://docs.microsoft.com/en-us/aspnet/core/mvc/models/file-uploads?view=aspnetcore-3.1), you're not supposed to decorate `IFormFile` parameters with the `[FromForm]` attribute as the binding source is automatically inferred from the type. In fact, the inferred value is `BindingSource.FormFile` and if you apply the attribute it will be set to `BindingSource.Form` instead, which screws up `ApiExplorer`, the metadata component that ships with ASP.NET Core and is heavily relied on by Swashbuckle. One particular issue here is that SwaggerUI will not treat the parameter as a file and so will not display a file upload button, if you do mistakenly include this attribute.
 
 ### Handle File Downloads ###
-`ApiExplorer` (the ASP.NET Core metadata component that Swashbuckle is built on) *DOES NOT* surface the `FileResult` type by default and so you need to explicitly tell it to with the `Produces` attribute:
+`ApiExplorer` (the ASP.NET Core metadata component that Swashbuckle is built on) *DOES NOT* surface the `FileResult` types by default and so you need to explicitly tell it to with the `ProducesResponseType` attribute (or `Produces` on .NET 5 or older):
 ```csharp
 [HttpGet("{fileName}")]
-[Produces("application/octet-stream", Type = typeof(FileResult))]
-public FileResult GetFile(string fileName)
+[ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status200OK, "image/jpeg")]
+public FileStreamResult GetFile(string fileName)
 ```
-If you want the swagger-ui to display a "Download file" link, you're operation will need to return a **Content-Type of "application/octet-stream"** or a **Content-Disposition of "attachement"**.
 
 ### Include Descriptions from XML Comments ###
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -593,15 +593,18 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 Description = description,
                 Content = responseContentTypes.ToDictionary(
                     contentType => contentType,
-                    contentType => CreateResponseMediaType(apiResponseType.ModelMetadata, schemaRepository)
+                    contentType => CreateResponseMediaType(apiResponseType.ModelMetadata?.ModelType ?? apiResponseType.Type, schemaRepository)
                 )
             };
         }
 
         private IEnumerable<string> InferResponseContentTypes(ApiDescription apiDescription, ApiResponseType apiResponseType)
         {
-            // If there's no associated model, return an empty list (i.e. no content)
-            if (apiResponseType.ModelMetadata == null) return Enumerable.Empty<string>();
+            // If there's no associated model type, return an empty list (i.e. no content)
+            if (apiResponseType.ModelMetadata == null && (apiResponseType.Type == null || apiResponseType.Type == typeof(void)))
+            {
+                return Enumerable.Empty<string>();
+            }
 
             // If there's content types explicitly specified via ProducesAttribute, use them
             var explicitContentTypes = apiDescription.CustomAttributes().OfType<ProducesAttribute>()
@@ -618,11 +621,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             return Enumerable.Empty<string>();
         }
 
-        private OpenApiMediaType CreateResponseMediaType(ModelMetadata modelMetadata, SchemaRepository schemaRespository)
+        private OpenApiMediaType CreateResponseMediaType(Type modelType, SchemaRepository schemaRespository)
         {
             return new OpenApiMediaType
             {
-                Schema = GenerateSchema(modelMetadata.ModelType, schemaRespository)
+                Schema = GenerateSchema(modelType, schemaRespository)
             };
         }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeController.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeController.cs
@@ -81,6 +81,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             throw new NotImplementedException();
         }
 
+        [ProducesResponseType(typeof(FileContentResult), 200, "application/zip")]
+        public FileContentResult ActionWithFileResult()
+        {
+            throw new NotImplementedException();
+        }
+
         [SwaggerIgnore]
         public void ActionWithSwaggerIgnoreAttribute()
         { }

--- a/test/WebSites/Basic/Controllers/FilesController.cs
+++ b/test/WebSites/Basic/Controllers/FilesController.cs
@@ -27,8 +27,12 @@ namespace Basic.Controllers
         }
 
         [HttpGet("{name}")]
-        [Produces("application/octet-stream", Type = typeof(FileResult))]
-        public FileResult GetFile(string name)
+#if NET6_0_OR_GREATER
+        [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status200OK, "text/plain", "application/zip")]
+#else
+        [Produces("text/plain", "application/zip", Type = typeof(FileStreamResult))]
+#endif
+        public FileStreamResult GetFile(string name)
         {
             var stream = new MemoryStream();
 
@@ -37,7 +41,9 @@ namespace Basic.Controllers
             writer.Flush();
             stream.Position = 0;
 
-            return File(stream, "application/octet-stream", name);
+            var contentType = name.EndsWith(".zip", StringComparison.InvariantCultureIgnoreCase) ? "application/zip" : "text/plain";
+
+            return File(stream, contentType, name);
         }
     }
 


### PR DESCRIPTION
When ProducesResponseType is used with FileResult subclasses and explicit content types, ApiExplorer sets ModelMetadata to null. We were then erroneously treating it as returning no content.

Resolves #2320, #2386