### PR TITLE
Use apiParameter.Type when it does not lie

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -407,7 +407,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 if (apiParameter is not null)
                 {
                     parameter.Schema = GenerateSchema(
-                        apiParameter.ModelMetadata.ModelType,
+                        apiParameter.Type,
                         schemaRepository,
                         apiParameter.PropertyInfo(),
                         apiParameter.ParameterInfo(),
@@ -568,9 +568,19 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             var isRequired = apiParameter.IsRequiredParameter();
 
-            var schema = (apiParameter.ModelMetadata != null)
+            var type = apiParameter.Type;
+
+            if (type is not null
+                && type == typeof(string)
+                && apiParameter.ModelMetadata?.ModelType is not null
+                && apiParameter.ModelMetadata.ModelType != type)
+            {
+                type = apiParameter.ModelMetadata.ModelType;
+            }
+
+            var schema = (type != null)
                 ? GenerateSchema(
-                    apiParameter.ModelMetadata.ModelType,
+                    type,
                     schemaRepository,
                     apiParameter.PropertyInfo(),
                     apiParameter.ParameterInfo(),

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_For_WebApi_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_For_WebApi_swaggerRequestUri=v1.verified.txt
@@ -48,6 +48,128 @@
         }
       }
     },
+    "/annotations/AsParameters": {
+      "get": {
+        "tags": [
+          "Annotations"
+        ],
+        "parameters": [
+          {
+            "name": "paramOne",
+            "in": "query",
+            "description": "Description",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "paramTwo",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "paramThree",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "paramFour",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "paramFive",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "paramSix",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "paramSeven",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "time"
+            }
+          },
+          {
+            "name": "paramEight",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "time"
+            }
+          },
+          {
+            "name": "paramNine",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/DateTimeKind"
+            }
+          },
+          {
+            "name": "paramTen",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DateTimeKind"
+            }
+          },
+          {
+            "name": "paramEleven",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "paramTwelve",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsParametersRecord"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/WithOpenApi/weatherforecast": {
       "get": {
         "tags": [
@@ -265,6 +387,72 @@
           }
         },
         "additionalProperties": false
+      },
+      "AsParametersRecord": {
+        "type": "object",
+        "properties": {
+          "paramOne": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "paramTwo": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "paramThree": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "paramFour": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paramFive": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "paramSix": {
+            "type": "string",
+            "format": "date"
+          },
+          "paramSeven": {
+            "type": "string",
+            "format": "time",
+            "nullable": true
+          },
+          "paramEight": {
+            "type": "string",
+            "format": "time"
+          },
+          "paramNine": {
+            "$ref": "#/components/schemas/DateTimeKind"
+          },
+          "paramTen": {
+            "$ref": "#/components/schemas/DateTimeKind"
+          },
+          "paramEleven": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "paramTwelve": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DateTimeKind": {
+        "enum": [
+          0,
+          1,
+          2
+        ],
+        "type": "integer",
+        "format": "int32"
       },
       "Fruit": {
         "type": "object",

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.TypesAreRenderedCorrectly.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.TypesAreRenderedCorrectly.verified.txt
@@ -48,6 +48,128 @@
         }
       }
     },
+    "/annotations/AsParameters": {
+      "get": {
+        "tags": [
+          "Annotations"
+        ],
+        "parameters": [
+          {
+            "name": "paramOne",
+            "in": "query",
+            "description": "Description",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "paramTwo",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "paramThree",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "paramFour",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "paramFive",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "paramSix",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "paramSeven",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "time"
+            }
+          },
+          {
+            "name": "paramEight",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "time"
+            }
+          },
+          {
+            "name": "paramNine",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/DateTimeKind"
+            }
+          },
+          {
+            "name": "paramTen",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DateTimeKind"
+            }
+          },
+          {
+            "name": "paramEleven",
+            "in": "query",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "paramTwelve",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsParametersRecord"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/WithOpenApi/weatherforecast": {
       "get": {
         "tags": [
@@ -265,6 +387,72 @@
           }
         },
         "additionalProperties": false
+      },
+      "AsParametersRecord": {
+        "type": "object",
+        "properties": {
+          "paramOne": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "paramTwo": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "paramThree": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "paramFour": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "paramFive": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "paramSix": {
+            "type": "string",
+            "format": "date"
+          },
+          "paramSeven": {
+            "type": "string",
+            "format": "time",
+            "nullable": true
+          },
+          "paramEight": {
+            "type": "string",
+            "format": "time"
+          },
+          "paramNine": {
+            "$ref": "#/components/schemas/DateTimeKind"
+          },
+          "paramTen": {
+            "$ref": "#/components/schemas/DateTimeKind"
+          },
+          "paramEleven": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "paramTwelve": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DateTimeKind": {
+        "enum": [
+          0,
+          1,
+          2
+        ],
+        "type": "integer",
+        "format": "int32"
       },
       "Fruit": {
         "type": "object",

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -339,7 +339,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                             new ApiParameterDescription
                             {
                                 Name = "ParameterInMetadata",
-                                ModelMetadata = ModelMetadataFactory.CreateForType(typeof(string))
+                                ModelMetadata = ModelMetadataFactory.CreateForType(typeof(string)),
+                                Type = typeof(string)
                             }
                         }),
                 }
@@ -604,7 +605,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                             {
                                 Name = "param",
                                 Source = BindingSource.Header,
-                                ModelMetadata = ModelMetadataFactory.CreateForType(typeof(string))
+                                ModelMetadata = ModelMetadataFactory.CreateForType(typeof(string)),
+                                Type = typeof(string)
                             }
                         }),
                 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.cs
@@ -272,7 +272,8 @@ public class SwaggerGeneratorVerifyTests
                         new ApiParameterDescription
                         {
                             Name = "ParameterInMetadata",
-                            ModelMetadata = ModelMetadataFactory.CreateForType(typeof(string))
+                            ModelMetadata = ModelMetadataFactory.CreateForType(typeof(string)),
+                            Type = typeof(string)
                         }
                     }),
             }
@@ -580,7 +581,8 @@ public class SwaggerGeneratorVerifyTests
                         {
                             Name = "param",
                             Source = BindingSource.Header,
-                            ModelMetadata = ModelMetadataFactory.CreateForType(typeof(string))
+                            ModelMetadata = ModelMetadataFactory.CreateForType(typeof(string)),
+                            Type = typeof(string)
                         }
                     }),
             }

--- a/test/Swashbuckle.AspNetCore.TestSupport/ApiExplorer/ApiDescriptionFactory.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/ApiExplorer/ApiDescriptionFactory.cs
@@ -48,6 +48,7 @@ namespace Swashbuckle.AspNetCore.TestSupport
                     if (parameterDescriptorWithParameterInfo != null && parameter.ModelMetadata == null)
                     {
                         parameter.ModelMetadata = ModelMetadataFactory.CreateForParameter(parameterDescriptorWithParameterInfo.ParameterInfo);
+                        parameter.Type = parameter.ModelMetadata.ModelType;
                     }
 
                     apiDescription.ParameterDescriptions.Add(parameter);
@@ -67,7 +68,7 @@ namespace Swashbuckle.AspNetCore.TestSupport
                 foreach (var responseType in supportedResponseTypes)
                 {
                     // If the provided action has a return value AND the response status is 2XX - use it to assign ModelMetadata
-                    if (methodInfo.ReturnType != null && responseType.StatusCode/100 == 2)
+                    if (methodInfo.ReturnType != null && responseType.StatusCode / 100 == 2)
                     {
                         responseType.ModelMetadata = ModelMetadataFactory.CreateForType(methodInfo.ReturnType);
                     }

--- a/test/WebSites/WebApi/EndPoints/SwaggerAnnotationsEndpoints.cs
+++ b/test/WebSites/WebApi/EndPoints/SwaggerAnnotationsEndpoints.cs
@@ -16,6 +16,11 @@ namespace WebApi.EndPoints
 
             group.MapPost("/fruit/{id}", CreateFruit);
 
+            group.MapGet("/AsParameters", ([AsParameters] AsParametersRecord record) =>
+            {
+                return record;
+            });
+
             return app;
         }
 
@@ -29,4 +34,11 @@ namespace WebApi.EndPoints
 
     [SwaggerSchema("Description for Schema")]
     record Fruit(string Name);
+
+    record class AsParametersRecord([SwaggerParameter(Description = "Description")] Guid? paramOne, Guid paramTwo,
+        DateTime? paramThree, DateTime paramFour,
+        DateOnly? paramFive, DateOnly paramSix,
+        TimeOnly? paramSeven, TimeOnly paramEight,
+        DateTimeKind? paramNine, DateTimeKind paramTen,
+        decimal? paramEleven, decimal paramTwelve);
 }

--- a/test/WebSites/WebApi/EndPoints/SwaggerAnnotationsEndpoints.cs
+++ b/test/WebSites/WebApi/EndPoints/SwaggerAnnotationsEndpoints.cs
@@ -35,10 +35,17 @@ namespace WebApi.EndPoints
     [SwaggerSchema("Description for Schema")]
     record Fruit(string Name);
 
-    record class AsParametersRecord([SwaggerParameter(Description = "Description")] Guid? paramOne, Guid paramTwo,
-        DateTime? paramThree, DateTime paramFour,
-        DateOnly? paramFive, DateOnly paramSix,
-        TimeOnly? paramSeven, TimeOnly paramEight,
-        DateTimeKind? paramNine, DateTimeKind paramTen,
-        decimal? paramEleven, decimal paramTwelve);
+    record class AsParametersRecord(
+        [SwaggerParameter(Description = "Description")] Guid? paramOne,
+        Guid paramTwo,
+        DateTime? paramThree,
+        DateTime paramFour,
+        DateOnly? paramFive,
+        DateOnly paramSix,
+        TimeOnly? paramSeven,
+        TimeOnly paramEight,
+        DateTimeKind? paramNine,
+        DateTimeKind paramTen,
+        decimal? paramEleven,
+        decimal paramTwelve);
 }


### PR DESCRIPTION
This PR fixes #2733.
It's a continuation of #2532 but with the VerifyTest running over IntegrationTest.

The issue is that the type for MvcWithNullable was coming as string(And its a LogLevel)
And the modelMetadata.ModelType that is coming from SwaggerAnnotationsEndpoints was coming as string.

So.. The best of both worlds