### PR TITLE
Disable parallel build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <Authors>domaindrivendev</Authors>
+    <!-- HACK See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2893 -->
+    <BuildInParallel>false</BuildInParallel>
     <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
     <Company>https://github.com/domaindrivendev/Swashbuckle.AspNetCore</Company>
     <ContinuousIntegrationBuild Condition=" '$(CI)' != '' ">true</ContinuousIntegrationBuild>

--- a/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
+++ b/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
@@ -28,7 +28,7 @@ namespace Swashbuckle.AspNetCore.Cli.Test
             Assert.True(productsPath.TryGetProperty("post", out _));
         }
 
-        [Fact(Skip = "Disabled because it makes CI unstable")]
+        [Fact]
         public void Overwrites_Existing_File()
         {
             using var temporaryDirectory = new TemporaryDirectory();


### PR DESCRIPTION
Disable parallel build to see if it fixes file-write conflicts. Relates to #2893.
