### PR TITLE
Adding check for existing directory and creating if doesn't exist

### DIFF
--- a/src/Swashbuckle.AspNetCore.Cli/Program.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/Program.cs
@@ -101,6 +101,15 @@ namespace Swashbuckle.AspNetCore.Cli
                         ? Path.Combine(Directory.GetCurrentDirectory(), arg1)
                         : null;
 
+                    if (!string.IsNullOrEmpty(outputPath))
+                    {
+                        string directoryPath = Path.GetDirectoryName(filePath);
+                        if (!string.IsNullOrEmpty(directoryPath) && !Directory.Exists(directoryPath))
+                        {
+                            Directory.CreateDirectory(directoryPath);
+                        }
+                    }
+
                     using (Stream stream = outputPath != null ? File.Create(outputPath) : Console.OpenStandardOutput())
                     using (var streamWriter = new FormattingStreamWriter(stream, CultureInfo.InvariantCulture))
                     {

--- a/src/Swashbuckle.AspNetCore.Cli/Program.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/Program.cs
@@ -103,7 +103,7 @@ namespace Swashbuckle.AspNetCore.Cli
 
                     if (!string.IsNullOrEmpty(outputPath))
                     {
-                        string directoryPath = Path.GetDirectoryName(filePath);
+                        string directoryPath = Path.GetDirectoryName(outputPath);
                         if (!string.IsNullOrEmpty(directoryPath) && !Directory.Exists(directoryPath))
                         {
                             Directory.CreateDirectory(directoryPath);

--- a/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
+++ b/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text;
 using System.Text.Json;
 using Swashbuckle.AspNetCore.TestSupport.Utilities;
 using Xunit;
@@ -131,10 +132,32 @@ namespace Swashbuckle.AspNetCore.Cli.Test
             Assert.True(path.TryGetProperty("get", out _));
         }
 
-        private static JsonDocument RunApplication(Func<string, string[]> setup)
+        [Fact]
+        public static void Creates_New_Folder_Path()
+        {
+            using var document = RunApplication(outputPath =>
+            [
+                "tofile",
+                "--output",
+                outputPath,
+                "--serializeasv2",
+                Path.Combine(Directory.GetCurrentDirectory(), "Basic.dll"),
+                "v1"
+            ], GenerateRandomString(5));
+
+            // verify one of the endpoints
+            var paths = document.RootElement.GetProperty("paths");
+            var productsPath = paths.GetProperty("/products");
+            Assert.True(productsPath.TryGetProperty("post", out _));
+        }
+
+        private static JsonDocument RunApplication(Func<string, string[]> setup, string subOutputPath = default)
         {
             using var temporaryDirectory = new TemporaryDirectory();
-            string outputPath = Path.Combine(temporaryDirectory.Path, "swagger.json");
+
+            var outputPath = !string.IsNullOrEmpty(subOutputPath)
+                ? Path.Combine(temporaryDirectory.Path, subOutputPath, "swagger.json")
+                : Path.Combine(temporaryDirectory.Path, "swagger.json");
 
             string[] args = setup(outputPath);
 
@@ -143,5 +166,20 @@ namespace Swashbuckle.AspNetCore.Cli.Test
             string json = File.ReadAllText(outputPath);
             return JsonDocument.Parse(json);
         }
+
+        private static string GenerateRandomString(int length)
+        {
+            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+            StringBuilder result = new StringBuilder(length);
+            Random random = new Random();
+
+            for (int i = 0; i < length; i++)
+            {
+                result.Append(chars[random.Next(chars.Length)]);
+            }
+
+            return result.ToString();
+        }
+
     }
 }

--- a/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
+++ b/test/Swashbuckle.AspNetCore.Cli.Test/ToolTests.cs
@@ -169,13 +169,12 @@ namespace Swashbuckle.AspNetCore.Cli.Test
 
         private static string GenerateRandomString(int length)
         {
-            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-            StringBuilder result = new StringBuilder(length);
-            Random random = new Random();
+            const string Choices = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+            var result = new StringBuilder(length);
 
             for (int i = 0; i < length; i++)
             {
-                result.Append(chars[random.Next(chars.Length)]);
+                result.Append(Choices[Random.Shared.Next(Choices.Length)]);
             }
 
             return result.ToString();


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

Fixes #2352

## Details on the issue fix or feature implementation

Checks if output directory exists. If it doesn't then it creates before trying to write to the file
