### PR TITLE
Existing output file should be deleted/overwritten

### DIFF
--- a/src/Swashbuckle.AspNetCore.Cli/Program.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/Program.cs
@@ -101,7 +101,7 @@ namespace Swashbuckle.AspNetCore.Cli
                         ? Path.Combine(Directory.GetCurrentDirectory(), arg1)
                         : null;
 
-                    using (Stream stream = outputPath != null ? File.OpenWrite(outputPath) : Console.OpenStandardOutput())
+                    using (Stream stream = outputPath != null ? File.Create(outputPath) : Console.OpenStandardOutput())
                     using (var streamWriter = new FormattingStreamWriter(stream, CultureInfo.InvariantCulture))
                     {
                         IOpenApiWriter writer;

--- a/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
+++ b/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
@@ -29,6 +29,28 @@ namespace Swashbuckle.AspNetCore.Cli.Test
         }
 
         [Fact]
+        public void Overwrites_Existing_File()
+        {
+            using var temporaryDirectory = new TemporaryDirectory();
+            var path = Path.Combine(temporaryDirectory.Path, "swagger.json");
+
+            var dummyContent = new string('x', 100_000);
+            File.WriteAllText(path, dummyContent);
+
+            var args = new string[] { "tofile", "--output", path, Path.Combine(Directory.GetCurrentDirectory(), "Basic.dll"), "v1" };
+            Assert.Equal(0, Program.Main(args));
+
+            var readContent = File.ReadAllText(path);
+            Assert.True(readContent.Length < dummyContent.Length);
+            using var document = JsonDocument.Parse(readContent);
+
+            // verify one of the endpoints
+            var paths = document.RootElement.GetProperty("paths");
+            var productsPath = paths.GetProperty("/products");
+            Assert.True(productsPath.TryGetProperty("post", out _));
+        }
+
+        [Fact]
         public void CustomDocumentSerializer_Writes_Custom_V2_Document()
         {
             using var temporaryDirectory = new TemporaryDirectory();

--- a/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
+++ b/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
@@ -29,28 +29,6 @@ namespace Swashbuckle.AspNetCore.Cli.Test
         }
 
         [Fact]
-        public void Overwrites_Existing_File()
-        {
-            using var temporaryDirectory = new TemporaryDirectory();
-            var path = Path.Combine(temporaryDirectory.Path, "swagger.json");
-
-            var dummyContent = new string('x', 100_000);
-            File.WriteAllText(path, dummyContent);
-
-            var args = new string[] { "tofile", "--output", path, Path.Combine(Directory.GetCurrentDirectory(), "Basic.dll"), "v1" };
-            Assert.Equal(0, Program.Main(args));
-
-            var readContent = File.ReadAllText(path);
-            Assert.True(readContent.Length < dummyContent.Length);
-            using var document = JsonDocument.Parse(readContent);
-
-            // verify one of the endpoints
-            var paths = document.RootElement.GetProperty("paths");
-            var productsPath = paths.GetProperty("/products");
-            Assert.True(productsPath.TryGetProperty("post", out _));
-        }
-
-        [Fact]
         public void CustomDocumentSerializer_Writes_Custom_V2_Document()
         {
             using var temporaryDirectory = new TemporaryDirectory();


### PR DESCRIPTION
The CLI currently uses `File.OpenWrite(path)` (added in https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/2677) to create an output stream for the resulting swagger document. This does not delete the existing contents, but instead starts writing from position 0, causing issues if the output is smaller than the previous file content.

I changed it to `File.Create(path)` to make sure any previous content is discarded.
