### PR TITLE
Only attest packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,18 +91,7 @@ jobs:
         github.event.repository.fork == false &&
         (github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
       with:
-        subject-path: |
-          ./artifacts/bin/Swashbuckle.AspNetCore.Annotations/release*/Swashbuckle.AspNetCore.Annotations.dll
-          ./artifacts/bin/Swashbuckle.AspNetCore.ApiTesting/release*/Swashbuckle.AspNetCore.ApiTesting.dll
-          ./artifacts/bin/Swashbuckle.AspNetCore.ApiTesting.Xunit/release*/Swashbuckle.AspNetCore.ApiTesting.Xunit.dll
-          ./artifacts/bin/Swashbuckle.AspNetCore.Cli/release*/dotnet-swagger.dll
-          ./artifacts/bin/Swashbuckle.AspNetCore.Cli/release*/dotnet-swagger.exe
-          ./artifacts/bin/Swashbuckle.AspNetCore.Newtonsoft/release*/Swashbuckle.AspNetCore.Newtonsoft.dll
-          ./artifacts/bin/Swashbuckle.AspNetCore.ReDoc/release*/Swashbuckle.AspNetCore.ReDoc.dll
-          ./artifacts/bin/Swashbuckle.AspNetCore.Swagger/release*/Swashbuckle.AspNetCore.Swagger.dll
-          ./artifacts/bin/Swashbuckle.AspNetCore.SwaggerGen/release*/Swashbuckle.AspNetCore.SwaggerGen.dll
-          ./artifacts/bin/Swashbuckle.AspNetCore.SwaggerUI/release*/Swashbuckle.AspNetCore.SwaggerUI.dll
-          ./artifacts/package/release/*
+        subject-path: ./artifacts/package/release/*
 
     - name: Publish NuGet packages
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3


### PR DESCRIPTION
Turns out there's a [64 file limit on attestations](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/actions/runs/9058739831/job/24884934967#step:9:66), and the binary/TFM combinations go beyond that.
