### PR TITLE
AsParameters throwing error on cast when showing the Description with EnableAnnotations

### DIFF
--- a/src/Swashbuckle.AspNetCore.Annotations/AnnotationsParameterFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Annotations/AnnotationsParameterFilter.cs
@@ -31,8 +31,7 @@ namespace Swashbuckle.AspNetCore.Annotations
         private void ApplyParamAnnotations(OpenApiParameter parameter, ParameterInfo parameterInfo)
         {
 
-            var swaggerParameterAttribute = parameterInfo.GetCustomAttributes<SwaggerParameterAttribute>()
-                .FirstOrDefault();
+            var swaggerParameterAttribute = parameterInfo.GetCustomAttribute<SwaggerParameterAttribute>();
 
             if (swaggerParameterAttribute != null)
                 ApplySwaggerParameterAttribute(parameter, swaggerParameterAttribute);

--- a/test/WebSites/WebApi/Program.cs
+++ b/test/WebSites/WebApi/Program.cs
@@ -1,8 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
+    c.EnableAnnotations();
     c.SwaggerDoc("v1", new() { Title = "WebApi", Version = "v1" });
 });
 
@@ -20,7 +24,7 @@ var summaries = new[]
 
 app.MapGet("/weatherforecast", () =>
 {
-    var forecast =  Enumerable.Range(1, 5).Select(index =>
+    var forecast = Enumerable.Range(1, 5).Select(index =>
         new WeatherForecast
         (
             DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
@@ -33,12 +37,21 @@ app.MapGet("/weatherforecast", () =>
 .WithName("GetWeatherForecast")
 .WithOpenApi();
 
+app.MapPost("/fruit/{id}", ([AsParameters] CreateFruitModel model) =>
+{
+    return model.Fruit;
+}).WithName("CreateFruit");
+
 app.Run();
 
+record struct CreateFruitModel
+    ([FromRoute, SwaggerParameter(Description = "The id of the fruit that will be created", Required = true)] string Id,
+    [FromBody] Fruit Fruit);
 record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
 {
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 }
+record Fruit(string Name);
 
 namespace WebApi
 {

--- a/test/WebSites/WebApi/WebApi.csproj
+++ b/test/WebSites/WebApi/WebApi.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.Annotations\Swashbuckle.AspNetCore.Annotations.csproj" />
     <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerGen\Swashbuckle.AspNetCore.SwaggerGen.csproj" />
     <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerUI\Swashbuckle.AspNetCore.SwaggerUI.csproj" />
   </ItemGroup>


### PR DESCRIPTION
This fixes an issue shown when investigating #2658. Not sure if this fixes it all.

Tested with the project WebApi, if you do not apply the GetCustomAttributes to GetCustomAttribute change then you will see an error on the SwaggerUi based on a Cast.

As the SwaggerParameter is an attribute that only can be set once per property there is no issue on the change
I have studied if inserting a test in Swashbuckle.AspNetCore.Annotations.Test, but the existing test are hitting this change, so I think there is no need to add it(In fact I have not seen a test using MinimalApi approach)