### PR TITLE
Fix libraries being handled as test projects

### DIFF
--- a/src/Swashbuckle.AspNetCore.ApiTesting.Xunit/Swashbuckle.AspNetCore.ApiTesting.Xunit.csproj
+++ b/src/Swashbuckle.AspNetCore.ApiTesting.Xunit/Swashbuckle.AspNetCore.ApiTesting.Xunit.csproj
@@ -17,4 +17,8 @@
     <PackageReference Include="xunit" VersionOverride="2.4.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectCapability Remove="TestContainer" />
+  </ItemGroup>
+  
 </Project>

--- a/test/Swashbuckle.AspNetCore.TestSupport/Swashbuckle.AspNetCore.TestSupport.csproj
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Swashbuckle.AspNetCore.TestSupport.csproj
@@ -22,4 +22,8 @@
     <PackageReference Include="xunit.core" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectCapability Remove="TestContainer" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
It caused error messages to printed by Visual Studio when discovering and executing tests. When running tests from a fully clean solution, VS only ends up running a few projects.

Errors such as:
```
Test project Swashbuckle.AspNetCore.ApiTesting.Xunit does not reference any .NET NuGet adapter. Test discovery or execution might not work for this project.
```

and:
```
Could not find testhost
```

How Test Explorer looks after running all tests on a completely fresh build:
<img src="https://github.com/domaindrivendev/Swashbuckle.AspNetCore/assets/6620662/38873843-66d4-46b4-80b0-00355ea32dd6" data-canonical-src="https://github.com/domaindrivendev/Swashbuckle.AspNetCore/assets/6620662/38873843-66d4-46b4-80b0-00355ea32dd6" width="300" />

