### PR TITLE
Missing Properties section when generating IFomFile/IFormFileCollection

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -447,6 +447,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                             };
                         }
                     }
+
                     static OpenApiSchema GenerateSchemaIncludingFormFile(ApiParameterDescription apiParameterDescription, OpenApiSchema generatedSchema)
                     {
                         if (generatedSchema.Reference is null
@@ -457,15 +458,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                                 Type = "object",
                                 Properties = new Dictionary<string, OpenApiSchema>()
                                 {
-                                    {
-                                        apiParameterDescription.Name,
-                                        generatedSchema
-                                    }
+                                    [apiParameterDescription.Name] = generatedSchema
                                 }
                             };
                         }
                         return generatedSchema;
                     }
+
                 }
             }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -427,25 +427,44 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                         if (countOfParameters == 1)
                         {
                             var requestParameter = requestParameters.First();
-                            content.Schema = GenerateSchema(
+                            content.Schema = GenerateSchemaIncludingFormFile(requestParameter, GenerateSchema(
                                 requestParameter.ModelMetadata.ModelType,
                                 schemaRepository,
                                 requestParameter.PropertyInfo(),
-                                requestParameter.ParameterInfo());
+                                requestParameter.ParameterInfo()));
                         }
                         else
                         {
                             content.Schema = new OpenApiSchema()
                             {
                                 AllOf = requestParameters.Select(s =>
-                                    GenerateSchema(
+                                    GenerateSchemaIncludingFormFile(s, GenerateSchema(
                                     s.ModelMetadata.ModelType,
                                     schemaRepository,
                                     s.PropertyInfo(),
-                                    s.ParameterInfo()))
+                                    s.ParameterInfo())))
                                 .ToList()
                             };
                         }
+                    }
+                    static OpenApiSchema GenerateSchemaIncludingFormFile(ApiParameterDescription apiParameterDescription, OpenApiSchema generatedSchema)
+                    {
+                        if (generatedSchema.Reference is null
+                            && ((generatedSchema.Type == "string" && generatedSchema.Format == "binary") || (generatedSchema.Type == "array" && generatedSchema.Items.Format == "binary")))
+                        {
+                            return new OpenApiSchema()
+                            {
+                                Type = "object",
+                                Properties = new Dictionary<string, OpenApiSchema>()
+                                {
+                                    {
+                                        apiParameterDescription.Name,
+                                        generatedSchema
+                                    }
+                                }
+                            };
+                        }
+                        return generatedSchema;
                     }
                 }
             }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_For_WebApi_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_For_WebApi_swaggerRequestUri=v1.verified.txt
@@ -112,6 +112,79 @@
         }
       }
     },
+    "/WithOpenApi/IFromFile": {
+      "post": {
+        "tags": [
+          "WithOpenApi"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/WithOpenApi/IFromFileCollection": {
+      "post": {
+        "tags": [
+          "WithOpenApi"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "collection": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/XmlComments/Car/{id}": {
       "get": {
         "tags": [

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_For_WebApi_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_For_WebApi_swaggerRequestUri=v1.verified.txt
@@ -107,7 +107,14 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.TypesAreRenderedCorrectly.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.TypesAreRenderedCorrectly.verified.txt
@@ -112,6 +112,79 @@
         }
       }
     },
+    "/WithOpenApi/IFromFile": {
+      "post": {
+        "tags": [
+          "WithOpenApi"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/WithOpenApi/IFromFileCollection": {
+      "post": {
+        "tags": [
+          "WithOpenApi"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "collection": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/XmlComments/Car/{id}": {
       "get": {
         "tags": [

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.TypesAreRenderedCorrectly.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.TypesAreRenderedCorrectly.verified.txt
@@ -107,7 +107,14 @@
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFile.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFile.verified.txt
@@ -1,0 +1,48 @@
+﻿{
+  Info: {
+    Title: Test API,
+    Version: V1
+  },
+  Paths: {
+    /resource: {
+      Operations: {
+        Post: {
+          OperationId: OperationIdSetInMetadata,
+          RequestBody: {
+            UnresolvedReference: false,
+            Required: false,
+            Content: {
+              application/someMediaType: {
+                Schema: {
+                  Type: object,
+                  ReadOnly: false,
+                  WriteOnly: false,
+                  Properties: {
+                    param: {
+                      Type: string,
+                      Format: binary,
+                      ReadOnly: false,
+                      WriteOnly: false,
+                      AdditionalPropertiesAllowed: true,
+                      Nullable: false,
+                      Deprecated: false,
+                      UnresolvedReference: false
+                    }
+                  },
+                  AdditionalPropertiesAllowed: true,
+                  Nullable: false,
+                  Deprecated: false,
+                  UnresolvedReference: false
+                }
+              }
+            }
+          },
+          Deprecated: false
+        }
+      },
+      UnresolvedReference: false
+    }
+  },
+  Components: {},
+  HashCode: 3B411279DDA5AD71B248D9E65E29E2545971131294B8FB032C0EC91640277615B8D600D78530054A7DA3754611589518B2C9773BB48A813B9951B46DE633743A
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFileCollection.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFileCollection.verified.txt
@@ -1,0 +1,57 @@
+﻿{
+  Info: {
+    Title: Test API,
+    Version: V1
+  },
+  Paths: {
+    /resource: {
+      Operations: {
+        Post: {
+          OperationId: OperationIdSetInMetadata,
+          RequestBody: {
+            UnresolvedReference: false,
+            Required: false,
+            Content: {
+              application/someMediaType: {
+                Schema: {
+                  Type: object,
+                  ReadOnly: false,
+                  WriteOnly: false,
+                  Properties: {
+                    param: {
+                      Type: array,
+                      ReadOnly: false,
+                      WriteOnly: false,
+                      Items: {
+                        Type: string,
+                        Format: binary,
+                        ReadOnly: false,
+                        WriteOnly: false,
+                        AdditionalPropertiesAllowed: true,
+                        Nullable: false,
+                        Deprecated: false,
+                        UnresolvedReference: false
+                      },
+                      AdditionalPropertiesAllowed: true,
+                      Nullable: false,
+                      Deprecated: false,
+                      UnresolvedReference: false
+                    }
+                  },
+                  AdditionalPropertiesAllowed: true,
+                  Nullable: false,
+                  Deprecated: false,
+                  UnresolvedReference: false
+                }
+              }
+            }
+          },
+          Deprecated: false
+        }
+      },
+      UnresolvedReference: false
+    }
+  },
+  Components: {},
+  HashCode: 64312D7E174EFA8B92E7869E39FD7367BB6A464F0C5E8A72D0B010AE96AAE157EE91BC02BEDFEC2B01CCC6BAA4E7FA79156782C09D435428AE8F732D3C9EB1B9
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.cs
@@ -1206,6 +1206,108 @@ public class SwaggerGeneratorVerifyTests
         return Verifier.Verify(document);
     }
 
+    [Fact]
+    public Task GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFile()
+    {
+        var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithConsumesAttribute));
+        var actionDescriptor = new ActionDescriptor
+        {
+            EndpointMetadata =
+            [
+                new OpenApiOperation
+                    {
+                        OperationId = "OperationIdSetInMetadata",
+                        RequestBody = new()
+                        {
+                            Content = new Dictionary<string, OpenApiMediaType>()
+                            {
+                                ["application/someMediaType"] = new()
+                            }
+                        }
+                    }
+            ],
+            RouteValues = new Dictionary<string, string>
+            {
+                ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
+            }
+        };
+        var subject = Subject(
+            apiDescriptions:
+            [
+                ApiDescriptionFactory.Create(
+                        actionDescriptor,
+                        methodInfo,
+                        groupName: "v1",
+                        httpMethod: "POST",
+                        relativePath: "resource",
+                        parameterDescriptions:
+                        [
+                            new ApiParameterDescription()
+                            {
+                                Name = "param",
+                                Source = BindingSource.Form,
+                                ModelMetadata = ModelMetadataFactory.CreateForType(typeof(IFormFile))
+                            }
+                        ]),
+            ]
+        );
+
+        var document = subject.GetSwagger("v1");
+
+        return Verifier.Verify(document);
+    }
+
+    [Fact]
+    public Task GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFileCollection()
+    {
+        var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithConsumesAttribute));
+        var actionDescriptor = new ActionDescriptor
+        {
+            EndpointMetadata =
+            [
+                new OpenApiOperation
+                    {
+                        OperationId = "OperationIdSetInMetadata",
+                        RequestBody = new()
+                        {
+                            Content = new Dictionary<string, OpenApiMediaType>()
+                            {
+                                ["application/someMediaType"] = new()
+                            }
+                        }
+                    }
+            ],
+            RouteValues = new Dictionary<string, string>
+            {
+                ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
+            }
+        };
+        var subject = Subject(
+            apiDescriptions:
+            [
+                ApiDescriptionFactory.Create(
+                        actionDescriptor,
+                        methodInfo,
+                        groupName: "v1",
+                        httpMethod: "POST",
+                        relativePath: "resource",
+                        parameterDescriptions:
+                        [
+                            new ApiParameterDescription()
+                            {
+                                Name = "param",
+                                Source = BindingSource.Form,
+                                ModelMetadata = ModelMetadataFactory.CreateForType(typeof(IFormFileCollection))
+                            }
+                        ]),
+            ]
+        );
+
+        var document = subject.GetSwagger("v1");
+
+        return Verifier.Verify(document);
+    }
+
     private static SwaggerGenerator Subject(
             IEnumerable<ApiDescription> apiDescriptions,
             SwaggerGeneratorOptions options = null,

--- a/test/WebSites/WebApi/EndPoints/OpenApiEndpoints.cs
+++ b/test/WebSites/WebApi/EndPoints/OpenApiEndpoints.cs
@@ -40,6 +40,18 @@ namespace WebApi.EndPoints
             .WithOpenApi()
             .DisableAntiforgery();
 
+            group.MapPost("/IFromFile", (IFormFile file) =>
+            {
+                return file.FileName;
+            }).WithOpenApi()
+            .DisableAntiforgery();
+
+            group.MapPost("/IFromFileCollection", (IFormFileCollection collection) =>
+            {
+                return $"{collection.Count} {string.Join(',', collection.Select(f => f.FileName))}";
+            }).WithOpenApi()
+            .DisableAntiforgery();
+
             return app;
         }
     }

--- a/test/WebSites/WebApi/EndPoints/OpenApiEndpoints.cs
+++ b/test/WebSites/WebApi/EndPoints/OpenApiEndpoints.cs
@@ -16,7 +16,9 @@ namespace WebApi.EndPoints
                 "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
             ];
 
-            var group = app.MapGroup("/WithOpenApi").WithTags("WithOpenApi");
+            var group = app.MapGroup("/WithOpenApi")
+                .WithTags("WithOpenApi")
+                .DisableAntiforgery();
 
             group.MapGet("weatherforecast", () =>
             {
@@ -35,22 +37,19 @@ namespace WebApi.EndPoints
 
             group.MapPost("/multipleForms", ([FromForm] Person person, [FromForm] Address address) =>
             {
-                TypedResults.NoContent();
+                return $"{person} {address}";
             })
-            .WithOpenApi()
-            .DisableAntiforgery();
+            .WithOpenApi();
 
             group.MapPost("/IFromFile", (IFormFile file) =>
             {
                 return file.FileName;
-            }).WithOpenApi()
-            .DisableAntiforgery();
+            }).WithOpenApi();
 
             group.MapPost("/IFromFileCollection", (IFormFileCollection collection) =>
             {
                 return $"{collection.Count} {string.Join(',', collection.Select(f => f.FileName))}";
-            }).WithOpenApi()
-            .DisableAntiforgery();
+            }).WithOpenApi();
 
             return app;
         }


### PR DESCRIPTION
This PR fixes #2625.
The documentation generated from Swashbuckle when the paramater was a FormFile or FormFileCollection was missing the Properties section in the Schema
