### PR TITLE
Avoid GitHub step summary file write conflicts

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -24,6 +24,7 @@
       <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
       <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
       <_ReportGeneratorLines Include="&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;" />
+      <_ReportGeneratorLines Include="&lt;!-- --&gt;" />
       <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
       <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
       <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -21,6 +21,8 @@
   <Target Name="GenerateCoverageReports" AfterTargets="GenerateCoverageResultAfterTest" Condition=" '$(CollectCoverage)' == 'true' ">
     <ReportGenerator ReportFiles="@(CoverletReport)" ReportTypes="$(ReportGeneratorReportTypes)" Tag="$(Version)" TargetDirectory="$(ReportGeneratorTargetDirectory)" Title="$(AssemblyName)" VerbosityLevel="Warning" />
     <ItemGroup>
+      <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
+      <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
       <_ReportGeneratorLines Include="&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;" />
       <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
       <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -24,6 +24,7 @@
       <_ReportGeneratorLines Include="&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;" />
       <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
       <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
+      <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
       <_ReportGeneratorLines Include="$([System.IO.File]::ReadAllText('$([System.IO.Path]::Combine($(ReportGeneratorTargetDirectory), 'SummaryGithub.md'))'))" />
       <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
       <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -23,12 +23,14 @@
     <ItemGroup>
       <_ReportGeneratorLines Include="&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;" />
       <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
+      <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
     </ItemGroup>
     <ReadLinesFromFile File="$([System.IO.Path]::Combine($(ReportGeneratorTargetDirectory), 'SummaryGithub.md'))" >
       <Output TaskParameter="Lines" ItemName="_CoverageGitHubSummary"/>
     </ReadLinesFromFile>
     <ItemGroup>
       <_ReportGeneratorLines Include="@(_CoverageGitHubSummary)" />
+      <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
       <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
       <_ReportGeneratorLines Include="&lt;/details&gt;" />
     </ItemGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -20,13 +20,15 @@
   </PropertyGroup>
   <Target Name="GenerateCoverageReports" AfterTargets="GenerateCoverageResultAfterTest" Condition=" '$(CollectCoverage)' == 'true' ">
     <ReportGenerator ReportFiles="@(CoverletReport)" ReportTypes="$(ReportGeneratorReportTypes)" Tag="$(Version)" TargetDirectory="$(ReportGeneratorTargetDirectory)" Title="$(AssemblyName)" VerbosityLevel="Warning" />
-    <ItemGroup>
-      <_ReportGeneratorLines Include="&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;" />
-      <_ReportGeneratorLines Include=";" />
-      <_ReportGeneratorLines Include="$([System.IO.File]::ReadAllText('$([System.IO.Path]::Combine($(ReportGeneratorTargetDirectory), 'SummaryGithub.md'))'))" />
-      <_ReportGeneratorLines Include=";" />
-      <_ReportGeneratorLines Include="&lt;/details&gt;" />
-    </ItemGroup>
-    <WriteLinesToFile Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' " ContinueOnError="WarnAndContinue" File="$(GITHUB_STEP_SUMMARY)" Lines="@(_ReportGeneratorLines)" />
+    <PropertyGroup>
+      <_ReportSummaryContent>&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;</_ReportSummaryContent>
+      <_ReportSummaryContent>$(_ReportSummaryContent)$([System.Environment]::NewLine)</_ReportSummaryContent>
+      <_ReportSummaryContent>$(_ReportSummaryContent)$([System.Environment]::NewLine)</_ReportSummaryContent>
+      <_ReportSummaryContent>$(_ReportSummaryContent)$([System.IO.File]::ReadAllText('$([System.IO.Path]::Combine($(ReportGeneratorTargetDirectory), 'SummaryGithub.md'))'))</_ReportSummaryContent>
+      <_ReportSummaryContent>$(_ReportSummaryContent)$([System.Environment]::NewLine)</_ReportSummaryContent>
+      <_ReportSummaryContent>$(_ReportSummaryContent)$([System.Environment]::NewLine)</_ReportSummaryContent>
+      <_ReportSummaryContent>$(_ReportSummaryContent)&lt;/details&gt;</_ReportSummaryContent>
+    </PropertyGroup>
+    <WriteLinesToFile Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' " ContinueOnError="WarnAndContinue" File="$(GITHUB_STEP_SUMMARY)" Lines="$(_ReportSummaryContent)" />
   </Target>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -24,12 +24,7 @@
       <_ReportGeneratorLines Include="&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;" />
       <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
       <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
-    </ItemGroup>
-    <ReadLinesFromFile File="$([System.IO.Path]::Combine($(ReportGeneratorTargetDirectory), 'SummaryGithub.md'))" >
-      <Output TaskParameter="Lines" ItemName="_CoverageGitHubSummary"/>
-    </ReadLinesFromFile>
-    <ItemGroup>
-      <_ReportGeneratorLines Include="@(_CoverageGitHubSummary)" />
+      <_ReportGeneratorLines Include="$([System.IO.File]::ReadAllText('$([System.IO.Path]::Combine($(ReportGeneratorTargetDirectory), 'SummaryGithub.md'))'))" />
       <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
       <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
       <_ReportGeneratorLines Include="&lt;/details&gt;" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -17,11 +17,21 @@
     <ReportGeneratorReportTypes Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' ">$(ReportGeneratorReportTypes);MarkdownSummaryGitHub</ReportGeneratorReportTypes>
     <ReportGeneratorTargetDirectory>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage'))</ReportGeneratorTargetDirectory>
     <MergeWith>$([System.IO.Path]::Combine($(ReportGeneratorTargetDirectory), 'coverage.json'))</MergeWith>
-    <_MarkdownSummaryPrefix>&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;</_MarkdownSummaryPrefix>
-    <_MarkdownSummarySuffix>&lt;/details&gt;</_MarkdownSummarySuffix>
   </PropertyGroup>
   <Target Name="GenerateCoverageReports" AfterTargets="GenerateCoverageResultAfterTest" Condition=" '$(CollectCoverage)' == 'true' ">
     <ReportGenerator ReportFiles="@(CoverletReport)" ReportTypes="$(ReportGeneratorReportTypes)" Tag="$(Version)" TargetDirectory="$(ReportGeneratorTargetDirectory)" Title="$(AssemblyName)" VerbosityLevel="Warning" />
-    <Exec Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' " Command="pwsh -Command %22('$(_MarkdownSummaryPrefix)' + [System.Environment]::NewLine + [System.Environment]::NewLine + (Get-Content $([System.IO.Path]::Combine($(ReportGeneratorTargetDirectory), 'SummaryGithub.md')) | Out-String) + [System.Environment]::NewLine + [System.Environment]::NewLine + '$(_MarkdownSummarySuffix)') >> $(GITHUB_STEP_SUMMARY)%22" />
+    <ItemGroup>
+      <_ReportGeneratorLines Include="&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;" />
+      <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
+    </ItemGroup>
+    <ReadLinesFromFile File="$([System.IO.Path]::Combine($(ReportGeneratorTargetDirectory), 'SummaryGithub.md'))" >
+      <Output TaskParameter="Lines" ItemName="_CoverageGitHubSummary"/>
+    </ReadLinesFromFile>
+    <ItemGroup>
+      <_ReportGeneratorLines Include="@(_CoverageGitHubSummary)" />
+      <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
+      <_ReportGeneratorLines Include="&lt;/details&gt;" />
+    </ItemGroup>
+    <WriteLinesToFile Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' " ContinueOnError="WarnAndContinue" File="$(GITHUB_STEP_SUMMARY)" Lines="@(_ReportGeneratorLines)" />
   </Target>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <Target Name="GenerateCoverageReports" AfterTargets="GenerateCoverageResultAfterTest" Condition=" '$(CollectCoverage)' == 'true' ">
     <ReportGenerator ReportFiles="@(CoverletReport)" ReportTypes="$(ReportGeneratorReportTypes)" Tag="$(Version)" TargetDirectory="$(ReportGeneratorTargetDirectory)" Title="$(AssemblyName)" VerbosityLevel="Warning" />
-    <PropertyGroup>
+    <PropertyGroup Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' ">
       <_ReportSummaryContent>&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;</_ReportSummaryContent>
       <_ReportSummaryContent>$(_ReportSummaryContent)$([System.Environment]::NewLine)</_ReportSummaryContent>
       <_ReportSummaryContent>$(_ReportSummaryContent)$([System.Environment]::NewLine)</_ReportSummaryContent>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -22,7 +22,9 @@
     <ReportGenerator ReportFiles="@(CoverletReport)" ReportTypes="$(ReportGeneratorReportTypes)" Tag="$(Version)" TargetDirectory="$(ReportGeneratorTargetDirectory)" Title="$(AssemblyName)" VerbosityLevel="Warning" />
     <ItemGroup>
       <_ReportGeneratorLines Include="&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;" />
-      <_ReportGeneratorLines Include="$([System.Environment]::NewLine)$([System.IO.File]::ReadAllText('$([System.IO.Path]::Combine($(ReportGeneratorTargetDirectory), 'SummaryGithub.md'))'))$([System.Environment]::NewLine)" />
+      <_ReportGeneratorLines Include=";" />
+      <_ReportGeneratorLines Include="$([System.IO.File]::ReadAllText('$([System.IO.Path]::Combine($(ReportGeneratorTargetDirectory), 'SummaryGithub.md'))'))" />
+      <_ReportGeneratorLines Include=";" />
       <_ReportGeneratorLines Include="&lt;/details&gt;" />
     </ItemGroup>
     <WriteLinesToFile Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' " ContinueOnError="WarnAndContinue" File="$(GITHUB_STEP_SUMMARY)" Lines="@(_ReportGeneratorLines)" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -21,16 +21,8 @@
   <Target Name="GenerateCoverageReports" AfterTargets="GenerateCoverageResultAfterTest" Condition=" '$(CollectCoverage)' == 'true' ">
     <ReportGenerator ReportFiles="@(CoverletReport)" ReportTypes="$(ReportGeneratorReportTypes)" Tag="$(Version)" TargetDirectory="$(ReportGeneratorTargetDirectory)" Title="$(AssemblyName)" VerbosityLevel="Warning" />
     <ItemGroup>
-      <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
-      <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
       <_ReportGeneratorLines Include="&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;" />
-      <_ReportGeneratorLines Include="&lt;!-- --&gt;" />
-      <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
-      <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
-      <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
-      <_ReportGeneratorLines Include="$([System.IO.File]::ReadAllText('$([System.IO.Path]::Combine($(ReportGeneratorTargetDirectory), 'SummaryGithub.md'))'))" />
-      <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
-      <_ReportGeneratorLines Include="$([System.Environment]::NewLine)" />
+      <_ReportGeneratorLines Include="$([System.Environment]::NewLine)$([System.IO.File]::ReadAllText('$([System.IO.Path]::Combine($(ReportGeneratorTargetDirectory), 'SummaryGithub.md'))'))$([System.Environment]::NewLine)" />
       <_ReportGeneratorLines Include="&lt;/details&gt;" />
     </ItemGroup>
     <WriteLinesToFile Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' " ContinueOnError="WarnAndContinue" File="$(GITHUB_STEP_SUMMARY)" Lines="@(_ReportGeneratorLines)" />

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/CustomDocumentSerializerTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/CustomDocumentSerializerTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Swashbuckle.AspNetCore.IntegrationTests
 {
+    [Collection("TestSite")]
     public class CustomDocumentSerializerTests
     {
         [Fact]

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/DocumentProviderTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/DocumentProviderTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 
 namespace Swashbuckle.AspNetCore.IntegrationTests
 {
+    [Collection("TestSite")]
     public class DocumentProviderTests
     {
         [Theory]

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
@@ -5,6 +5,7 @@ using ReDocApp = ReDoc;
 
 namespace Swashbuckle.AspNetCore.IntegrationTests
 {
+    [Collection("TestSite")]
     public class ReDocIntegrationTests
     {
         [Fact]

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerIntegrationTests.cs
@@ -11,6 +11,7 @@ using ReDocApp = ReDoc;
 
 namespace Swashbuckle.AspNetCore.IntegrationTests
 {
+    [Collection("TestSite")]
     public class SwaggerIntegrationTests
     {
         [Theory]

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace Swashbuckle.AspNetCore.IntegrationTests
 {
+    [Collection("TestSite")]
     public class SwaggerUIIntegrationTests
     {
         [Theory]


### PR DESCRIPTION
- Refactor coverage report for GitHub step summary to try and resolve file conflict issues (and make the code more readable).
- Move test cases that use `TestSite` into the same test collection to stop them being run in parallel with each other.

Contributes to #2836.
