### PR TITLE
Adding support for .Net8 Model State Attributes

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
@@ -47,6 +47,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 else if (attribute is LengthAttribute lengthAttribute)
                     ApplyLengthAttribute(schema, lengthAttribute);
 
+                else if (attribute is Base64StringAttribute base64Attribute)
+                    ApplyBase64Attribute(schema);
+
 #endif
 
                 else if (attribute is RangeAttribute rangeAttribute)
@@ -169,10 +172,23 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             }
         }
 
+        private static void ApplyBase64Attribute(OpenApiSchema schema)
+        {
+            if (schema.Type == "string")
+            {
+                schema.Format = "byte";
+            }
+        }
+
 #endif
 
         private static void ApplyRangeAttribute(OpenApiSchema schema, RangeAttribute rangeAttribute)
         {
+#if NET8_0_OR_GREATER
+            schema.ExclusiveMinimum = rangeAttribute.MinimumIsExclusive;
+            schema.ExclusiveMaximum = rangeAttribute.MaximumIsExclusive;
+#endif
+
             schema.Maximum = decimal.TryParse(rangeAttribute.Maximum.ToString(), out decimal maximum)
                 ? maximum
                 : schema.Maximum;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
@@ -174,10 +174,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private static void ApplyBase64Attribute(OpenApiSchema schema)
         {
-            if (schema.Type == "string")
-            {
-                schema.Format = "byte";
-            }
+            schema.Format = "byte";
         }
 
 #endif

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
@@ -182,8 +182,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private static void ApplyRangeAttribute(OpenApiSchema schema, RangeAttribute rangeAttribute)
         {
 #if NET8_0_OR_GREATER
+
             schema.ExclusiveMinimum = rangeAttribute.MinimumIsExclusive;
             schema.ExclusiveMaximum = rangeAttribute.MaximumIsExclusive;
+
 #endif
 
             schema.Maximum = decimal.TryParse(rangeAttribute.Maximum.ToString(), out decimal maximum)

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -322,6 +322,9 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Assert.Equal(3, schema.Properties["StringWithLength"].MaxLength);
             Assert.Equal(1, schema.Properties["ArrayWithLength"].MinItems);
             Assert.Equal(3, schema.Properties["ArrayWithLength"].MaxItems);
+            Assert.Equal(true, schema.Properties["IntWithRange"].ExclusiveMinimum);
+            Assert.Equal(true, schema.Properties["IntWithRange"].ExclusiveMaximum);
+            Assert.Equal("byte", schema.Properties["StringWithBase64"].Format);
 #endif
             Assert.Equal(1, schema.Properties["IntWithRange"].Minimum);
             Assert.Equal(10, schema.Properties["IntWithRange"].Maximum);

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -325,6 +325,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Assert.Equal(true, schema.Properties["IntWithRange"].ExclusiveMinimum);
             Assert.Equal(true, schema.Properties["IntWithRange"].ExclusiveMaximum);
             Assert.Equal("byte", schema.Properties["StringWithBase64"].Format);
+            Assert.Equal("string", schema.Properties["StringWithBase64"].Type);
 #endif
             Assert.Equal(1, schema.Properties["IntWithRange"].Minimum);
             Assert.Equal(10, schema.Properties["IntWithRange"].Maximum);

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -348,6 +348,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal(true, schema.Properties["IntWithRange"].ExclusiveMinimum);
             Assert.Equal(true, schema.Properties["IntWithRange"].ExclusiveMaximum);
             Assert.Equal("byte", schema.Properties["StringWithBase64"].Format);
+            Assert.Equal("string", schema.Properties["StringWithBase64"].Type);
 #endif
             Assert.Equal(1, schema.Properties["IntWithRange"].Minimum);
             Assert.Equal(10, schema.Properties["IntWithRange"].Maximum);

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -345,6 +345,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal(3, schema.Properties["StringWithLength"].MaxLength);
             Assert.Equal(1, schema.Properties["ArrayWithLength"].MinItems);
             Assert.Equal(3, schema.Properties["ArrayWithLength"].MaxItems);
+            Assert.Equal(true, schema.Properties["IntWithRange"].ExclusiveMinimum);
+            Assert.Equal(true, schema.Properties["IntWithRange"].ExclusiveMaximum);
+            Assert.Equal("byte", schema.Properties["StringWithBase64"].Format);
 #endif
             Assert.Equal(1, schema.Properties["IntWithRange"].Minimum);
             Assert.Equal(10, schema.Properties["IntWithRange"].Maximum);

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributes.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributes.cs
@@ -24,12 +24,13 @@ namespace Swashbuckle.AspNetCore.TestSupport
         public int IntWithRange { get; set; }
         [Base64String]
         public string StringWithBase64 { get; set; }
+
 #else
+
         [Range(1, 10)]
         public int IntWithRange { get; set; }
+
 #endif
-
-
 
         [RegularExpression("^[3-6]?\\d{12,15}$")]
         public string StringWithRegularExpression { get; set; }

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributes.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributes.cs
@@ -20,11 +20,16 @@ namespace Swashbuckle.AspNetCore.TestSupport
 
         [Length(1, 3)]
         public string[] ArrayWithLength { get; set; }
-
-#endif
-
+        [Range(1, 10, MinimumIsExclusive = true, MaximumIsExclusive = true)]
+        public int IntWithRange { get; set; }
+        [Base64String]
+        public string StringWithBase64 { get; set; }
+#else
         [Range(1, 10)]
         public int IntWithRange { get; set; }
+#endif
+
+
 
         [RegularExpression("^[3-6]?\\d{12,15}$")]
         public string StringWithRegularExpression { get; set; }

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributes.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributes.cs
@@ -20,8 +20,10 @@ namespace Swashbuckle.AspNetCore.TestSupport
 
         [Length(1, 3)]
         public string[] ArrayWithLength { get; set; }
+
         [Range(1, 10, MinimumIsExclusive = true, MaximumIsExclusive = true)]
         public int IntWithRange { get; set; }
+
         [Base64String]
         public string StringWithBase64 { get; set; }
 

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributesViaMetadataType.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributesViaMetadataType.cs
@@ -17,6 +17,7 @@ namespace Swashbuckle.AspNetCore.TestSupport
         public string StringWithLength { get; set; }
 
         public string[] ArrayWithLength { get; set; }
+
         public string StringWithBase64 { get; set; }
 
 #endif
@@ -47,18 +48,22 @@ namespace Swashbuckle.AspNetCore.TestSupport
 
         [Length(1, 3)]
         public string StringWithLength { get; set; }
+
         [Length(1, 3)]
         public string[] ArrayWithLength { get; set; }
 
         [Range(1, 10, MinimumIsExclusive = true, MaximumIsExclusive = true)]
         public int IntWithRange { get; set; }
+
         [Base64String]
         public string StringWithBase64 { get; set; }
+
 #else
+
         [Range(1, 10)]
         public int IntWithRange { get; set; }
-#endif
 
+#endif
 
         [RegularExpression("^[3-6]?\\d{12,15}$")]
         public string StringWithRegularExpression { get; set; }

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributesViaMetadataType.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributesViaMetadataType.cs
@@ -17,6 +17,7 @@ namespace Swashbuckle.AspNetCore.TestSupport
         public string StringWithLength { get; set; }
 
         public string[] ArrayWithLength { get; set; }
+        public string StringWithBase64 { get; set; }
 
 #endif
 
@@ -46,14 +47,18 @@ namespace Swashbuckle.AspNetCore.TestSupport
 
         [Length(1, 3)]
         public string StringWithLength { get; set; }
-
         [Length(1, 3)]
         public string[] ArrayWithLength { get; set; }
 
-#endif
-
+        [Range(1, 10, MinimumIsExclusive = true, MaximumIsExclusive = true)]
+        public int IntWithRange { get; set; }
+        [Base64String]
+        public string StringWithBase64 { get; set; }
+#else
         [Range(1, 10)]
         public int IntWithRange { get; set; }
+#endif
+
 
         [RegularExpression("^[3-6]?\\d{12,15}$")]
         public string StringWithRegularExpression { get; set; }


### PR DESCRIPTION
Fixes #2957

It adds support for Base64String and MinimumIsExclusive and MaximumIsExclusive  properties for RangeAttribute.
The SwaggerUi does not seem to be looking at neither of these properties when validating it

