### PR TITLE
Move inline css and js to external files for SwaggerUI and ReDoc

### DIFF
--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
@@ -113,13 +113,11 @@ namespace Swashbuckle.AspNetCore.ReDoc
             {
                 case "index.css":
                     response.ContentType = "text/css";
-                    stream = typeof(ReDocMiddleware).GetTypeInfo().Assembly
-                                .GetManifestResourceStream($"Swashbuckle.AspNetCore.ReDoc.{fileName}");
+                    stream = ResourceHelper.GetEmbeddedResource(fileName);
                     break;
                 case "index.js":
                     response.ContentType = "application/javascript;charset=utf-8";
-                    stream = typeof(ReDocMiddleware).GetTypeInfo().Assembly
-                                .GetManifestResourceStream($"Swashbuckle.AspNetCore.ReDoc.{fileName}");
+                    stream = ResourceHelper.GetEmbeddedResource(fileName);
                     break;
                 default:
                     response.ContentType = "text/html;charset=utf-8";

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocOptions.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocOptions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Text.Json.Serialization;
 
 namespace Swashbuckle.AspNetCore.ReDoc
@@ -16,8 +15,7 @@ namespace Swashbuckle.AspNetCore.ReDoc
         /// <summary>
         /// Gets or sets a Stream function for retrieving the redoc page
         /// </summary>
-        public Func<Stream> IndexStream { get; set; } = () => typeof(ReDocOptions).GetTypeInfo().Assembly
-            .GetManifestResourceStream("Swashbuckle.AspNetCore.ReDoc.index.html");
+        public Func<Stream> IndexStream { get; set; } = () => ResourceHelper.GetEmbeddedResource("index.html");
 
         /// <summary>
         /// Gets or sets a title for the redoc page

--- a/src/Swashbuckle.AspNetCore.ReDoc/ResourceHelper.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ResourceHelper.cs
@@ -1,0 +1,13 @@
+﻿using System.IO;
+using System.Reflection;
+
+namespace Swashbuckle.AspNetCore.ReDoc;
+
+internal class ResourceHelper
+{
+    public static Stream GetEmbeddedResource(string fileName)
+    {
+        return typeof(ResourceHelper).GetTypeInfo().Assembly
+            .GetManifestResourceStream($"Swashbuckle.AspNetCore.ReDoc.{fileName}");
+    }
+}

--- a/src/Swashbuckle.AspNetCore.ReDoc/ResourceHelper.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ResourceHelper.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace Swashbuckle.AspNetCore.ReDoc;
 
-internal class ResourceHelper
+internal static class ResourceHelper
 {
     public static Stream GetEmbeddedResource(string fileName)
     {

--- a/src/Swashbuckle.AspNetCore.ReDoc/Swashbuckle.AspNetCore.ReDoc.csproj
+++ b/src/Swashbuckle.AspNetCore.ReDoc/Swashbuckle.AspNetCore.ReDoc.csproj
@@ -11,7 +11,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="index.css" />
+    <None Remove="index.js" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="index.css" />
     <EmbeddedResource Include="index.html" />
+    <EmbeddedResource Include="index.js" />
     <EmbeddedResource Include="node_modules/redoc/bundles/redoc.standalone.js" />
   </ItemGroup>
 

--- a/src/Swashbuckle.AspNetCore.ReDoc/index.css
+++ b/src/Swashbuckle.AspNetCore.ReDoc/index.css
@@ -1,0 +1,4 @@
+﻿body {
+    margin: 0;
+    padding: 0;
+}

--- a/src/Swashbuckle.AspNetCore.ReDoc/index.html
+++ b/src/Swashbuckle.AspNetCore.ReDoc/index.html
@@ -10,19 +10,12 @@
     <!--
     Redoc doesn't change outer page styles
     -->
-    <style>
-        body {
-            margin: 0;
-            padding: 0;
-        }
-    </style>
+    <link href="index.css" rel="stylesheet" type="text/css">
     %(HeadContent)
 </head>
 <body>
     <div id="redoc-container"></div>
     <script src="redoc.standalone.js"></script>
-    <script type="text/javascript">
-        Redoc.init('%(SpecUrl)', JSON.parse('%(ConfigObject)'), document.getElementById('redoc-container'))
-    </script>
+    <script src="index.js"></script>
 </body>
 </html>

--- a/src/Swashbuckle.AspNetCore.ReDoc/index.js
+++ b/src/Swashbuckle.AspNetCore.ReDoc/index.js
@@ -1,0 +1,1 @@
+Redoc.init('%(SpecUrl)', JSON.parse('%(ConfigObject)'), document.getElementById('redoc-container'));

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/ResourceHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/ResourceHelper.cs
@@ -1,0 +1,13 @@
+﻿using System.IO;
+using System.Reflection;
+
+namespace Swashbuckle.AspNetCore.SwaggerUI;
+
+internal class ResourceHelper
+{
+    public static Stream GetEmbeddedResource(string fileName)
+    {
+        return typeof(ResourceHelper).GetTypeInfo().Assembly
+            .GetManifestResourceStream($"Swashbuckle.AspNetCore.SwaggerUI.{fileName}");
+    }
+}

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/ResourceHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/ResourceHelper.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace Swashbuckle.AspNetCore.SwaggerUI;
 
-internal class ResourceHelper
+internal static class ResourceHelper
 {
     public static Stream GetEmbeddedResource(string fileName)
     {

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -123,8 +123,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
             if (fileName == "index.js")
             {
                 response.ContentType = "application/javascript;charset=utf-8";
-                stream = typeof(SwaggerUIMiddleware).GetTypeInfo().Assembly
-                            .GetManifestResourceStream($"Swashbuckle.AspNetCore.SwaggerUI.{fileName}");
+                stream = ResourceHelper.GetEmbeddedResource(fileName);
             }
             else
             {

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -18,8 +17,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// <summary>
         /// Gets or sets a Stream function for retrieving the swagger-ui page
         /// </summary>
-        public Func<Stream> IndexStream { get; set; } = () => typeof(SwaggerUIOptions).GetTypeInfo().Assembly
-            .GetManifestResourceStream("Swashbuckle.AspNetCore.SwaggerUI.index.html");
+        public Func<Stream> IndexStream { get; set; } = () => ResourceHelper.GetEmbeddedResource("index.html");
 
         /// <summary>
         /// Gets or sets a title for the swagger-ui page
@@ -34,7 +32,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// <summary>
         /// Gets the JavaScript config object, represented as JSON, that will be passed to the SwaggerUI
         /// </summary>
-        public ConfigObject ConfigObject  { get; set; } = new ConfigObject();
+        public ConfigObject ConfigObject { get; set; } = new ConfigObject();
 
         /// <summary>
         /// Gets the JavaScript config object, represented as JSON, that will be passed to the initOAuth method

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
@@ -6,7 +6,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <PackageTags>swagger;documentation;discovery;help;webapi;aspnet;aspnetcore</PackageTags>
-    <SignAssembly>true</SignAssembly>    
+    <SignAssembly>true</SignAssembly>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <EmbeddedResource Include="node_modules/swagger-ui-dist/**/*" Exclude="**/*/index.html;**/*/*.map;**/*/*.json;**/*/*.md;**/*/swagger-ui-es-*" />
-    <None Remove="fix-edge-fetch.js" />
     <None Remove="index.js" />
     <EmbeddedResource Include="index.html" />
     <EmbeddedResource Include="index.js" />

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
@@ -6,7 +6,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <PackageTags>swagger;documentation;discovery;help;webapi;aspnet;aspnetcore</PackageTags>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>true</SignAssembly>    
     <TargetFrameworks>netstandard2.0;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
@@ -16,7 +16,10 @@
 
   <ItemGroup>
     <EmbeddedResource Include="node_modules/swagger-ui-dist/**/*" Exclude="**/*/index.html;**/*/*.map;**/*/*.json;**/*/*.md;**/*/swagger-ui-es-*" />
+    <None Remove="fix-edge-fetch.js" />
+    <None Remove="index.js" />
     <EmbeddedResource Include="index.html" />
+    <EmbeddedResource Include="index.js" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
@@ -16,9 +16,8 @@
 
   <ItemGroup>
     <EmbeddedResource Include="node_modules/swagger-ui-dist/**/*" Exclude="**/*/index.html;**/*/*.map;**/*/*.json;**/*/*.md;**/*/swagger-ui-es-*" />
-    <None Remove="index.js" />
-    <EmbeddedResource Include="index.html" />
-    <EmbeddedResource Include="index.js" />
+    <None Remove="index.html;index.js" />
+    <EmbeddedResource Include="index.html;index.js" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
@@ -5,113 +5,17 @@
     <meta charset="UTF-8">
     <title>%(DocumentTitle)</title>
     <link rel="stylesheet" type="text/css" href="%(StylesPath)">
+    <link rel="stylesheet" type="text/css" href="./index.css">
     <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
-    <style>
-
-        html {
-            box-sizing: border-box;
-            overflow: -moz-scrollbars-vertical;
-            overflow-y: scroll;
-        }
-
-        *,
-        *:before,
-        *:after {
-            box-sizing: inherit;
-        }
-
-        body {
-            margin: 0;
-            background: #fafafa;
-        }
-    </style>
-    %(HeadContent)
+    %(HeadContent)   
 </head>
 
 <body>
     <div id="swagger-ui"></div>
 
-    <!-- Workaround for https://github.com/swagger-api/swagger-editor/issues/1371 -->
-    <script>
-        if (window.navigator.userAgent.indexOf("Edge") > -1) {
-            console.log("Removing native Edge fetch in favor of swagger-ui's polyfill")
-            window.fetch = undefined;
-        }
-    </script>
-
     <script src="%(ScriptBundlePath)"></script>
     <script src="%(ScriptPresetsPath)"></script>
-    <script>
-        /* Source: https://gist.github.com/lamberta/3768814
-         * Parse a string function definition and return a function object. Does not use eval.
-         * @param {string} str
-         * @return {function}
-         *
-         * Example:
-         *  var f = function (x, y) { return x * y; };
-         *  var g = parseFunction(f.toString());
-         *  g(33, 3); //=> 99
-         */
-        function parseFunction(str) {
-            if (!str) return void (0);
-
-            var fn_body_idx = str.indexOf('{'),
-                fn_body = str.substring(fn_body_idx + 1, str.lastIndexOf('}')),
-                fn_declare = str.substring(0, fn_body_idx),
-                fn_params = fn_declare.substring(fn_declare.indexOf('(') + 1, fn_declare.lastIndexOf(')')),
-                args = fn_params.split(',');
-
-            args.push(fn_body);
-
-            function Fn() {
-                return Function.apply(this, args);
-            }
-            Fn.prototype = Function.prototype;
-
-            return new Fn();
-        }
-
-        window.onload = function () {
-            var configObject = JSON.parse('%(ConfigObject)');
-            var oauthConfigObject = JSON.parse('%(OAuthConfigObject)');
-
-            // Workaround for https://github.com/swagger-api/swagger-ui/issues/5945
-            configObject.urls.forEach(function (item) {
-                if (item.url.startsWith("http") || item.url.startsWith("/")) return;
-                item.url = window.location.href.replace("index.html", item.url).split('#')[0];
-            });
-
-            // If validatorUrl is not explicitly provided, disable the feature by setting to null
-            if (!configObject.hasOwnProperty("validatorUrl"))
-                configObject.validatorUrl = null
-
-            // If oauth2RedirectUrl isn't specified, use the built-in default
-            if (!configObject.hasOwnProperty("oauth2RedirectUrl"))
-                configObject.oauth2RedirectUrl = (new URL("oauth2-redirect.html", window.location.href)).href;
-
-            // Apply mandatory parameters
-            configObject.dom_id = "#swagger-ui";
-            configObject.presets = [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset];
-            configObject.layout = "StandaloneLayout";
-
-            // Parse and add interceptor functions
-            var interceptors = JSON.parse('%(Interceptors)');
-            if (interceptors.RequestInterceptorFunction)
-                configObject.requestInterceptor = parseFunction(interceptors.RequestInterceptorFunction);
-            if (interceptors.ResponseInterceptorFunction)
-                configObject.responseInterceptor = parseFunction(interceptors.ResponseInterceptorFunction);
-
-            // Begin Swagger UI call region
-
-            const ui = SwaggerUIBundle(configObject);
-
-            ui.initOAuth(oauthConfigObject);
-
-            // End Swagger UI call region
-
-            window.ui = ui
-        }
-    </script>
+    <script src="index.js"></script>
 </body>
 </html>

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/index.html
@@ -14,8 +14,8 @@
 <body>
     <div id="swagger-ui"></div>
 
-    <script src="%(ScriptBundlePath)"></script>
-    <script src="%(ScriptPresetsPath)"></script>
-    <script src="index.js"></script>
+    <script src="%(ScriptBundlePath)" charset="utf-8"></script>
+    <script src="%(ScriptPresetsPath)" charset="utf-8"></script>
+    <script src="index.js" charset="utf-8"></script>
 </body>
 </html>

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/index.js
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/index.js
@@ -1,10 +1,4 @@
-﻿// Workaround for https://github.com/swagger-api/swagger-editor/issues/1371
-if (window.navigator.userAgent.indexOf("Edge") > -1) {
-    console.log("Removing native Edge fetch in favor of swagger-ui's polyfill")
-    window.fetch = undefined;
-}
-
-/* Source: https://gist.github.com/lamberta/3768814
+﻿/* Source: https://gist.github.com/lamberta/3768814
  * Parse a string function definition and return a function object. Does not use eval.
  * @param {string} str
  * @return {function}

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/index.js
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/index.js
@@ -1,0 +1,75 @@
+﻿// Workaround for https://github.com/swagger-api/swagger-editor/issues/1371
+if (window.navigator.userAgent.indexOf("Edge") > -1) {
+    console.log("Removing native Edge fetch in favor of swagger-ui's polyfill")
+    window.fetch = undefined;
+}
+
+/* Source: https://gist.github.com/lamberta/3768814
+ * Parse a string function definition and return a function object. Does not use eval.
+ * @param {string} str
+ * @return {function}
+ *
+ * Example:
+ *  var f = function (x, y) { return x * y; };
+ *  var g = parseFunction(f.toString());
+ *  g(33, 3); //=> 99
+ */
+function parseFunction(str) {
+    if (!str) return void (0);
+
+    var fn_body_idx = str.indexOf('{'),
+        fn_body = str.substring(fn_body_idx + 1, str.lastIndexOf('}')),
+        fn_declare = str.substring(0, fn_body_idx),
+        fn_params = fn_declare.substring(fn_declare.indexOf('(') + 1, fn_declare.lastIndexOf(')')),
+        args = fn_params.split(',');
+
+    args.push(fn_body);
+
+    function Fn() {
+        return Function.apply(this, args);
+    }
+    Fn.prototype = Function.prototype;
+
+    return new Fn();
+}
+
+window.onload = function () {
+    var configObject = JSON.parse('%(ConfigObject)');
+    var oauthConfigObject = JSON.parse('%(OAuthConfigObject)');
+
+    // Workaround for https://github.com/swagger-api/swagger-ui/issues/5945
+    configObject.urls.forEach(function (item) {
+        if (item.url.startsWith("http") || item.url.startsWith("/")) return;
+        item.url = window.location.href.replace("index.html", item.url).split('#')[0];
+    });
+
+    // If validatorUrl is not explicitly provided, disable the feature by setting to null
+    if (!configObject.hasOwnProperty("validatorUrl"))
+        configObject.validatorUrl = null
+
+    // If oauth2RedirectUrl isn't specified, use the built-in default
+    if (!configObject.hasOwnProperty("oauth2RedirectUrl"))
+        configObject.oauth2RedirectUrl = (new URL("oauth2-redirect.html", window.location.href)).href;
+
+    // Apply mandatory parameters
+    configObject.dom_id = "#swagger-ui";
+    configObject.presets = [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset];
+    configObject.layout = "StandaloneLayout";
+
+    // Parse and add interceptor functions
+    var interceptors = JSON.parse('%(Interceptors)');
+    if (interceptors.RequestInterceptorFunction)
+        configObject.requestInterceptor = parseFunction(interceptors.RequestInterceptorFunction);
+    if (interceptors.ResponseInterceptorFunction)
+        configObject.responseInterceptor = parseFunction(interceptors.ResponseInterceptorFunction);
+
+    // Begin Swagger UI call region
+
+    const ui = SwaggerUIBundle(configObject);
+
+    ui.initOAuth(oauthConfigObject);
+
+    // End Swagger UI call region
+
+    window.ui = ui
+}

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
@@ -20,27 +20,33 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
         }
 
         [Fact]
+        public async Task IndexUrl_ReturnsEmbeddedVersionOfTheRedocUI()
+        {
+            var client = new TestSite(typeof(ReDocApp.Startup)).BuildClient();
+
+            var htmlResponse = await client.GetAsync("/api-docs/index.html");
+            var cssResponse = await client.GetAsync("/api-docs/index.css");
+            var jsResponse = await client.GetAsync("/api-docs/redoc.standalone.js");
+
+            Assert.Equal(HttpStatusCode.OK, htmlResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, cssResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
+        }
+
+        [Fact]
         public async Task RedocMiddleware_ReturnsInitializerScript()
         {
             var client = new TestSite(typeof(ReDocApp.Startup)).BuildClient();
 
             var response = await client.GetAsync("/api-docs/index.js");
-            var indexContent = await response.Content.ReadAsStringAsync();
+            var content = await response.Content.ReadAsStringAsync();
 
-            Assert.Contains("Redoc.init", indexContent);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        }
-
-        [Fact]
-        public async Task IndexUrl_ReturnsEmbeddedVersionOfTheRedocUI()
-        {
-            var client = new TestSite(typeof(ReDocApp.Startup)).BuildClient();
-
-            var indexResponse = await client.GetAsync("/api-docs/index.html");
-            var jsResponse = await client.GetAsync("/api-docs/redoc.standalone.js");
-
-            var indexContent = await indexResponse.Content.ReadAsStringAsync();
-            Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
+            Assert.Contains("Redoc.init", content);
+            Assert.DoesNotContain("%(DocumentTitle)", content);
+            Assert.DoesNotContain("%(HeadContent)", content);
+            Assert.DoesNotContain("%(SpecUrl)", content);
+            Assert.DoesNotContain("%(ConfigObject)", content);
         }
 
         [Fact]
@@ -48,24 +54,30 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
         {
             var client = new TestSite(typeof(ReDocApp.Startup)).BuildClient();
 
-            var indexResponse = await client.GetAsync("/Api-Docs/index.html");
-            var jsResponse = await client.GetAsync("/Api-Docs/redoc.standalone.js");
+            var htmlResponse = await client.GetAsync("/Api-Docs/index.html");
+            var cssResponse = await client.GetAsync("/Api-Docs/index.css");
+            var jsInitResponse = await client.GetAsync("/Api-Docs/index.js");
+            var jsRedocResponse = await client.GetAsync("/Api-Docs/redoc.standalone.js");
 
-            var indexContent = await indexResponse.Content.ReadAsStringAsync();
-            Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, htmlResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, cssResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, jsInitResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, jsRedocResponse.StatusCode);
         }
 
         [Theory]
-        [InlineData("/redoc/1.0/index.js", "/swagger/1.0/swagger.json")]
-        [InlineData("/redoc/2.0/index.js", "/swagger/2.0/swagger.json")]
-        public async Task RedocMiddleware_CanBeConfiguredMultipleTimes(string redocUrl, string swaggerPath)
+        [InlineData("/redoc/1.0/index.html", "/redoc/1.0/index.js", "/swagger/1.0/swagger.json")]
+        [InlineData("/redoc/2.0/index.html", "/redoc/2.0/index.js", "/swagger/2.0/swagger.json")]
+        public async Task RedocMiddleware_CanBeConfiguredMultipleTimes(string htmlUrl, string jsUrl, string swaggerPath)
         {
             var client = new TestSite(typeof(MultipleVersions.Startup)).BuildClient();
 
-            var response = await client.GetAsync(redocUrl);
-            var content = await response.Content.ReadAsStringAsync();
+            var htmlResponse = await client.GetAsync(htmlUrl);
+            var jsResponse = await client.GetAsync(jsUrl);
+            var content = await jsResponse.Content.ReadAsStringAsync();
 
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, htmlResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
             Assert.Contains(swaggerPath, content);
         }
     }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
@@ -20,6 +20,18 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
         }
 
         [Fact]
+        public async Task RedocMiddleware_ReturnsInitializerScript()
+        {
+            var client = new TestSite(typeof(ReDocApp.Startup)).BuildClient();
+
+            var response = await client.GetAsync("/api-docs/index.js");
+            var indexContent = await response.Content.ReadAsStringAsync();
+
+            Assert.Contains("Redoc.init", indexContent);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
         public async Task IndexUrl_ReturnsEmbeddedVersionOfTheRedocUI()
         {
             var client = new TestSite(typeof(ReDocApp.Startup)).BuildClient();
@@ -28,7 +40,6 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
             var jsResponse = await client.GetAsync("/api-docs/redoc.standalone.js");
 
             var indexContent = await indexResponse.Content.ReadAsStringAsync();
-            Assert.Contains("Redoc.init", indexContent);
             Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
         }
 
@@ -41,13 +52,12 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
             var jsResponse = await client.GetAsync("/Api-Docs/redoc.standalone.js");
 
             var indexContent = await indexResponse.Content.ReadAsStringAsync();
-            Assert.Contains("Redoc.init", indexContent);
             Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
         }
 
         [Theory]
-        [InlineData("/redoc/1.0/index.html", "/swagger/1.0/swagger.json")]
-        [InlineData("/redoc/2.0/index.html", "/swagger/2.0/swagger.json")]
+        [InlineData("/redoc/1.0/index.js", "/swagger/1.0/swagger.json")]
+        [InlineData("/redoc/2.0/index.js", "/swagger/2.0/swagger.json")]
         public async Task RedocMiddleware_CanBeConfiguredMultipleTimes(string redocUrl, string swaggerPath)
         {
             var client = new TestSite(typeof(MultipleVersions.Startup)).BuildClient();

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -26,35 +26,19 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
         }
 
         [Theory]
-        [InlineData(typeof(Basic.Startup), "/index.js")]
-        [InlineData(typeof(CustomUIConfig.Startup), "/swagger/index.js")]
-        public async Task SwaggerUIMiddleware_ReturnsInitializerScript(
-            Type startupType,
-            string indexJsPath)
-        {
-            var client = new TestSite(startupType).BuildClient();
-
-            var indexResponse = await client.GetAsync(indexJsPath);
-            Assert.Equal(HttpStatusCode.OK, indexResponse.StatusCode);
-
-            var indexContent = await indexResponse.Content.ReadAsStringAsync();
-            Assert.Contains("SwaggerUIBundle", indexContent);
-        }
-
-        [Theory]
         [InlineData(typeof(Basic.Startup), "/index.html", "/swagger-ui.js", "/index.css", "/swagger-ui.css")]
         [InlineData(typeof(CustomUIConfig.Startup), "/swagger/index.html", "/swagger/swagger-ui.js", "swagger/index.css", "/swagger/swagger-ui.css")]
         public async Task IndexUrl_ReturnsEmbeddedVersionOfTheSwaggerUI(
             Type startupType,
-            string indexPath,
+            string htmlPath,
             string swaggerUijsPath,
             string indexCssPath,
             string swaggerUiCssPath)
         {
             var client = new TestSite(startupType).BuildClient();
 
-            var indexResponse = await client.GetAsync(indexPath);
-            Assert.Equal(HttpStatusCode.OK, indexResponse.StatusCode);
+            var htmlResponse = await client.GetAsync(htmlPath);
+            Assert.Equal(HttpStatusCode.OK, htmlResponse.StatusCode);
 
             var jsResponse = await client.GetAsync(swaggerUijsPath);
             Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
@@ -64,6 +48,30 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
 
             cssResponse = await client.GetAsync(swaggerUiCssPath);
             Assert.Equal(HttpStatusCode.OK, cssResponse.StatusCode);
+        }
+
+        [Theory]
+        [InlineData(typeof(Basic.Startup), "/index.js")]
+        [InlineData(typeof(CustomUIConfig.Startup), "/swagger/index.js")]
+        public async Task SwaggerUIMiddleware_ReturnsInitializerScript(
+            Type startupType,
+            string indexJsPath)
+        {
+            var client = new TestSite(startupType).BuildClient();
+
+            var jsResponse = await client.GetAsync(indexJsPath);
+            Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
+
+            var jsContent = await jsResponse.Content.ReadAsStringAsync();
+            Assert.Contains("SwaggerUIBundle", jsContent);
+            Assert.DoesNotContain("%(DocumentTitle)", jsContent);
+            Assert.DoesNotContain("%(HeadContent)", jsContent);
+            Assert.DoesNotContain("%(StylesPath)", jsContent);
+            Assert.DoesNotContain("%(ScriptBundlePath)", jsContent);
+            Assert.DoesNotContain("%(ScriptPresetsPath)", jsContent);
+            Assert.DoesNotContain("%(ConfigObject)", jsContent);
+            Assert.DoesNotContain("%(OAuthConfigObject)", jsContent);
+            Assert.DoesNotContain("%(Interceptors)", jsContent);
         }
 
         [Fact]
@@ -102,17 +110,19 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
         }
 
         [Theory]
-        [InlineData("/swagger/index.js", new[] { "Version 1.0", "Version 2.0" })]
-        [InlineData("/swagger/1.0/index.js", new[] { "Version 1.0" })]
-        [InlineData("/swagger/2.0/index.js", new[] { "Version 2.0" })]
-        public async Task SwaggerUIMiddleware_CanBeConfiguredMultipleTimes(string swaggerUiUrl, string[] versions)
+        [InlineData("/swagger/index.html", "/swagger/index.js", new[] { "Version 1.0", "Version 2.0" })]
+        [InlineData("/swagger/1.0/index.html", "/swagger/1.0/index.js", new[] { "Version 1.0" })]
+        [InlineData("/swagger/2.0/index.html", "/swagger/2.0/index.js", new[] { "Version 2.0" })]
+        public async Task SwaggerUIMiddleware_CanBeConfiguredMultipleTimes(string htmlUrl, string jsUrl, string[] versions)
         {
             var client = new TestSite(typeof(MultipleVersions.Startup)).BuildClient();
 
-            var response = await client.GetAsync(swaggerUiUrl);
-            var content = await response.Content.ReadAsStringAsync();
+            var htmlResponse = await client.GetAsync(htmlUrl);
+            var jsResponse = await client.GetAsync(jsUrl);
+            var content = await jsResponse.Content.ReadAsStringAsync();
 
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, htmlResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
             foreach (var version in versions)
             {
                 Assert.Contains(version, content);
@@ -124,20 +134,20 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
         [InlineData(typeof(CustomUIConfig.Startup), "/swagger/index.html", "/ext/custom-stylesheet.css", "/ext/custom-javascript.js", "/ext/custom-javascript.js")]
         public async Task IndexUrl_Returns_ExpectedAssetPaths(
             Type startupType,
-            string indexPath,
+            string htmlPath,
             string cssPath,
             string scriptBundlePath,
             string scriptPresetsPath)
         {
             var client = new TestSite(startupType).BuildClient();
 
-            var indexResponse = await client.GetAsync(indexPath);
-            Assert.Equal(HttpStatusCode.OK, indexResponse.StatusCode);
-            var content = await indexResponse.Content.ReadAsStringAsync();
+            var htmlResponse = await client.GetAsync(htmlPath);
+            Assert.Equal(HttpStatusCode.OK, htmlResponse.StatusCode);
 
+            var content = await htmlResponse.Content.ReadAsStringAsync();
             Assert.Contains($"<link rel=\"stylesheet\" type=\"text/css\" href=\"{cssPath}\">", content);
-            Assert.Contains($"<script src=\"{scriptBundlePath}\">", content);
-            Assert.Contains($"<script src=\"{scriptPresetsPath}\">", content);
+            Assert.Contains($"<script src=\"{scriptBundlePath}\" charset=\"utf-8\">", content);
+            Assert.Contains($"<script src=\"{scriptPresetsPath}\" charset=\"utf-8\">", content);
         }
     }
 }


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

Resolves #2881.

## Details on the issue fix or feature implementation

Moved inline javascript to separate files
ReDoc: Moved inline CSS to separate file
SwaggerUi: Reused CSS file from the package

Middleware changes to respond with corresponding files
