### PR TITLE
Only set Exclusive Range when they are, do not set them when they are…

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
@@ -183,12 +183,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
 #if NET8_0_OR_GREATER
 
-            if(rangeAttribute.MinimumIsExclusive)
+            if (rangeAttribute.MinimumIsExclusive)
             {
                 schema.ExclusiveMinimum = true;
             }
 
-            if(rangeAttribute.MaximumIsExclusive)
+            if (rangeAttribute.MaximumIsExclusive)
             {
                 schema.ExclusiveMaximum = true;
             }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
@@ -183,8 +183,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
 #if NET8_0_OR_GREATER
 
-            schema.ExclusiveMinimum = rangeAttribute.MinimumIsExclusive;
-            schema.ExclusiveMaximum = rangeAttribute.MaximumIsExclusive;
+            if(rangeAttribute.MinimumIsExclusive)
+            {
+                schema.ExclusiveMinimum = true;
+            }
+
+            if(rangeAttribute.MaximumIsExclusive)
+            {
+                schema.ExclusiveMaximum = true;
+            }
 
 #endif
 

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -322,10 +322,15 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Assert.Equal(3, schema.Properties["StringWithLength"].MaxLength);
             Assert.Equal(1, schema.Properties["ArrayWithLength"].MinItems);
             Assert.Equal(3, schema.Properties["ArrayWithLength"].MaxItems);
-            Assert.Equal(true, schema.Properties["IntWithRange"].ExclusiveMinimum);
-            Assert.Equal(true, schema.Properties["IntWithRange"].ExclusiveMaximum);
             Assert.Equal("byte", schema.Properties["StringWithBase64"].Format);
             Assert.Equal("string", schema.Properties["StringWithBase64"].Type);
+            Assert.Null(schema.Properties["IntWithRange"].ExclusiveMinimum);
+            Assert.Null(schema.Properties["IntWithRange"].ExclusiveMaximum);
+            Assert.Equal(true, schema.Properties["IntWithExclusiveRange"].ExclusiveMinimum);
+            Assert.Equal(true, schema.Properties["IntWithExclusiveRange"].ExclusiveMaximum);
+#else
+            Assert.Null(schema.Properties["IntWithRange"].ExclusiveMinimum);
+            Assert.Null(schema.Properties["IntWithRange"].ExclusiveMaximum);
 #endif
             Assert.Equal(1, schema.Properties["IntWithRange"].Minimum);
             Assert.Equal(10, schema.Properties["IntWithRange"].Maximum);

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -322,16 +322,13 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Assert.Equal(3, schema.Properties["StringWithLength"].MaxLength);
             Assert.Equal(1, schema.Properties["ArrayWithLength"].MinItems);
             Assert.Equal(3, schema.Properties["ArrayWithLength"].MaxItems);
-            Assert.Equal("byte", schema.Properties["StringWithBase64"].Format);
-            Assert.Equal("string", schema.Properties["StringWithBase64"].Type);
-            Assert.Null(schema.Properties["IntWithRange"].ExclusiveMinimum);
-            Assert.Null(schema.Properties["IntWithRange"].ExclusiveMaximum);
             Assert.Equal(true, schema.Properties["IntWithExclusiveRange"].ExclusiveMinimum);
             Assert.Equal(true, schema.Properties["IntWithExclusiveRange"].ExclusiveMaximum);
-#else
+            Assert.Equal("byte", schema.Properties["StringWithBase64"].Format);
+            Assert.Equal("string", schema.Properties["StringWithBase64"].Type);
+#endif
             Assert.Null(schema.Properties["IntWithRange"].ExclusiveMinimum);
             Assert.Null(schema.Properties["IntWithRange"].ExclusiveMaximum);
-#endif
             Assert.Equal(1, schema.Properties["IntWithRange"].Minimum);
             Assert.Equal(10, schema.Properties["IntWithRange"].Maximum);
             Assert.Equal("^[3-6]?\\d{12,15}$", schema.Properties["StringWithRegularExpression"].Pattern);

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -345,16 +345,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal(3, schema.Properties["StringWithLength"].MaxLength);
             Assert.Equal(1, schema.Properties["ArrayWithLength"].MinItems);
             Assert.Equal(3, schema.Properties["ArrayWithLength"].MaxItems);
-            Assert.Equal("byte", schema.Properties["StringWithBase64"].Format);
-            Assert.Equal("string", schema.Properties["StringWithBase64"].Type);
-            Assert.Null(schema.Properties["IntWithRange"].ExclusiveMinimum);
-            Assert.Null(schema.Properties["IntWithRange"].ExclusiveMaximum);
             Assert.Equal(true, schema.Properties["IntWithExclusiveRange"].ExclusiveMinimum);
             Assert.Equal(true, schema.Properties["IntWithExclusiveRange"].ExclusiveMaximum);
-#else
+            Assert.Equal("byte", schema.Properties["StringWithBase64"].Format);
+            Assert.Equal("string", schema.Properties["StringWithBase64"].Type);
+#endif
             Assert.Null(schema.Properties["IntWithRange"].ExclusiveMinimum);
             Assert.Null(schema.Properties["IntWithRange"].ExclusiveMaximum);
-#endif
             Assert.Equal(1, schema.Properties["IntWithRange"].Minimum);
             Assert.Equal(10, schema.Properties["IntWithRange"].Maximum);
             Assert.Equal("^[3-6]?\\d{12,15}$", schema.Properties["StringWithRegularExpression"].Pattern);

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -345,10 +345,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal(3, schema.Properties["StringWithLength"].MaxLength);
             Assert.Equal(1, schema.Properties["ArrayWithLength"].MinItems);
             Assert.Equal(3, schema.Properties["ArrayWithLength"].MaxItems);
-            Assert.Equal(true, schema.Properties["IntWithRange"].ExclusiveMinimum);
-            Assert.Equal(true, schema.Properties["IntWithRange"].ExclusiveMaximum);
             Assert.Equal("byte", schema.Properties["StringWithBase64"].Format);
             Assert.Equal("string", schema.Properties["StringWithBase64"].Type);
+            Assert.Null(schema.Properties["IntWithRange"].ExclusiveMinimum);
+            Assert.Null(schema.Properties["IntWithRange"].ExclusiveMaximum);
+            Assert.Equal(true, schema.Properties["IntWithExclusiveRange"].ExclusiveMinimum);
+            Assert.Equal(true, schema.Properties["IntWithExclusiveRange"].ExclusiveMaximum);
+#else
+            Assert.Null(schema.Properties["IntWithRange"].ExclusiveMinimum);
+            Assert.Null(schema.Properties["IntWithRange"].ExclusiveMaximum);
 #endif
             Assert.Equal(1, schema.Properties["IntWithRange"].Minimum);
             Assert.Equal(10, schema.Properties["IntWithRange"].Maximum);

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributes.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributes.cs
@@ -22,17 +22,15 @@ namespace Swashbuckle.AspNetCore.TestSupport
         public string[] ArrayWithLength { get; set; }
 
         [Range(1, 10, MinimumIsExclusive = true, MaximumIsExclusive = true)]
-        public int IntWithRange { get; set; }
+        public int IntWithExclusiveRange { get; set; }
 
         [Base64String]
         public string StringWithBase64 { get; set; }
 
-#else
+#endif
 
         [Range(1, 10)]
         public int IntWithRange { get; set; }
-
-#endif
 
         [RegularExpression("^[3-6]?\\d{12,15}$")]
         public string StringWithRegularExpression { get; set; }

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributesViaMetadataType.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributesViaMetadataType.cs
@@ -20,6 +20,8 @@ namespace Swashbuckle.AspNetCore.TestSupport
 
         public string StringWithBase64 { get; set; }
 
+        public double IntWithExclusiveRange { get; set; }
+
 #endif
 
         public int IntWithRange { get; set; }
@@ -53,17 +55,15 @@ namespace Swashbuckle.AspNetCore.TestSupport
         public string[] ArrayWithLength { get; set; }
 
         [Range(1, 10, MinimumIsExclusive = true, MaximumIsExclusive = true)]
-        public int IntWithRange { get; set; }
+        public int IntWithExclusiveRange { get; set; }
 
         [Base64String]
         public string StringWithBase64 { get; set; }
 
-#else
+#endif
 
         [Range(1, 10)]
         public int IntWithRange { get; set; }
-
-#endif
 
         [RegularExpression("^[3-6]?\\d{12,15}$")]
         public string StringWithRegularExpression { get; set; }


### PR DESCRIPTION
Fixes #2959, it was a little breaking change that was affecting a client implementation.
There is no need to set the Inclusive/Exclusive parameter when they are not set to true, to have the same OpenApi document with dotnet7 and dotnet8