### PR TITLE
Fix serialization of AdditionalItems

### DIFF
--- a/src/Swashbuckle.AspNetCore.ReDoc/Swashbuckle.AspNetCore.ReDoc.csproj
+++ b/src/Swashbuckle.AspNetCore.ReDoc/Swashbuckle.AspNetCore.ReDoc.csproj
@@ -26,7 +26,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <Target Name="NpmInstall" BeforeTargets="DispatchToInnerBuilds">
+  <Target Name="NpmInstall" BeforeTargets="DispatchToInnerBuilds" Condition=" '$(CI)' != '' OR !Exists('$(MSBuildThisFileDirectory)\node_modules') ">
     <Exec Command="npm install" ContinueOnError="true">
       <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
     </Exec>

--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
@@ -30,7 +30,7 @@ namespace Swashbuckle.AspNetCore.Swagger
         {
             _next = next;
             _options = options ?? new SwaggerOptions();
-            _requestMatcher = new TemplateMatcher(TemplateParser.Parse(_options.RouteTemplate), new RouteValueDictionary());
+            _requestMatcher = new TemplateMatcher(TemplateParser.Parse(_options.RouteTemplate), []);
         }
 
 #if !NETSTANDARD

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIJsonSerializerContext.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIJsonSerializerContext.cs
@@ -1,4 +1,7 @@
 ﻿#if NET6_0_OR_GREATER
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 namespace Swashbuckle.AspNetCore.SwaggerUI;
@@ -6,6 +9,36 @@ namespace Swashbuckle.AspNetCore.SwaggerUI;
 [JsonSerializable(typeof(ConfigObject))]
 [JsonSerializable(typeof(InterceptorFunctions))]
 [JsonSerializable(typeof(OAuthConfigObject))]
+// These primitive types are declared for common types that may be used with ConfigObject.AdditionalItems. See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2884.
+[JsonSerializable(typeof(bool))]
+[JsonSerializable(typeof(byte))]
+[JsonSerializable(typeof(sbyte))]
+[JsonSerializable(typeof(short))]
+[JsonSerializable(typeof(ushort))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(uint))]
+[JsonSerializable(typeof(long))]
+[JsonSerializable(typeof(ulong))]
+[JsonSerializable(typeof(float))]
+[JsonSerializable(typeof(double))]
+[JsonSerializable(typeof(decimal))]
+[JsonSerializable(typeof(char))]
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(DateTime))]
+[JsonSerializable(typeof(DateTimeOffset))]
+[JsonSerializable(typeof(TimeSpan))]
+[JsonSerializable(typeof(JsonArray))]
+[JsonSerializable(typeof(JsonObject))]
+[JsonSerializable(typeof(JsonDocument))]
+#if NET7_0_OR_GREATER
+[JsonSerializable(typeof(DateOnly))]
+[JsonSerializable(typeof(TimeOnly))]
+#endif
+#if NET8_0_OR_GREATER
+[JsonSerializable(typeof(Half))]
+[JsonSerializable(typeof(Int128))]
+[JsonSerializable(typeof(UInt128))]
+#endif
 [JsonSourceGenerationOptions(
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -89,7 +89,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
             await _staticFileMiddleware.Invoke(httpContext);
         }
 
-        private StaticFileMiddleware CreateStaticFileMiddleware(
+        private static StaticFileMiddleware CreateStaticFileMiddleware(
             RequestDelegate next,
             IWebHostEnvironment hostingEnv,
             ILoggerFactory loggerFactory,
@@ -104,7 +104,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
             return new StaticFileMiddleware(next, hostingEnv, Options.Create(staticFileOptions), loggerFactory);
         }
 
-        private void RespondWithRedirect(HttpResponse response, string location)
+        private static void RespondWithRedirect(HttpResponse response, string location)
         {
             response.StatusCode = 301;
             response.Headers["Location"] = location;

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -162,7 +162,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         public string ValidatorUrl { get; set; } = null;
 
         [JsonExtensionData]
-        public Dictionary<string, object> AdditionalItems { get; set; } = new Dictionary<string, object>();
+        public Dictionary<string, object> AdditionalItems { get; set; } = [];
     }
 
     public class UrlDescriptor
@@ -233,7 +233,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// <summary>
         /// String array of initially selected oauth scopes, default is empty array
         /// </summary>
-        public IEnumerable<string> Scopes { get; set; } = new string[] { };
+        public IEnumerable<string> Scopes { get; set; } = [];
 
         /// <summary>
         /// Additional query parameters added to authorizationUrl and tokenUrl

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
@@ -30,7 +30,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <Target Name="NpmInstall" BeforeTargets="DispatchToInnerBuilds">
+  <Target Name="NpmInstall" BeforeTargets="DispatchToInnerBuilds" Condition=" '$(CI)' != '' OR !Exists('$(MSBuildThisFileDirectory)\node_modules') ">
     <Exec Command="npm install" ContinueOnError="true">
       <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
     </Exec>

--- a/test/WebSites/CustomUIConfig/Startup.cs
+++ b/test/WebSites/CustomUIConfig/Startup.cs
@@ -1,9 +1,11 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerUI;
 
 namespace CustomUIConfig
@@ -76,6 +78,34 @@ namespace CustomUIConfig
                 c.UseResponseInterceptor("(res) => { console.log('Custom interceptor intercepted response from:', res.url); return res; }");
                 c.EnablePersistAuthorization();
 
+                c.ConfigObject.AdditionalItems.Add("syntaxHighlight", false);
+                c.ConfigObject.AdditionalItems.Add("charProperty", 'c');
+                c.ConfigObject.AdditionalItems.Add("stringProperty", "value");
+                c.ConfigObject.AdditionalItems.Add("byteProperty", (byte)1);
+                c.ConfigObject.AdditionalItems.Add("signedByteProperty", (sbyte)1);
+                c.ConfigObject.AdditionalItems.Add("int16Property", (short)1);
+                c.ConfigObject.AdditionalItems.Add("uint16Property", (ushort)1);
+                c.ConfigObject.AdditionalItems.Add("int32Property", 1);
+                c.ConfigObject.AdditionalItems.Add("uint32Property", 1u);
+                c.ConfigObject.AdditionalItems.Add("int64Property", 1L);
+                c.ConfigObject.AdditionalItems.Add("uint64Property", 1uL);
+                c.ConfigObject.AdditionalItems.Add("floatProperty", 1f);
+                c.ConfigObject.AdditionalItems.Add("doubleProperty", 1d);
+                c.ConfigObject.AdditionalItems.Add("decimalProperty", 1m);
+                c.ConfigObject.AdditionalItems.Add("dateTimeProperty", DateTime.UtcNow);
+                c.ConfigObject.AdditionalItems.Add("dateTimeOffsetProperty", DateTimeOffset.UtcNow);
+                c.ConfigObject.AdditionalItems.Add("timeSpanProperty", new TimeSpan(12, 34, 56));
+                c.ConfigObject.AdditionalItems.Add("jsonArray", new JsonArray() { "string" });
+                c.ConfigObject.AdditionalItems.Add("jsonObject", new JsonObject() { ["foo"] = "bar" });
+                c.ConfigObject.AdditionalItems.Add("jsonDocument", JsonDocument.Parse("""{ "foo": "bar" }"""));
+
+#if NET8_0_OR_GREATER
+                c.ConfigObject.AdditionalItems.Add("dateOnlyProperty", new DateOnly(1977, 05, 25));
+                c.ConfigObject.AdditionalItems.Add("timeOnlyProperty", new TimeOnly(12, 34, 56));
+                c.ConfigObject.AdditionalItems.Add("halfProperty", Half.CreateChecked(1));
+                c.ConfigObject.AdditionalItems.Add("int128Property", Int128.CreateChecked(1));
+                c.ConfigObject.AdditionalItems.Add("unt128Property", UInt128.CreateChecked(1));
+#endif
             });
         }
     }


### PR DESCRIPTION
- Extend custom `JsonSerializerContext` to cover objects that might be added to the additional JSON property.
- Speed up local development iterations by only running `npm install` when the `node_modules` directory does not already exist.
- Apply code refactoring suggestions from Visual Studio.

Resolves #2884.
