### PR TITLE
Fix RequestBodyFilters not being deep copied

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSwaggerGeneratorOptions.cs
@@ -70,7 +70,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             target.ParameterFilters = new List<IParameterFilter>(source.ParameterFilters);
             target.OperationFilters = new List<IOperationFilter>(source.OperationFilters);
             target.DocumentFilters = new List<IDocumentFilter>(source.DocumentFilters);
-            target.InferSecuritySchemes = source.InferSecuritySchemes;
+            target.RequestBodyFilters = new List<IRequestBodyFilter>(source.RequestBodyFilters);
             target.SecuritySchemesSelector = source.SecuritySchemesSelector;
         }
 


### PR DESCRIPTION
Fix the property being copied twice instead of `RequestBodyFilters` being copied at all.

Missed from #2796.

Resolves #2273.
