### PR TITLE
Do not run IHostedService implementations

### DIFF
--- a/Swashbuckle.AspNetCore.sln
+++ b/Swashbuckle.AspNetCore.sln
@@ -113,6 +113,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApi", "test\WebSites\Web
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApi.Aot", "test\WebSites\WebApi.Aot\WebApi.Aot.csproj", "{07BB09CF-6C6F-4D00-A459-93586345C921}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinimalAppWithHostedServices", "test\WebSites\MinimalAppWithHostedServices\MinimalAppWithHostedServices.csproj", "{D06A88E8-6F42-4F40-943A-E266C0AE6EC9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -259,6 +261,10 @@ Global
 		{07BB09CF-6C6F-4D00-A459-93586345C921}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{07BB09CF-6C6F-4D00-A459-93586345C921}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{07BB09CF-6C6F-4D00-A459-93586345C921}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D06A88E8-6F42-4F40-943A-E266C0AE6EC9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D06A88E8-6F42-4F40-943A-E266C0AE6EC9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D06A88E8-6F42-4F40-943A-E266C0AE6EC9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D06A88E8-6F42-4F40-943A-E266C0AE6EC9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -302,6 +308,7 @@ Global
 		{B6037A37-4A4F-438D-B18A-0C9D1408EAB2} = {DB3F57FC-1472-4F03-B551-43394DA3C5EB}
 		{DE1D77F8-3916-4DEE-A57D-6DDC357F64C6} = {DB3F57FC-1472-4F03-B551-43394DA3C5EB}
 		{07BB09CF-6C6F-4D00-A459-93586345C921} = {DB3F57FC-1472-4F03-B551-43394DA3C5EB}
+		{D06A88E8-6F42-4F40-943A-E266C0AE6EC9} = {DB3F57FC-1472-4F03-B551-43394DA3C5EB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {36FC6A67-247D-4149-8EDD-79FFD1A75F51}

--- a/src/Swashbuckle.AspNetCore.Cli/CommandRunner.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/CommandRunner.cs
@@ -17,10 +17,10 @@ namespace Swashbuckle.AspNetCore.Cli
         {
             CommandName = commandName;
             CommandDescription = commandDescription;
-            _argumentDescriptors = new Dictionary<string, string>();
-            _optionDescriptors = new Dictionary<string, OptionDescriptor>();
-            _runFunc = (namedArgs) => { return 1; }; // noop
-            _subRunners = new List<CommandRunner>();
+            _argumentDescriptors = [];
+            _optionDescriptors = [];
+            _runFunc = (_) => 1; // no-op
+            _subRunners = [];
             _output = output;
         }
 

--- a/src/Swashbuckle.AspNetCore.Cli/HostFactoryResolver.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/HostFactoryResolver.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Extensions.Hosting
                 return null;
             }
 
-            return args => (T)factory.Invoke(null, new object[] { args });
+            return args => (T)factory.Invoke(null, [args]);
         }
 
         // TReturn Factory(string[] args);
@@ -153,7 +153,7 @@ namespace Microsoft.Extensions.Hosting
         private static object Build(object builder)
         {
             var buildMethod = builder.GetType().GetMethod("Build");
-            return buildMethod?.Invoke(builder, Array.Empty<object>());
+            return buildMethod?.Invoke(builder, []);
         }
 
         private static IServiceProvider GetServiceProvider(object host)
@@ -174,13 +174,19 @@ namespace Microsoft.Extensions.Hosting
             private readonly TimeSpan _waitTimeout;
             private readonly bool _stopApplication;
 
-            private readonly TaskCompletionSource<object> _hostTcs = new TaskCompletionSource<object>();
+            private readonly TaskCompletionSource<object> _hostTcs = new();
             private IDisposable _disposable;
-            private Action<object> _configure;
-            private Action<Exception> _entrypointCompleted;
-            private static readonly AsyncLocal<HostingListener> _currentListener = new AsyncLocal<HostingListener>();
+            private readonly Action<object> _configure;
+            private readonly Action<Exception> _entrypointCompleted;
+            private static readonly AsyncLocal<HostingListener> _currentListener = new();
 
-            public HostingListener(string[] args, MethodInfo entryPoint, TimeSpan waitTimeout, bool stopApplication, Action<object> configure, Action<Exception> entrypointCompleted)
+            public HostingListener(
+                string[] args,
+                MethodInfo entryPoint,
+                TimeSpan waitTimeout,
+                bool stopApplication,
+                Action<object> configure,
+                Action<Exception> entrypointCompleted)
             {
                 _args = args;
                 _entryPoint = entryPoint;
@@ -192,84 +198,82 @@ namespace Microsoft.Extensions.Hosting
 
             public object CreateHost()
             {
-                using (var subscription = DiagnosticListener.AllListeners.Subscribe(this))
+                using var subscription = DiagnosticListener.AllListeners.Subscribe(this);
+
+                // Kick off the entry point on a new thread so we don't block the current one
+                // in case we need to timeout the execution
+                var thread = new Thread(() =>
                 {
-
-                    // Kick off the entry point on a new thread so we don't block the current one
-                    // in case we need to timeout the execution
-                    var thread = new Thread(() =>
-                    {
-                        Exception exception = null;
-
-                        try
-                        {
-                            // Set the async local to the instance of the HostingListener so we can filter events that
-                            // aren't scoped to this execution of the entry point.
-                            _currentListener.Value = this;
-
-                            var parameters = _entryPoint.GetParameters();
-                            if (parameters.Length == 0)
-                            {
-                                _entryPoint.Invoke(null, Array.Empty<object>());
-                            }
-                            else
-                            {
-                                _entryPoint.Invoke(null, new object[] { _args });
-                            }
-
-                            // Try to set an exception if the entry point returns gracefully, this will force
-                            // build to throw
-                            _hostTcs.TrySetException(new InvalidOperationException("Unable to build IHost"));
-                        }
-                        catch (TargetInvocationException tie) when (tie.InnerException is StopTheHostException)
-                        {
-                            // The host was stopped by our own logic
-                        }
-                        catch (TargetInvocationException tie)
-                        {
-                            exception = tie.InnerException ?? tie;
-
-                            // Another exception happened, propagate that to the caller
-                            _hostTcs.TrySetException(exception);
-                        }
-                        catch (Exception ex)
-                        {
-                            exception = ex;
-
-                            // Another exception happened, propagate that to the caller
-                            _hostTcs.TrySetException(ex);
-                        }
-                        finally
-                        {
-                            // Signal that the entry point is completed
-                            _entrypointCompleted?.Invoke(exception);
-                        }
-                    })
-                    {
-                        // Make sure this doesn't hang the process
-                        IsBackground = true
-                    };
-
-                    // Start the thread
-                    thread.Start();
+                    Exception exception = null;
 
                     try
                     {
-                        // Wait before throwing an exception
-                        if (!_hostTcs.Task.Wait(_waitTimeout))
+                        // Set the async local to the instance of the HostingListener so we can filter events that
+                        // aren't scoped to this execution of the entry point.
+                        _currentListener.Value = this;
+
+                        var parameters = _entryPoint.GetParameters();
+                        if (parameters.Length == 0)
                         {
-                            throw new InvalidOperationException("Unable to build IHost");
+                            _entryPoint.Invoke(null, []);
                         }
+                        else
+                        {
+                            _entryPoint.Invoke(null, [_args]);
+                        }
+
+                        // Try to set an exception if the entry point returns gracefully, this will force
+                        // build to throw
+                        _hostTcs.TrySetException(new InvalidOperationException("Unable to build IHost"));
                     }
-                    catch (AggregateException) when (_hostTcs.Task.IsCompleted)
+                    catch (TargetInvocationException tie) when (tie.InnerException is StopTheHostException)
                     {
-                        // Lets this propagate out of the call to GetAwaiter().GetResult()
+                        // The host was stopped by our own logic
                     }
+                    catch (TargetInvocationException tie)
+                    {
+                        exception = tie.InnerException ?? tie;
 
-                    Debug.Assert(_hostTcs.Task.IsCompleted);
+                        // Another exception happened, propagate that to the caller
+                        _hostTcs.TrySetException(exception);
+                    }
+                    catch (Exception ex)
+                    {
+                        exception = ex;
 
-                    return _hostTcs.Task.GetAwaiter().GetResult();
+                        // Another exception happened, propagate that to the caller
+                        _hostTcs.TrySetException(ex);
+                    }
+                    finally
+                    {
+                        // Signal that the entry point is completed
+                        _entrypointCompleted?.Invoke(exception);
+                    }
+                })
+                {
+                    // Make sure this doesn't hang the process
+                    IsBackground = true
+                };
+
+                // Start the thread
+                thread.Start();
+
+                try
+                {
+                    // Wait before throwing an exception
+                    if (!_hostTcs.Task.Wait(_waitTimeout))
+                    {
+                        throw new InvalidOperationException("Unable to build IHost");
+                    }
                 }
+                catch (AggregateException) when (_hostTcs.Task.IsCompleted)
+                {
+                    // Lets this propagate out of the call to GetAwaiter().GetResult()
+                }
+
+                Debug.Assert(_hostTcs.Task.IsCompleted);
+
+                return _hostTcs.Task.GetAwaiter().GetResult();
             }
 
             public void OnCompleted()
@@ -279,7 +283,6 @@ namespace Microsoft.Extensions.Hosting
 
             public void OnError(Exception error)
             {
-
             }
 
             public void OnNext(DiagnosticListener value)
@@ -321,10 +324,7 @@ namespace Microsoft.Extensions.Hosting
                 }
             }
 
-            private sealed class StopTheHostException : Exception
-            {
-
-            }
+            private sealed class StopTheHostException : Exception;
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.Cli/HostingApplication.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/HostingApplication.cs
@@ -4,7 +4,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Http.Features;
+#if NETCOREAPP3_0_OR_GREATER
 using Microsoft.Extensions.DependencyInjection;
+#endif
 using Microsoft.Extensions.Hosting;
 
 namespace Swashbuckle.AspNetCore.Cli
@@ -69,18 +71,17 @@ namespace Swashbuckle.AspNetCore.Cli
                 // We set the application name in the hosting environment to the startup assembly
                 // to avoid falling back to the entry assembly (dotnet-swagger) when configuring our
                 // application.
-                var services = ((IHost)factory(new[] { $"--{HostDefaults.ApplicationKey}={assemblyName}" })).Services;
+                var services = ((IHost)factory([$"--{HostDefaults.ApplicationKey}={assemblyName}"])).Services;
 
                 // Wait for the application to start so that we know it's fully configured. This is important because
                 // we need the middleware pipeline to be configured before we access the ISwaggerProvider in
                 // in the IServiceProvider
                 var applicationLifetime = services.GetRequiredService<IHostApplicationLifetime>();
 
-                using (var registration = applicationLifetime.ApplicationStarted.Register(() => waitForStartTcs.TrySetResult(null)))
-                {
-                    waitForStartTcs.Task.Wait();
-                    return services;
-                }
+                using var registration = applicationLifetime.ApplicationStarted.Register(() => waitForStartTcs.TrySetResult(null));
+                waitForStartTcs.Task.Wait();
+
+                return services;
             }
             catch (InvalidOperationException)
             {
@@ -103,7 +104,6 @@ namespace Swashbuckle.AspNetCore.Cli
             public void Dispose() { }
             public Task StartAsync<TContext>(IHttpApplication<TContext> application, CancellationToken cancellationToken) => Task.CompletedTask;
             public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.Cli/HostingApplication.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/HostingApplication.cs
@@ -39,8 +39,9 @@ namespace Swashbuckle.AspNetCore.Cli
                         // exclude all implementations of IHostedService
                         // except Microsoft.AspNetCore.Hosting.GenericWebHostService because that one will build/configure
                         // the WebApplication/Middleware pipeline in the case of the GenericWebHostBuilder.
-                        if (typeof(IHostedService).IsAssignableFrom(services[i].ServiceType)
-                            && services[i].ImplementationType is not { FullName: "Microsoft.AspNetCore.Hosting.GenericWebHostService" })
+                        var registration = services[i];
+                        if (registration.ServiceType == typeof(IHostedService)
+                            && registration.ImplementationType is not { FullName: "Microsoft.AspNetCore.Hosting.GenericWebHostService" })
                         {
                             services.RemoveAt(i);
                         }

--- a/src/Swashbuckle.AspNetCore.Cli/HostingApplication.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/HostingApplication.cs
@@ -33,6 +33,18 @@ namespace Swashbuckle.AspNetCore.Cli
                 {
                     services.AddSingleton<IServer, NoopServer>();
                     services.AddSingleton<IHostLifetime, NoopHostLifetime>();
+
+                    for (var i = services.Count - 1; i >= 0; i--)
+                    {
+                        // exclude all implementations of IHostedService
+                        // except Microsoft.AspNetCore.Hosting.GenericWebHostService because that one will build/configure
+                        // the WebApplication/Middleware pipeline in the case of the GenericWebHostBuilder.
+                        if (typeof(IHostedService).IsAssignableFrom(services[i].ServiceType)
+                            && services[i].ImplementationType is not { FullName: "Microsoft.AspNetCore.Hosting.GenericWebHostService" })
+                        {
+                            services.RemoveAt(i);
+                        }
+                    }
                 });
             }
 

--- a/test/Swashbuckle.AspNetCore.Cli.Test/CommandRunnerTests.cs
+++ b/test/Swashbuckle.AspNetCore.Cli.Test/CommandRunnerTests.cs
@@ -4,10 +4,10 @@ using Xunit;
 
 namespace Swashbuckle.AspNetCore.Cli.Test
 {
-    public class CommandRunnerTests
+    public static class CommandRunnerTests
     {
         [Fact]
-        public void Run_ParsesArgumentsAndExecutesCommands_AccordingToConfiguredMetadata()
+        public static void Run_ParsesArgumentsAndExecutesCommands_AccordingToConfiguredMetadata()
         {
             var receivedValues = new List<string>();
             var subject = new CommandRunner("test", "a test", new StringWriter());
@@ -36,23 +36,23 @@ namespace Swashbuckle.AspNetCore.Cli.Test
                 });
             });
 
-            var cmd1ExitCode = subject.Run(new[] { "cmd1", "--opt1", "foo", "--opt2", "bar" });
-            var cmd2ExitCode = subject.Run(new[] { "cmd2", "--opt1", "blah", "--opt2", "dblah" });
+            var cmd1ExitCode = subject.Run(["cmd1", "--opt1", "foo", "--opt2", "bar"]);
+            var cmd2ExitCode = subject.Run(["cmd2", "--opt1", "blah", "--opt2", "dblah"]);
 
             Assert.Equal(2, cmd1ExitCode);
             Assert.Equal(3, cmd2ExitCode);
-            Assert.Equal(new[] { "foo", null, "bar", "blah", null, "dblah" }, receivedValues.ToArray());
+            Assert.Equal(["foo", null, "bar", "blah", null, "dblah"], [.. receivedValues]);
         }
 
         [Fact]
-        public void Run_PrintsAvailableCommands_WhenUnexpectedCommandIsProvided()
+        public static void Run_PrintsAvailableCommands_WhenUnexpectedCommandIsProvided()
         {
             var output = new StringWriter();
             var subject = new CommandRunner("test", "a test", output);
             subject.SubCommand("cmd", "does something", c => {
             });
 
-            var exitCode = subject.Run(new[] { "foo" });
+            var exitCode = subject.Run(["foo"]);
 
             Assert.StartsWith("a test", output.ToString());
             Assert.Contains("Commands:", output.ToString());
@@ -60,14 +60,14 @@ namespace Swashbuckle.AspNetCore.Cli.Test
         }
 
         [Fact]
-        public void Run_PrintsAvailableCommands_WhenHelpOptionIsProvided()
+        public static void Run_PrintsAvailableCommands_WhenHelpOptionIsProvided()
         {
             var output = new StringWriter();
             var subject = new CommandRunner("test", "a test", output);
             subject.SubCommand("cmd", "does something", c => {
             });
 
-            var exitCode = subject.Run(new[] { "--help" });
+            var exitCode = subject.Run(["--help"]);
 
             Assert.StartsWith("a test", output.ToString());
             Assert.Contains("Commands:", output.ToString());
@@ -75,15 +75,15 @@ namespace Swashbuckle.AspNetCore.Cli.Test
         }
 
         [Theory]
-        [InlineData(new[] { "--opt1" }, new string[] { }, new[] { "cmd", "--opt2", "foo" }, true)]
-        [InlineData(new[] { "--opt1" }, new string[] { }, new[] { "cmd", "--opt1" }, true)]
-        [InlineData(new[] { "--opt1" }, new string[] { }, new[] { "cmd", "--opt1", "--opt2" }, true)]
-        [InlineData(new[] { "--opt1" }, new string[] { }, new[] { "cmd", "--opt1", "foo" }, false)]
-        [InlineData(new string[] { }, new[] { "arg1" }, new[] { "cmd" }, true)]
-        [InlineData(new string[] { }, new[] { "arg1" }, new[] { "cmd", "--opt1" }, true)]
-        [InlineData(new string[] {}, new[] { "arg1" }, new[] { "cmd", "foo", "bar" }, true)]
-        [InlineData(new string[] {}, new[] { "arg1" }, new[] { "cmd", "foo" }, false)]
-        public void Run_PrintsCommandUsage_WhenUnexpectedArgumentsAreProvided(
+        [InlineData(new[] { "--opt1" }, new string[0], new[] { "cmd", "--opt2", "foo" }, true)]
+        [InlineData(new[] { "--opt1" }, new string[0], new[] { "cmd", "--opt1" }, true)]
+        [InlineData(new[] { "--opt1" }, new string[0], new[] { "cmd", "--opt1", "--opt2" }, true)]
+        [InlineData(new[] { "--opt1" }, new string[0], new[] { "cmd", "--opt1", "foo" }, false)]
+        [InlineData(new string[0], new[] { "arg1" }, new[] { "cmd" }, true)]
+        [InlineData(new string[0], new[] { "arg1" }, new[] { "cmd", "--opt1" }, true)]
+        [InlineData(new string[0], new[] { "arg1" }, new[] { "cmd", "foo", "bar" }, true)]
+        [InlineData(new string[0], new[] { "arg1" }, new[] { "cmd", "foo" }, false)]
+        public static void Run_PrintsCommandUsage_WhenUnexpectedArgumentsAreProvided(
             string[] optionNames,
             string[] argNames,
             string[] providedArgs,

--- a/test/Swashbuckle.AspNetCore.Cli.Test/Swashbuckle.AspNetCore.Cli.Test.csproj
+++ b/test/Swashbuckle.AspNetCore.Cli.Test/Swashbuckle.AspNetCore.Cli.Test.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\Swashbuckle.AspNetCore.TestSupport\Swashbuckle.AspNetCore.TestSupport.csproj" />
     <ProjectReference Include="..\WebSites\Basic\Basic.csproj" />
     <ProjectReference Include="..\WebSites\CustomDocumentSerializer\CustomDocumentSerializer.csproj" />
+    <ProjectReference Include="..\WebSites\MinimalAppWithHostedServices\MinimalAppWithHostedServices.csproj" />
     <ProjectReference Include="..\WebSites\MinimalApp\MinimalApp.csproj" />
     <ProjectReference Include="..\..\src\Swashbuckle.AspNetCore.Cli\Swashbuckle.AspNetCore.Cli.csproj" />
   </ItemGroup>

--- a/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
+++ b/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
@@ -35,20 +35,22 @@ namespace Swashbuckle.AspNetCore.Cli.Test
         }
 
         [Fact]
-        public void Overwrites_Existing_File()
+        public static void Overwrites_Existing_File()
         {
-            using var temporaryDirectory = new TemporaryDirectory();
-            var path = Path.Combine(temporaryDirectory.Path, "swagger.json");
+            using var document = RunApplication((outputPath) =>
+            {
+                File.WriteAllText(outputPath, new string('x', 100_000));
 
-            var dummyContent = new string('x', 100_000);
-            File.WriteAllText(path, dummyContent);
-
-            var args = new string[] { "tofile", "--output", path, Path.Combine(Directory.GetCurrentDirectory(), "Basic.dll"), "v1" };
-            Assert.Equal(0, Program.Main(args));
-
-            var readContent = File.ReadAllText(path);
-            Assert.True(readContent.Length < dummyContent.Length);
-            using var document = JsonDocument.Parse(readContent);
+                return
+                [
+                    "tofile",
+                    "--output",
+                    outputPath,
+                    "--serializeasv2",
+                    Path.Combine(Directory.GetCurrentDirectory(), "Basic.dll"),
+                    "v1"
+                ];
+            });
 
             // verify one of the endpoints
             var paths = document.RootElement.GetProperty("paths");

--- a/test/WebSites/MinimalAppWithHostedServices/MinimalAppWithHostedServices.csproj
+++ b/test/WebSites/MinimalAppWithHostedServices/MinimalAppWithHostedServices.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <DotNetSwaggerPath>$([System.IO.Path]::Combine('$(ArtifactsPath)', 'bin', 'Swashbuckle.AspNetCore.Cli', '$(Configuration)_$(TargetFramework)', 'dotnet-swagger.dll'))</DotNetSwaggerPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerGen\Swashbuckle.AspNetCore.SwaggerGen.csproj" />
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerUI\Swashbuckle.AspNetCore.SwaggerUI.csproj" />
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.Swagger\Swashbuckle.AspNetCore.Swagger.csproj" />
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.Cli\Swashbuckle.AspNetCore.Cli.csproj" />
+  </ItemGroup>
+
+</Project>
+

--- a/test/WebSites/MinimalAppWithHostedServices/Program.cs
+++ b/test/WebSites/MinimalAppWithHostedServices/Program.cs
@@ -1,0 +1,34 @@
+﻿var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new() { Title = "MinimalApp", Version = "v1" });
+});
+
+builder.Services.AddHostedService<HostedService>();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "MinimalApp v1"));
+}
+
+app.MapGet("/ShouldContain", () => "Hello World!");
+
+app.Run();
+
+class HostedService : IHostedService
+{
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        throw new Exception("Crash!");
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/test/WebSites/MinimalAppWithHostedServices/Properties/launchSettings.json
+++ b/test/WebSites/MinimalAppWithHostedServices/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "MinimalAppWithHostedServices": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:57095;http://localhost:57096"
+    }
+  }
+}


### PR DESCRIPTION
- Remove `IHostedService` implementations so the CLI doesn't run hosted services (and then hang/fail).
- Refactor CLI tests to reduce duplication.
- Use newer C# syntax as suggested by Visual Studio.

Supersedes #2713.

Resolves #2712.

/cc @desjoerd
