### PR TITLE
Replace `<br />`, `<br/>`, and `<br>` in XML comments with `Environment.Newline`

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
@@ -21,6 +21,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 .HumanizeCodeTags()
                 .HumanizeMultilineCodeTags()
                 .HumanizeParaTags()
+                .HumanizeBrTags() // must be called after HumanizeParaTags() so that it replaces any additional <br> tags
                 .DecodeXml();
         }
 
@@ -108,6 +109,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             return ParaTag().Replace(text, (match) => "<br>" + match.Groups["display"].Value);
         }
 
+        private static string HumanizeBrTags(this string text)
+        {
+            return BrTag().Replace(text, m => Environment.NewLine);
+        }
+
         private static string DecodeXml(this string text)
         {
             return WebUtility.HtmlDecode(text);
@@ -118,6 +124,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private const string MultilineCodeTagPattern = @"<code>(?<display>.+?)</code>";
         private const string ParaTagPattern = @"<para>(?<display>.+?)</para>";
         private const string HrefPattern = @"<see href=\""(.*)\"">(.*)<\/see>";
+        private const string BrPattern = @"(<br ?\/?>)"; // handles <br>, <br/>, <br />
 
 #if NET7_0_OR_GREATER
         [GeneratedRegex(RefTagPattern)]
@@ -134,18 +141,23 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         [GeneratedRegex(HrefPattern)]
         private static partial Regex HrefTag();
+
+        [GeneratedRegex(BrPattern)]
+        private static partial Regex BrTag();
 #else
         private static readonly Regex _refTag = new(RefTagPattern);
         private static readonly Regex _codeTag = new(CodeTagPattern);
         private static readonly Regex _multilineCodeTag = new(MultilineCodeTagPattern, RegexOptions.Singleline);
         private static readonly Regex _paraTag = new(ParaTagPattern, RegexOptions.Singleline);
         private static readonly Regex _hrefTag = new(HrefPattern);
+        private static readonly Regex _brTag = new(BrPattern);
 
         private static Regex RefTag() => _refTag;
         private static Regex CodeTag() => _codeTag;
         private static Regex MultilineCodeTag() => _multilineCodeTag;
         private static Regex ParaTag() => _paraTag;
         private static Regex HrefTag() => _hrefTag;
+        private static Regex BrTag() => _brTag;
 #endif
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
@@ -128,10 +128,11 @@ A line of text",
         [InlineData(@"<paramref name=""param1"" /> does something", "param1 does something")]
         [InlineData("<c>DoWork</c> is a method in <c>TestClass</c>.", "`DoWork` is a method in `TestClass`.")]
         [InlineData("<code>DoWork</code> is a method in <code>\nTestClass\n</code>.", "```DoWork``` is a method in ```\nTestClass\n```.")]
-        [InlineData("<para>This is a paragraph</para>.", "<br>This is a paragraph.")]
+        [InlineData("<para>This is a paragraph</para>.", "\r\nThis is a paragraph.")]
         [InlineData("GET /Todo?iscomplete=true&amp;owner=mike", "GET /Todo?iscomplete=true&owner=mike")]
         [InlineData(@"Returns a <see langword=""null""/> item.", "Returns a null item.")]
         [InlineData(@"<see href=""https://www.iso.org/iso-4217-currency-codes.html"">ISO currency code</see>", "[ISO currency code](https://www.iso.org/iso-4217-currency-codes.html)")]
+        [InlineData("First line.<br />Second line.<br/>Third line.<br>Fourth line.", "First line.\r\nSecond line.\r\nThird line.\r\nFourth line.")]
         public void Humanize_HumanizesInlineTags(
             string input,
             string expectedOutput)


### PR DESCRIPTION
## The issue or feature being addressed

 `<br />`, `<br/>`, and `<br>` tags present in the XML comments end up appearing unchanged in the documentation. The should instead be rendered as new lines.

## Details on the issue fix or feature implementation

`Environment.NewLine` produces `\r\n` or `\n` which is standard for most markdown usages.

Similar to https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/2392
