### PR TITLE
Update SchemaGenerator to fix #2514 and #2052 (Rebased)

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -174,6 +174,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             knownTypesDataContracts = null;
 
             if (dataContract.DataType != DataType.Object) return false;
+            if (dataContract.UnderlyingType.IsAssignableToOneOf(BinaryStringTypes)) return false;
 
             var subTypes = _generatorOptions.SubTypesSelector(dataContract.UnderlyingType);
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -387,21 +387,18 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                         .Where(dataProperty => dataProperty.MemberInfo.DeclaringType == dataContract.UnderlyingType);
                 }
 
-                if (_generatorOptions.UseOneOfForPolymorphism)
+                if (IsBaseTypeWithKnownTypesDefined(dataContract, out var knownTypesDataContracts))
                 {
-                    if (IsBaseTypeWithKnownTypesDefined(dataContract, out var knownTypesDataContracts))
+                    foreach (var knownTypeDataContract in knownTypesDataContracts)
                     {
-                        foreach(var knownTypeDataContract in knownTypesDataContracts)
-                        {
-                            // Ensure schema is generated for all known types
-                            GenerateConcreteSchema(knownTypeDataContract, schemaRepository);
-                        }
+                        // Ensure schema is generated for all known types
+                        GenerateConcreteSchema(knownTypeDataContract, schemaRepository);
+                    }
 
-                        if (TryGetDiscriminatorFor(dataContract, schemaRepository, knownTypesDataContracts, out var discriminator))
-                        {
-                            schema.Properties.Add(discriminator.PropertyName, new OpenApiSchema { Type = "string" });
-                            schema.Required.Add(discriminator.PropertyName);
-                        }
+                    if (TryGetDiscriminatorFor(dataContract, schemaRepository, knownTypesDataContracts, out var discriminator))
+                    {
+                        schema.Properties.Add(discriminator.PropertyName, new OpenApiSchema { Type = "string" });
+                        schema.Required.Add(discriminator.PropertyName);
                     }
                 }
             }

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -480,7 +480,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 
             var schemaRepository = new SchemaRepository();
 
-            var referenceSchema = subject.GenerateSchema(typeof(BaseType), schemaRepository);
+            var referenceSchema = subject.GenerateSchema(typeof(ConsumingType), schemaRepository);
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
             Assert.Contains("TypeName", schema.Properties.Keys);

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/BaseType.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/BaseType.cs
@@ -1,5 +1,10 @@
 ﻿namespace Swashbuckle.AspNetCore.TestSupport
 {
+    public class ConsumingType
+    {
+        public BaseType ConsumingProperty { get; set; }
+    }
+
     public class BaseType
     {
         public string BaseProperty { get; set; }

--- a/test/WebSites/NswagClientExample/swagger_net6.0.json
+++ b/test/WebSites/NswagClientExample/swagger_net6.0.json
@@ -29,7 +29,14 @@
                   {
                     "$ref": "#/components/schemas/Dog"
                   }
-                ]
+                ],
+                "discriminator": {
+                  "propertyName": "animalType",
+                  "mapping": {
+                    "Cat": "#/components/schemas/Cat",
+                    "Dog": "#/components/schemas/Dog"
+                  }
+                }
               }
             },
             "text/json": {
@@ -44,7 +51,14 @@
                   {
                     "$ref": "#/components/schemas/Dog"
                   }
-                ]
+                ],
+                "discriminator": {
+                  "propertyName": "animalType",
+                  "mapping": {
+                    "Cat": "#/components/schemas/Cat",
+                    "Dog": "#/components/schemas/Dog"
+                  }
+                }
               }
             },
             "application/*+json": {
@@ -59,7 +73,14 @@
                   {
                     "$ref": "#/components/schemas/Dog"
                   }
-                ]
+                ],
+                "discriminator": {
+                  "propertyName": "animalType",
+                  "mapping": {
+                    "Cat": "#/components/schemas/Cat",
+                    "Dog": "#/components/schemas/Dog"
+                  }
+                }
               }
             }
           },
@@ -85,14 +106,7 @@
             "$ref": "#/components/schemas/AnimalType"
           }
         },
-        "additionalProperties": false,
-        "discriminator": {
-          "propertyName": "animalType",
-          "mapping": {
-            "Cat": "#/components/schemas/Cat",
-            "Dog": "#/components/schemas/Dog"
-          }
-        }
+        "additionalProperties": false
       },
       "AnimalType": {
         "enum": [

--- a/test/WebSites/NswagClientExample/swagger_net8.0.json
+++ b/test/WebSites/NswagClientExample/swagger_net8.0.json
@@ -29,7 +29,14 @@
                   {
                     "$ref": "#/components/schemas/Dog"
                   }
-                ]
+                ],
+                "discriminator": {
+                  "propertyName": "animalType",
+                  "mapping": {
+                    "Cat": "#/components/schemas/Cat",
+                    "Dog": "#/components/schemas/Dog"
+                  }
+                }
               }
             },
             "text/json": {
@@ -44,7 +51,14 @@
                   {
                     "$ref": "#/components/schemas/Dog"
                   }
-                ]
+                ],
+                "discriminator": {
+                  "propertyName": "animalType",
+                  "mapping": {
+                    "Cat": "#/components/schemas/Cat",
+                    "Dog": "#/components/schemas/Dog"
+                  }
+                }
               }
             },
             "application/*+json": {
@@ -59,7 +73,14 @@
                   {
                     "$ref": "#/components/schemas/Dog"
                   }
-                ]
+                ],
+                "discriminator": {
+                  "propertyName": "animalType",
+                  "mapping": {
+                    "Cat": "#/components/schemas/Cat",
+                    "Dog": "#/components/schemas/Dog"
+                  }
+                }
               }
             }
           },
@@ -85,14 +106,7 @@
             "$ref": "#/components/schemas/AnimalType"
           }
         },
-        "additionalProperties": false,
-        "discriminator": {
-          "propertyName": "animalType",
-          "mapping": {
-            "Cat": "#/components/schemas/Cat",
-            "Dog": "#/components/schemas/Dog"
-          }
-        }
+        "additionalProperties": false
       },
       "AnimalType": {
         "enum": [


### PR DESCRIPTION
Rebases #2683

## The issue or feature being addressed
#2052 #2514
<!-- Please include the existing GitHub issue number where relevant, e.g. "Fixes #123" -->

## Details on the issue fix or feature implementation

> This pull request fixes (reverts) the placement of the discriminator to the polymorphic oneOf element. Fixes https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2052.
>
> This pull request also fixes https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2514 and the bug where enabling UseOneOfForPolymorphism forces UseAllOfForInheritance=true (when UseAllOfForInheritance=false).