### PR TITLE
Allow Swagger UI CSS and JS paths to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1257,7 +1257,7 @@ app.UseSwaggerUI(c =>
 
 ### Change CSS or JS Paths ###
 
-By default, the Swagger UI inclide default CSS and JS, but if you need to change path or URL (ex CDN):
+By default, the Swagger UI include default CSS and JS, but if you wish to change the path or URL (for example to use a CDN):
 
 ```csharp
 app.UseSwaggerUI(c =>

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ The steps described above will get you up and running with minimal setup. Howeve
 * [Swashbuckle.AspNetCore.SwaggerUI](#swashbuckleaspnetcoreswaggerui)
     * [Change Relative Path to the UI](#change-relative-path-to-the-ui)
     * [Change Document Title](#change-document-title)
+    * [Change CSS or JS Paths](#change-css-or-js-paths)
     * [List Multiple Swagger Documents](#list-multiple-swagger-documents)
     * [Apply swagger-ui Parameters](#apply-swagger-ui-parameters)
     * [Inject Custom JavaScript](#inject-custom-javascript)
@@ -1251,6 +1252,19 @@ By default, the Swagger UI will have a generic document title. When you have mul
 app.UseSwaggerUI(c =>
 {
     c.DocumentTitle = "My Swagger UI";
+}
+```
+
+### Change CSS or JS Paths ###
+
+By default, the Swagger UI inclide default CSS and JS, but if you need to change path or URL (ex CDN):
+
+```csharp
+app.UseSwaggerUI(c =>
+{
+    c.StylesPath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.10/swagger-ui.min.css";
+    c.ScriptBundlePath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.10/swagger-ui-bundle.min.js";
+    c.ScriptPresetsPath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.10/swagger-ui-standalone-preset.min.js";
 }
 ```
 

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -163,9 +163,9 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
             {
                 { "%(DocumentTitle)", _options.DocumentTitle },
                 { "%(HeadContent)", _options.HeadContent },
-                { "%(PathCss)", _options.PathCss },
-                { "%(PathBundleJs)", _options.PathBundleJs },
-                { "%(PathStandaloneJs)", _options.PathStandaloneJs },
+                { "%(PathCss)", _options.StylesPath },
+                { "%(PathBundleJs)", _options.ScriptBundlePath },
+                { "%(PathStandaloneJs)", _options.ScriptPresetsPath },
                 { "%(ConfigObject)", configObject },
                 { "%(OAuthConfigObject)", oauthConfigObject },
                 { "%(Interceptors)", interceptors },

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -163,6 +163,9 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
             {
                 { "%(DocumentTitle)", _options.DocumentTitle },
                 { "%(HeadContent)", _options.HeadContent },
+                { "%(PathCss)", _options.PathCss },
+                { "%(PathBundleJs)", _options.PathBundleJs },
+                { "%(PathStandaloneJs)", _options.PathStandaloneJs },
                 { "%(ConfigObject)", configObject },
                 { "%(OAuthConfigObject)", oauthConfigObject },
                 { "%(Interceptors)", interceptors },

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -163,9 +163,9 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
             {
                 { "%(DocumentTitle)", _options.DocumentTitle },
                 { "%(HeadContent)", _options.HeadContent },
-                { "%(PathCss)", _options.StylesPath },
-                { "%(PathBundleJs)", _options.ScriptBundlePath },
-                { "%(PathStandaloneJs)", _options.ScriptPresetsPath },
+                { "%(StylesPath)", _options.StylesPath },
+                { "%(ScriptBundlePath)", _options.ScriptBundlePath },
+                { "%(ScriptPresetsPath)", _options.ScriptPresetsPath },
                 { "%(ConfigObject)", configObject },
                 { "%(OAuthConfigObject)", oauthConfigObject },
                 { "%(Interceptors)", interceptors },

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -52,17 +52,17 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         public JsonSerializerOptions JsonSerializerOptions { get; set; }
 
         /// <summary>
-        /// Path to bundle js file.
+        /// Gets or sets the path or URL to the Swagger UI JavaScript bundle file.
         /// </summary>
         public string PathBundleJs { get; set; } = "./swagger-ui-bundle.js";
 
         /// <summary>
-        /// Path to standalone js file.
+        /// Gets or sets the path or URL to the Swagger UI JavaScript standalone presets file.
         /// </summary>
         public string PathStandaloneJs { get; set; } = "./swagger-ui-standalone-preset.js";
 
         /// <summary>
-        /// Path to css file.
+        /// Gets or sets the path or URL to the Swagger UI CSS file.
         /// </summary>
         public string PathCss { get; set; } = "./swagger-ui.css";
     }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -54,17 +54,17 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// <summary>
         /// Gets or sets the path or URL to the Swagger UI JavaScript bundle file.
         /// </summary>
-        public string PathBundleJs { get; set; } = "./swagger-ui-bundle.js";
+        public string ScriptBundlePath { get; set; } = "./swagger-ui-bundle.js";
 
         /// <summary>
         /// Gets or sets the path or URL to the Swagger UI JavaScript standalone presets file.
         /// </summary>
-        public string PathStandaloneJs { get; set; } = "./swagger-ui-standalone-preset.js";
+        public string ScriptPresetsPath { get; set; } = "./swagger-ui-standalone-preset.js";
 
         /// <summary>
         /// Gets or sets the path or URL to the Swagger UI CSS file.
         /// </summary>
-        public string PathCss { get; set; } = "./swagger-ui.css";
+        public string StylesPath { get; set; } = "./swagger-ui.css";
     }
 
     public class ConfigObject

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -50,6 +50,21 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// Gets or sets the optional JSON serialization options to use to serialize options to the HTML document.
         /// </summary>
         public JsonSerializerOptions JsonSerializerOptions { get; set; }
+
+        /// <summary>
+        /// Path to bundle js file.
+        /// </summary>
+        public string PathBundleJs { get; set; } = "./swagger-ui-bundle.js";
+
+        /// <summary>
+        /// Path to standalone js file.
+        /// </summary>
+        public string PathStandaloneJs { get; set; } = "./swagger-ui-standalone-preset.js";
+
+        /// <summary>
+        /// Path to css file.
+        /// </summary>
+        public string PathCss { get; set; } = "./swagger-ui.css";
     }
 
     public class ConfigObject

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <title>%(DocumentTitle)</title>
-    <link rel="stylesheet" type="text/css" href="./swagger-ui.css">
+    <link rel="stylesheet" type="text/css" href="%(PathCss)">
     <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
     <style>
@@ -40,8 +40,8 @@
         }
     </script>
 
-    <script src="./swagger-ui-bundle.js"></script>
-    <script src="./swagger-ui-standalone-preset.js"></script>
+    <script src="%(BundleJs)"></script>
+    <script src="%(StandaloneJs)"></script>
     <script>
         /* Source: https://gist.github.com/lamberta/3768814
          * Parse a string function definition and return a function object. Does not use eval.

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <title>%(DocumentTitle)</title>
-    <link rel="stylesheet" type="text/css" href="%(PathCss)">
+    <link rel="stylesheet" type="text/css" href="%(StylesPath)">
     <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
     <style>
@@ -40,8 +40,8 @@
         }
     </script>
 
-    <script src="%(BundleJs)"></script>
-    <script src="%(StandaloneJs)"></script>
+    <script src="%(ScriptBundlePath)"></script>
+    <script src="%(ScriptPresetsPath)"></script>
     <script>
         /* Source: https://gist.github.com/lamberta/3768814
          * Parse a string function definition and return a function object. Does not use eval.

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -90,12 +90,11 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
         }
 
         [Theory]
-        [InlineData(typeof(Basic.Startup), "/index.html", "/swagger-ui.js", "/swagger-ui.css", "/swagger-ui-bundle.js", "/swagger-ui-standalone-preset.js")]
-        [InlineData(typeof(CustomUIConfig.Startup), "/swagger/index.html", "/swagger/swagger-ui.js", "/ext/custom-stylesheet.css", "/ext/custom-javascript.js", "/ext/custom-javascript.js")]
+        [InlineData(typeof(Basic.Startup), "/index.html", "./swagger-ui.css", "./swagger-ui-bundle.js", "./swagger-ui-standalone-preset.js")]
+        [InlineData(typeof(CustomUIConfig.Startup), "/swagger/index.html", "/ext/custom-stylesheet.css", "/ext/custom-javascript.js", "/ext/custom-javascript.js")]
         public async Task IndexUrl_Returns_ExpectedAssetPaths(
             Type startupType,
             string indexPath,
-            string jsPath,
             string cssPath,
             string scriptBundlePath,
             string scriptPresetsPath)
@@ -104,50 +103,11 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
 
             var indexResponse = await client.GetAsync(indexPath);
             Assert.Equal(HttpStatusCode.OK, indexResponse.StatusCode);
-            var indexContent = await indexResponse.Content.ReadAsStringAsync();
-            Assert.Contains("SwaggerUIBundle", indexContent);
+            var content = await indexResponse.Content.ReadAsStringAsync();
 
-            var jsResponse = await client.GetAsync(jsPath);
-            Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
-
-            var cssResponse = await client.GetAsync(cssPath);
-            Assert.Equal(HttpStatusCode.OK, cssResponse.StatusCode);
-
-            var scriptBundleResponse = await client.GetAsync(scriptBundlePath);
-            Assert.Equal(HttpStatusCode.OK, scriptBundleResponse.StatusCode);
-
-            var scriptPresetsResponse = await client.GetAsync(scriptPresetsPath);
-            Assert.Equal(HttpStatusCode.OK, scriptPresetsResponse.StatusCode);
-        }
-
-        [Theory]
-        [InlineData(typeof(CustomUIConfig.Startup), "/swagger/index.html", "/swagger/swagger-ui.js", "/ext/custom-stylesheet-2.css", "/ext/custom-javascript-2.js", "/ext/custom-javascript-2.js")]
-        public async Task IndexUrl_ReturnsCustomScripts_NotFound(
-            Type startupType,
-            string indexPath,
-            string jsPath,
-            string cssPath,
-            string scriptBundlePath,
-            string scriptPresetsPath)
-        {
-            var client = new TestSite(startupType).BuildClient();
-
-            var indexResponse = await client.GetAsync(indexPath);
-            Assert.Equal(HttpStatusCode.OK, indexResponse.StatusCode);
-            var indexContent = await indexResponse.Content.ReadAsStringAsync();
-            Assert.Contains("SwaggerUIBundle", indexContent);
-
-            var jsResponse = await client.GetAsync(jsPath);
-            Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
-
-            var cssResponse = await client.GetAsync(cssPath);
-            Assert.Equal(HttpStatusCode.NotFound, cssResponse.StatusCode);
-
-            var scriptBundleResponse = await client.GetAsync(scriptBundlePath);
-            Assert.Equal(HttpStatusCode.NotFound, scriptBundleResponse.StatusCode);
-
-            var scriptPresetsResponse = await client.GetAsync(scriptPresetsPath);
-            Assert.Equal(HttpStatusCode.NotFound, scriptPresetsResponse.StatusCode);
+            Assert.Contains($"<link rel=\"stylesheet\" type=\"text/css\" href=\"{cssPath}\">", content);
+            Assert.Contains($"<script src=\"{scriptBundlePath}\">", content);
+            Assert.Contains($"<script src=\"{scriptPresetsPath}\">", content);
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -92,7 +92,7 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
         [Theory]
         [InlineData(typeof(Basic.Startup), "/index.html", "/swagger-ui.js", "/swagger-ui.css", "/swagger-ui-bundle.js", "/swagger-ui-standalone-preset.js")]
         [InlineData(typeof(CustomUIConfig.Startup), "/swagger/index.html", "/swagger/swagger-ui.js", "/ext/custom-stylesheet.css", "/ext/custom-javascript.js", "/ext/custom-javascript.js")]
-        public async Task IndexUrl_ReturnsCustomScripts(
+        public async Task IndexUrl_Returns_ExpectedAssetPaths(
             Type startupType,
             string indexPath,
             string jsPath,

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -88,5 +88,66 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
                 Assert.Contains(version, content);
             }
         }
+
+        [Theory]
+        [InlineData(typeof(Basic.Startup), "/index.html", "/swagger-ui.js", "/swagger-ui.css", "/swagger-ui-bundle.js", "/swagger-ui-standalone-preset.js")]
+        [InlineData(typeof(CustomUIConfig.Startup), "/swagger/index.html", "/swagger/swagger-ui.js", "/ext/custom-stylesheet.css", "/ext/custom-javascript.js", "/ext/custom-javascript.js")]
+        public async Task IndexUrl_ReturnsCustomScripts(
+            Type startupType,
+            string indexPath,
+            string jsPath,
+            string cssPath,
+            string scriptBundlePath,
+            string scriptPresetsPath)
+        {
+            var client = new TestSite(startupType).BuildClient();
+
+            var indexResponse = await client.GetAsync(indexPath);
+            Assert.Equal(HttpStatusCode.OK, indexResponse.StatusCode);
+            var indexContent = await indexResponse.Content.ReadAsStringAsync();
+            Assert.Contains("SwaggerUIBundle", indexContent);
+
+            var jsResponse = await client.GetAsync(jsPath);
+            Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
+
+            var cssResponse = await client.GetAsync(cssPath);
+            Assert.Equal(HttpStatusCode.OK, cssResponse.StatusCode);
+
+            var scriptBundleResponse = await client.GetAsync(scriptBundlePath);
+            Assert.Equal(HttpStatusCode.OK, scriptBundleResponse.StatusCode);
+
+            var scriptPresetsResponse = await client.GetAsync(scriptPresetsPath);
+            Assert.Equal(HttpStatusCode.OK, scriptPresetsResponse.StatusCode);
+        }
+
+        [Theory]
+        [InlineData(typeof(CustomUIConfig.Startup), "/swagger/index.html", "/swagger/swagger-ui.js", "/ext/custom-stylesheet-2.css", "/ext/custom-javascript-2.js", "/ext/custom-javascript-2.js")]
+        public async Task IndexUrl_ReturnsCustomScripts_NotFound(
+            Type startupType,
+            string indexPath,
+            string jsPath,
+            string cssPath,
+            string scriptBundlePath,
+            string scriptPresetsPath)
+        {
+            var client = new TestSite(startupType).BuildClient();
+
+            var indexResponse = await client.GetAsync(indexPath);
+            Assert.Equal(HttpStatusCode.OK, indexResponse.StatusCode);
+            var indexContent = await indexResponse.Content.ReadAsStringAsync();
+            Assert.Contains("SwaggerUIBundle", indexContent);
+
+            var jsResponse = await client.GetAsync(jsPath);
+            Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
+
+            var cssResponse = await client.GetAsync(cssPath);
+            Assert.Equal(HttpStatusCode.NotFound, cssResponse.StatusCode);
+
+            var scriptBundleResponse = await client.GetAsync(scriptBundlePath);
+            Assert.Equal(HttpStatusCode.NotFound, scriptBundleResponse.StatusCode);
+
+            var scriptPresetsResponse = await client.GetAsync(scriptPresetsPath);
+            Assert.Equal(HttpStatusCode.NotFound, scriptPresetsResponse.StatusCode);
+        }
     }
 }

--- a/test/WebSites/CustomUIConfig/Startup.cs
+++ b/test/WebSites/CustomUIConfig/Startup.cs
@@ -70,6 +70,9 @@ namespace CustomUIConfig
 
                 // Other
                 c.DocumentTitle = "CustomUIConfig";
+                c.StylesPath = "/ext/custom-stylesheet.css";
+                c.ScriptBundlePath = "/ext/custom-javascript.js";
+                c.ScriptPresetsPath = "/ext/custom-javascript.js";
                 c.InjectStylesheet("/ext/custom-stylesheet.css");
                 c.InjectJavascript("/ext/custom-javascript.js");
                 c.UseRequestInterceptor("(req) => { req.headers['x-my-custom-header'] = 'MyCustomValue'; return req; }");


### PR DESCRIPTION
Move CSS and JS to parameters, for available to use CDN or custom URL.
