### PR TITLE
Document arrays of GenericParameters with XmlComments

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsNodeNameHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsNodeNameHelper.cs
@@ -50,7 +50,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private static string QualifiedNameFor(Type type, bool expandGenericArgs = false)
         {
             if (type.IsArray)
-                return $"{QualifiedNameFor(type.GetElementType(), expandGenericArgs)}[]";
+            {
+                var elementType = type.GetElementType();
+                return elementType.IsGenericParameter ? $"`{elementType.GenericParameterPosition}[]" : $"{QualifiedNameFor(type.GetElementType(), expandGenericArgs)}[]";
+            }
+
 
             var builder = new StringBuilder();
 

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=GenericControllers.Startup_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=GenericControllers.Startup_swaggerRequestUri=v1.verified.txt
@@ -57,6 +57,80 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "Orders"
+        ],
+        "summary": "Delete by Ids",
+        "parameters": [
+          {
+            "name": "tennantId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "deleting Ids",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            },
+            "text/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Deleted",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Failed"
+          }
+        }
       }
     },
     "/{tennantId}/products": {
@@ -109,6 +183,80 @@
                 }
               }
             }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Products"
+        ],
+        "summary": "Delete by Ids",
+        "parameters": [
+          {
+            "name": "tennantId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "deleting Ids",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Product"
+                }
+              }
+            },
+            "text/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Product"
+                }
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Product"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Deleted",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Failed"
           }
         }
       }

--- a/test/WebSites/GenericControllers/Controllers/GenericResourceController.cs
+++ b/test/WebSites/GenericControllers/Controllers/GenericResourceController.cs
@@ -1,6 +1,5 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using Microsoft.AspNetCore.Http;
+﻿using System.ComponentModel.DataAnnotations;
+using System.Threading;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GenericControllers.Controllers
@@ -11,11 +10,26 @@ namespace GenericControllers.Controllers
         /// Creates a resource
         /// </summary>
         /// <param name="resource">The resource</param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
         [HttpPost]
         [ProducesResponseType(201)]
         [Consumes("application/json")]
-        public int Create([FromBody, Required]TResource resource)
+        public int Create([FromBody, Required] TResource resource, CancellationToken cancellationToken)
+        {
+            return 1;
+        }
+
+        /// <summary>
+        /// Delete by Ids
+        /// </summary>
+        /// <param name="ids">deleting Ids</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        /// <response code="200">Deleted</response>
+        /// <response code="404">Failed</response>
+        [HttpDelete("")]
+        public virtual int Delete([Required, FromBody] TResource[] ids, CancellationToken cancellationToken)
         {
             return 1;
         }


### PR DESCRIPTION
It fixes an issue found while analyzing #2655 

I am hesitant to fix the other issue found (When there are 2 methods on a Controller with the same number of parameters, because you will have to make assumptions here. The base class has to has the firstParameter as TResource and do not have more parameters.. Because I tried to do the following:
![image](https://github.com/user-attachments/assets/81f31af8-bce8-4a56-b7ac-334bc8687577)


But it seems extremelly over complicated and I do not like it very much, the issue is that the XML only has the comments for the baseClass and when searching for the Method, SwashBuckle is searching by the Name, and the number of parameters inside the file MethodInfoExtensions