### PR TITLE
Fix stale permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   issues: read
   pull-requests: read
 


### PR DESCRIPTION
Fix warning due to missing permissions to manage the cache.

See https://github.com/actions/stale/issues/1133#issuecomment-2079373371.
