### PR TITLE
Use HttpMethods.IsGet()

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
@@ -99,7 +99,11 @@ namespace Swashbuckle.AspNetCore.Swagger
         {
             documentName = null;
             extension = null;
-            if (request.Method != "GET") return false;
+
+            if (!HttpMethods.IsGet(request.Method))
+            {
+                return false;
+            }
 
             var routeValues = new RouteValueDictionary();
             if (_requestMatcher.TryMatch(request.Path, routeValues))


### PR DESCRIPTION
Use `HttpMethods.IsGet()` instead of a string comparison.
