### PR TITLE
Add posibility to Ignore properties in FromForm Request with SwaggerIgnore attribute

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -548,7 +548,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     : formParameter.Name;
 
                 var propertyInfo = formParameter.PropertyInfo();
-                if (formParameter.ModelMetadata != null && (!propertyInfo?.HasAttribute<SwaggerIgnoreAttribute>() ?? true))
+                if (!propertyInfo?.HasAttribute<SwaggerIgnoreAttribute>() ?? true)
                 {
                     var schema = (formParameter.ModelMetadata != null)
                     ? GenerateSchema(

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -547,18 +547,22 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     ? formParameter.Name.ToCamelCase()
                     : formParameter.Name;
 
-                var schema = (formParameter.ModelMetadata != null)
+                var propertyInfo = formParameter.PropertyInfo();
+                if (formParameter.ModelMetadata != null && (!propertyInfo?.HasAttribute<SwaggerIgnoreAttribute>() ?? true))
+                {
+                    var schema = (formParameter.ModelMetadata != null)
                     ? GenerateSchema(
                         formParameter.ModelMetadata.ModelType,
                         schemaRepository,
-                        formParameter.PropertyInfo(),
+                        propertyInfo,
                         formParameter.ParameterInfo())
                     : new OpenApiSchema { Type = "string" };
 
-                properties.Add(name, schema);
+                    properties.Add(name, schema);
 
-                if (formParameter.IsRequiredParameter())
-                    requiredPropertyNames.Add(name);
+                    if (formParameter.IsRequiredParameter())
+                        requiredPropertyNames.Add(name);
+                }
             }
 
             return new OpenApiSchema

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeController.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Swashbuckle.AspNetCore.Annotations;
+using Swashbuckle.AspNetCore.SwaggerGen.Test.Fixtures;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
@@ -27,28 +28,28 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void ActionWithObsoleteAttribute()
         { }
 
-        public void ActionWithParameterWithBindNeverAttribute([BindNever]string param)
+        public void ActionWithParameterWithBindNeverAttribute([BindNever] string param)
         { }
 
-        public void ActionWithParameterWithRequiredAttribute([Required]string param)
+        public void ActionWithParameterWithRequiredAttribute([Required] string param)
         { }
 
-        public void ActionWithParameterWithBindRequiredAttribute([BindRequired]string param)
+        public void ActionWithParameterWithBindRequiredAttribute([BindRequired] string param)
         { }
 
         public void ActionWithIntParameter(int param)
         { }
 
-        public void ActionWithIntParameterWithRangeAttribute([Range(1, 12)]int param)
+        public void ActionWithIntParameterWithRangeAttribute([Range(1, 12)] int param)
         { }
 
         public void ActionWithIntParameterWithDefaultValue(int param = 1)
         { }
 
-        public void ActionWithIntParameterWithDefaultValueAttribute([DefaultValue(3)]int param)
+        public void ActionWithIntParameterWithDefaultValueAttribute([DefaultValue(3)] int param)
         { }
 
-        public void ActionWithIntParameterWithRequiredAttribute([Required]int param)
+        public void ActionWithIntParameterWithRequiredAttribute([Required] int param)
         { }
 
         public void ActionWithIntParameterWithSwaggerIgnoreAttribute([SwaggerIgnore] int param)
@@ -101,10 +102,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void ActionWithSwaggerIgnoreAttribute()
         { }
 
-        public void ActionHavingIFormFileParamWithFromFormAtribute([FromForm] IFormFile fileUpload)
+        public void ActionHavingIFormFileParamWithFromFormAttribute([FromForm] IFormFile fileUpload)
         { }
 
-        public void ActionHavingFromFormAtributeButNotWithIFormFile([FromForm] string param1, IFormFile param2)
+        public void ActionHavingFromFormAttributeButNotWithIFormFile([FromForm] string param1, IFormFile param2)
+        { }
+        public void ActionHavingFromFormAttributeWithSwaggerIgnore([FromForm] SwaggerIngoreAnnotatedType param1)
         { }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeICompositeMetadataDetailsProvider.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeICompositeMetadataDetailsProvider.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test.Fixtures
+{
+    internal class FakeICompositeMetadataDetailsProvider : ICompositeMetadataDetailsProvider
+    {
+        public void CreateBindingMetadata(BindingMetadataProviderContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CreateDisplayMetadata(DisplayMetadataProviderContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CreateValidationMetadata(ValidationMetadataProviderContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/WebSites/Basic/Controllers/FromFormParamsController.cs
+++ b/test/WebSites/Basic/Controllers/FromFormParamsController.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace Basic.Controllers
 {
@@ -7,7 +8,13 @@ namespace Basic.Controllers
     {
         [HttpPost("registrations")]
         [Consumes("application/x-www-form-urlencoded")]
-        public IActionResult PostForm([FromForm]RegistrationForm form)
+        public IActionResult PostForm([FromForm] RegistrationForm form)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        [HttpPost("registrationsWithIgnoreProperties")]
+        public IActionResult PostFormWithIgnoredProperties([FromForm] RegistrationFormWithIgnoredProperties form)
         {
             throw new System.NotImplementedException();
         }
@@ -15,6 +22,14 @@ namespace Basic.Controllers
 
     public class RegistrationForm
     {
+        public string Name { get; set; }
+
+        public IEnumerable<int> PhoneNumbers { get; set; }
+    }
+
+    public class RegistrationFormWithIgnoredProperties
+    {
+        [SwaggerIgnore, FromForm(Name = "internal_Name")]
         public string Name { get; set; }
 
         public IEnumerable<int> PhoneNumbers { get; set; }


### PR DESCRIPTION
# Ignore Properties in FromForm requests

This PR fixes #2919.

In the PR #2610, the project added the SwaggerIgnore attribute, which can ignore Methods from being populated into OpenApi doc or just properties of an object. But it did not added the possibility when the object is one that comes from a FromForm request so I am adding it in this PR

Since this is my first contribution, I am not sure if I have to do a UnitTest to test this behaviour, but in the Basic sample app I inserted a new Endpoint, that you can see the Swagger to see what this PR is addressing.
