### PR TITLE
Swagger UI refactoring

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNetCore.Builder
             if (options.ConfigObject.Urls == null)
             {
                 var hostingEnv = app.ApplicationServices.GetRequiredService<IWebHostEnvironment>();
-                options.ConfigObject.Urls = new[] { new UrlDescriptor { Name = $"{hostingEnv.ApplicationName} v1", Url = "v1/swagger.json" } };
+                options.ConfigObject.Urls = [new UrlDescriptor { Name = $"{hostingEnv.ApplicationName} v1", Url = "v1/swagger.json" }];
             }
 
             return app.UseSwaggerUI(options);

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -198,8 +198,10 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
 
     public class UrlDescriptor
     {
+        [JsonPropertyName("url")]
         public string Url { get; set; }
 
+        [JsonPropertyName("name")]
         public string Name { get; set; }
     }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -72,30 +72,37 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// <summary>
         /// One or more Swagger JSON endpoints (url and name) to power the UI
         /// </summary>
+        [JsonPropertyName("urls")]
         public IEnumerable<UrlDescriptor> Urls { get; set; } = null;
 
         /// <summary>
         /// If set to true, enables deep linking for tags and operations
         /// </summary>
+        [JsonPropertyName("deepLinking")]
         public bool DeepLinking { get; set; } = false;
+
         /// <summary>
         /// If set to true, it persists authorization data and it would not be lost on browser close/refresh
         /// </summary>
+        [JsonPropertyName("persistAuthorization")]
         public bool PersistAuthorization { get; set; } = false;
 
         /// <summary>
         /// Controls the display of operationId in operations list
         /// </summary>
+        [JsonPropertyName("displayOperationId")]
         public bool DisplayOperationId { get; set; } = false;
 
         /// <summary>
         /// The default expansion depth for models (set to -1 completely hide the models)
         /// </summary>
+        [JsonPropertyName("defaultModelsExpandDepth")]
         public int DefaultModelsExpandDepth { get; set; } = 1;
 
         /// <summary>
         /// The default expansion depth for the model on the model-example section
         /// </summary>
+        [JsonPropertyName("defaultModelExpandDepth")]
         public int DefaultModelExpandDepth { get; set; } = 1;
 
         /// <summary>
@@ -105,11 +112,13 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
 #if NET6_0_OR_GREATER
         [JsonConverter(typeof(JavascriptStringEnumConverter<ModelRendering>))]
 #endif
+        [JsonPropertyName("defaultModelRendering")]
         public ModelRendering DefaultModelRendering { get; set; } = ModelRendering.Example;
 
         /// <summary>
         /// Controls the display of the request duration (in milliseconds) for Try-It-Out requests
         /// </summary>
+        [JsonPropertyName("displayRequestDuration")]
         public bool DisplayRequestDuration { get; set; } = false;
 
         /// <summary>
@@ -119,6 +128,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
 #if NET6_0_OR_GREATER
         [JsonConverter(typeof(JavascriptStringEnumConverter<DocExpansion>))]
 #endif
+        [JsonPropertyName("docExpansion")]
         public DocExpansion DocExpansion { get; set; } = DocExpansion.List;
 
         /// <summary>
@@ -126,21 +136,25 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// that are shown. Can be an empty string or specific value, in which case filtering will be enabled using that
         /// value as the filter expression. Filtering is case sensitive matching the filter expression anywhere inside the tag
         /// </summary>
+        [JsonPropertyName("filter")]
         public string Filter { get; set; } = null;
 
         /// <summary>
         /// If set, limits the number of tagged operations displayed to at most this many. The default is to show all operations
         /// </summary>
+        [JsonPropertyName("maxDisplayedTags")]
         public int? MaxDisplayedTags { get; set; } = null;
 
         /// <summary>
         /// Controls the display of vendor extension (x-) fields and values for Operations, Parameters, and Schema
         /// </summary>
+        [JsonPropertyName("showExtensions")]
         public bool ShowExtensions { get; set; } = false;
 
         /// <summary>
         /// Controls the display of extensions (pattern, maxLength, minLength, maximum, minimum) fields and values for Parameters
         /// </summary>
+        [JsonPropertyName("showCommonExtensions")]
         public bool ShowCommonExtensions { get; set; } = false;
 
         /// <summary>
@@ -156,6 +170,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
 #if NET6_0_OR_GREATER
         [JsonConverter(typeof(JavascriptStringEnumEnumerableConverter<SubmitMethod>))]
 #endif
+        [JsonPropertyName("supportedSubmitMethods")]
         public IEnumerable<SubmitMethod> SupportedSubmitMethods { get; set; } =
 #if NET5_0_OR_GREATER
             Enum.GetValues<SubmitMethod>();
@@ -174,6 +189,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// You can use this parameter to set a different validator URL, for example for locally deployed validators (Validator Badge).
         /// Setting it to null will disable validation
         /// </summary>
+        [JsonPropertyName("validatorUrl")]
         public string ValidatorUrl { get; set; } = null;
 
         [JsonExtensionData]
@@ -222,37 +238,44 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// <summary>
         /// Default clientId
         /// </summary>
+        [JsonPropertyName("clientId")]
         public string ClientId { get; set; } = null;
 
         /// <summary>
         /// Default clientSecret
         /// </summary>
         /// <remarks>Setting this exposes the client secrets in inline javascript in the swagger-ui generated html.</remarks>
+        [JsonPropertyName("clientSecret")]
         public string ClientSecret { get; set; } = null;
 
         /// <summary>
         /// Realm query parameter (for oauth1) added to authorizationUrl and tokenUrl
         /// </summary>
+        [JsonPropertyName("realm")]
         public string Realm { get; set; } = null;
 
         /// <summary>
         /// Application name, displayed in authorization popup
         /// </summary>
+        [JsonPropertyName("appName")]
         public string AppName { get; set; } = null;
 
         /// <summary>
         /// Scope separator for passing scopes, encoded before calling, default value is a space (encoded value %20)
         /// </summary>
+        [JsonPropertyName("scopeSeparator")]
         public string ScopeSeparator { get; set; } = " ";
 
         /// <summary>
         /// String array of initially selected oauth scopes, default is empty array
         /// </summary>
+        [JsonPropertyName("scopes")]
         public IEnumerable<string> Scopes { get; set; } = [];
 
         /// <summary>
         /// Additional query parameters added to authorizationUrl and tokenUrl
         /// </summary>
+        [JsonPropertyName("additionalQueryStringParams")]
         public Dictionary<string, string> AdditionalQueryStringParams { get; set; } = null;
 
         /// <summary>
@@ -260,12 +283,14 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// pass the Client Password using the HTTP Basic Authentication scheme
         /// (Authorization header with Basic base64encode(client_id + client_secret))
         /// </summary>
+        [JsonPropertyName("useBasicAuthenticationWithAccessCodeGrant")]
         public bool UseBasicAuthenticationWithAccessCodeGrant { get; set; } = false;
 
         /// <summary>
         /// Only applies to authorizatonCode flows. Proof Key for Code Exchange brings enhanced security for OAuth public clients.
         /// The default is false
         /// </summary>
+        [JsonPropertyName("usePkceWithAuthorizationCodeGrant")]
         public bool UsePkceWithAuthorizationCodeGrant { get; set; } = false;
     }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptionsExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Text;
-using System.Linq;
 using System.Collections.Generic;
+using System.Text;
 using Swashbuckle.AspNetCore.SwaggerUI;
 
 namespace Microsoft.AspNetCore.Builder
@@ -42,8 +41,10 @@ namespace Microsoft.AspNetCore.Builder
         /// <param name="name">The description that appears in the document selector drop-down</param>
         public static void SwaggerEndpoint(this SwaggerUIOptions options, string url, string name)
         {
-            var urls = new List<UrlDescriptor>(options.ConfigObject.Urls ?? Enumerable.Empty<UrlDescriptor>());
-            urls.Add(new UrlDescriptor { Url = url, Name = name });
+            var urls = new List<UrlDescriptor>(options.ConfigObject.Urls ?? [])
+            {
+                new() { Url = url, Name = name }
+            };
             options.ConfigObject.Urls = urls;
         }
 

--- a/test/WebSites/OAuth2Integration/AuthServer/Config.cs
+++ b/test/WebSites/OAuth2Integration/AuthServer/Config.cs
@@ -13,17 +13,19 @@ namespace OAuth2Integration.AuthServer
                 ClientId = "test-id",
                 ClientName = "Test client (Code with PKCE)",
 
-                RedirectUris = new[] {
+                RedirectUris =
+                [
                     "http://localhost:55202/resource-server/swagger/oauth2-redirect.html", // IIS Express
-                    "http://localhost:5000/resource-server/swagger/oauth2-redirect.html", // Kestrel
-                },
+                    "http://localhost:5000/resource-server/swagger/oauth2-redirect.html", // Kestrel (HTTP)
+                    "https://localhost:5001/resource-server/swagger/oauth2-redirect.html", // Kestrel (HTTPS)
+                ],
 
                 ClientSecrets = { new Secret("test-secret".Sha256()) },
                 RequireConsent = true,
 
                 AllowedGrantTypes = GrantTypes.Code,
                 RequirePkce = true,
-                AllowedScopes = new[] { "readAccess", "writeAccess" },
+                AllowedScopes = ["readAccess", "writeAccess"],
             };
         }
 
@@ -33,25 +35,25 @@ namespace OAuth2Integration.AuthServer
             {
                 Name = "api",
                 DisplayName = "API",
-                Scopes = new[]
-                {
+                Scopes =
+                [
                     new Scope("readAccess", "Access read operations"),
                     new Scope("writeAccess", "Access write operations")
-                }
+                ]
             };
         }
 
         internal static List<TestUser> TestUsers()
         {
-            return new List<TestUser>
-            {
+            return
+            [
                 new TestUser
                 {
                     SubjectId = "joebloggs",
                     Username = "joebloggs",
                     Password = "pass123"
                 }
-            };
+            ];
         }
     }
 }

--- a/test/WebSites/OAuth2Integration/AuthServer/Controllers/ConsentController.cs
+++ b/test/WebSites/OAuth2Integration/AuthServer/Controllers/ConsentController.cs
@@ -1,10 +1,10 @@
-﻿using System.Threading.Tasks;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNetCore.Mvc;
-using IdentityServer4.Stores;
-using IdentityServer4.Services;
+using System.Threading.Tasks;
 using IdentityServer4.Models;
+using IdentityServer4.Services;
+using IdentityServer4.Stores;
+using Microsoft.AspNetCore.Mvc;
 
 namespace OAuth2Integration.AuthServer.Controllers
 {

--- a/test/WebSites/OAuth2Integration/Program.cs
+++ b/test/WebSites/OAuth2Integration/Program.cs
@@ -1,11 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace OAuth2Integration
 {

--- a/test/WebSites/OAuth2Integration/Properties/launchSettings.json
+++ b/test/WebSites/OAuth2Integration/Properties/launchSettings.json
@@ -1,13 +1,4 @@
-﻿{
-  "$schema": "http://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:55202",
-      "sslPort": 0
-    }
-  },
+{
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
@@ -21,10 +12,19 @@
       "commandName": "Project",
       "launchBrowser": true,
       "launchUrl": "resource-server/swagger",
-      "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "applicationUrl": "https://localhost:5001"
+    }
+  },
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:55202",
+      "sslPort": 0
     }
   }
 }

--- a/test/WebSites/OAuth2Integration/ResourceServer/Swagger/SecurityRequirementsOperationFilter.cs
+++ b/test/WebSites/OAuth2Integration/ResourceServer/Swagger/SecurityRequirementsOperationFilter.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Microsoft.Extensions.Options;
@@ -28,9 +27,10 @@ namespace OAuth2Integration.ResourceServer.Swagger
                 .Concat(context.MethodInfo.DeclaringType.GetCustomAttributes(true))
                 .OfType<AuthorizeAttribute>()
                 .Select(attr => attr.Policy)
+                .Where(p => p != null)
                 .Distinct();
 
-            var requiredScopes = requiredPolicies.Select(p => _authorizationOptions.GetPolicy(p))
+            var requiredScopes = requiredPolicies.Select(_authorizationOptions.GetPolicy)
                 .SelectMany(r => r.Requirements.OfType<ClaimsAuthorizationRequirement>())
                 .Where(cr => cr.ClaimType == "scope")
                 .SelectMany(r => r.AllowedValues)
@@ -47,13 +47,13 @@ namespace OAuth2Integration.ResourceServer.Swagger
                     Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "oauth2" }
                 };
 
-                operation.Security = new List<OpenApiSecurityRequirement>
-                {
+                operation.Security =
+                [
                     new OpenApiSecurityRequirement
                     {
                         [ oAuthScheme ] = requiredScopes
                     }
-                };
+                ];
             }
         }
     }

--- a/test/WebSites/OAuth2Integration/Startup.cs
+++ b/test/WebSites/OAuth2Integration/Startup.cs
@@ -1,12 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
+using OAuth2Integration.ResourceServer.Swagger;
 
 namespace OAuth2Integration
 {
@@ -31,12 +33,12 @@ namespace OAuth2Integration
 
             // The auth setup is a little nuanced because this app provides the auth-server & the resource-server
             // Use the "Cookies" scheme by default & explicitly require "Bearer" in the resource-server controllers
-            // See https://docs.microsoft.com/en-us/aspnet/core/security/authorization/limitingidentitybyscheme?tabs=aspnetcore2x
+            // See https://learn.microsoft.com/aspnet/core/security/authorization/limitingidentitybyscheme
             services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
                 .AddCookie()
                 .AddIdentityServerAuthentication(c =>
                 {
-                    c.Authority = "http://localhost:5000/auth-server/";
+                    c.Authority = "https://localhost:5001/auth-server/";
                     c.RequireHttpsMetadata = false;
                     c.ApiName = "api";
                 });
@@ -80,12 +82,12 @@ namespace OAuth2Integration
                         {
                             Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "oauth2" }
                         },
-                        new[] { "readAccess", "writeAccess" }
+                        ["readAccess", "writeAccess"]
                     }
                 });
 
                 // Assign scope requirements to operations based on AuthorizeAttribute
-                //c.OperationFilter<SecurityRequirementsOperationFilter>();
+                c.OperationFilter<SecurityRequirementsOperationFilter>();
             });
         }
 

--- a/test/WebSites/OAuth2Integration/Startup.cs
+++ b/test/WebSites/OAuth2Integration/Startup.cs
@@ -132,7 +132,7 @@ namespace OAuth2Integration
                 resourceServer.UseSwagger();
                 resourceServer.UseSwaggerUI(c =>
                 {
-                    c.SwaggerEndpoint("/resource-server/swagger/v1/swagger.json", "My%20API%20V1");
+                    c.SwaggerEndpoint("/resource-server/swagger/v1/swagger.json", "My API V1");
                     c.EnableDeepLinking();
 
                     // Additional OAuth settings (See https://github.com/swagger-api/swagger-ui/blob/v3.10.0/docs/usage/oauth2.md)

--- a/test/WebSites/OAuth2Integration/Startup.cs
+++ b/test/WebSites/OAuth2Integration/Startup.cs
@@ -130,7 +130,7 @@ namespace OAuth2Integration
                 resourceServer.UseSwagger();
                 resourceServer.UseSwaggerUI(c =>
                 {
-                    c.SwaggerEndpoint("/resource-server/swagger/v1/swagger.json", "My API V1");
+                    c.SwaggerEndpoint("/resource-server/swagger/v1/swagger.json", "My%20API%20V1");
                     c.EnableDeepLinking();
 
                     // Additional OAuth settings (See https://github.com/swagger-api/swagger-ui/blob/v3.10.0/docs/usage/oauth2.md)


### PR DESCRIPTION
Refactoring for a few things I spotted while investigating #2939:

- Add explicit `[JsonPropertyName]` attributes to the Swagger UI configuration objects to ensure we don't accidentally break things with refactoring on the C# side (property name changes etc.)
- Apply some IDE refactoring suggestions (collection expressions, redundant usings).
- Use HTTPS with Kestrel for the OAuth 2 sample.
- Fix broken operation filter for the OAuth 2 sample.
- Update old documentation URL.
