### PR TITLE
Exclude unused Swagger-UI files

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="node_modules/swagger-ui-dist/**/*" Exclude="**/*/index.html;**/*/*.map;**/*/*.json;**/*/*.md" />
+    <EmbeddedResource Include="node_modules/swagger-ui-dist/**/*" Exclude="**/*/index.html;**/*/*.map;**/*/*.json;**/*/*.md;**/*/swagger-ui-es-*" />
     <EmbeddedResource Include="index.html" />
   </ItemGroup>
 


### PR DESCRIPTION
Exclude large `swagger-ui-es*` files, which reduces the size of the SwaggerUI assembly to ~2,145KB.

There's no much else we can remove, swagger-ui itself is large.

Resolves #1646.
