### PR TITLE
Add workaround for Swagger UI operation id wrapping

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
@@ -26,6 +26,13 @@
             background: #fafafa;
         }
     </style>
+    
+    <!-- Workaround for https://github.com/swagger-api/swagger-ui/issues/9577 -->
+    <style>
+        .opblock-summary-operation-id {
+            word-break: normal !important;
+        }
+    </style>
     %(HeadContent)
 </head>
 


### PR DESCRIPTION
## The issue or feature being addressed
Since Swashbuckle 6.6.0 updated from Swagger UI version 4.15.5 to 5.17.9 the operation ids (which are shown if `app.UseSwaggerUI(c => c.DisplayOperationId());` is used) are wrapping even if there would be enough space. See swagger-api/swagger-ui#9577

## Details on the issue fix or feature implementation
The workaround works, but I'm not sure if this is the best way to fix this. This is also why I didn't create a PR for Swagger UI directly.

I'm also not sure if this should really be added to Swashbuckle. But the index.html file already contains some other workarounds, so I guess it's fine?

I've tested the fix by using the `SwaggerUIOptions.HeadContent` property. But I'd like to test it with a real Swashbuckle package too. Is there a way to get a PR build published on the MyGet feed?

An alternative would be to modify the method `DisplayOperationId` instead. In there we could do this:
```cs
var builder = new StringBuilder(options.HeadContent);
builder.AppendLine("<style>.opblock-summary-operation-id { word-break: normal !important; }</style>");
options.HeadContent = builder.ToString();
```

I'm open for better ideas.