### PR TITLE
Make XML comment examples AoT compatible

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/CustomJsonSerializationContext.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/CustomJsonSerializationContext.cs
@@ -1,0 +1,12 @@
+﻿#if NET8_0_OR_GREATER
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen;
+
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(JsonElement))]
+internal sealed partial class CustomJsonSerializerContext : JsonSerializerContext;
+
+#endif

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/OpenApiAnyFactory.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/OpenApiAnyFactory.cs
@@ -9,7 +9,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             try
             {
-                var jsonElement = JsonSerializer.Deserialize<JsonElement>(json);
+                var jsonElement =
+#if NET8_0_OR_GREATER
+                    JsonSerializer.Deserialize(json, CustomJsonSerializerContext.Default.JsonElement)
+#else
+                    JsonSerializer.Deserialize<JsonElement>(json)
+#endif
+                    ;
 
                 return CreateFromJsonElement(jsonElement);
             }
@@ -18,7 +24,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             return null;
         }
 
-        private static IOpenApiAny CreateOpenApiArray(JsonElement jsonElement)
+        private static OpenApiArray CreateOpenApiArray(JsonElement jsonElement)
         {
             var openApiArray = new OpenApiArray();
 
@@ -30,7 +36,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             return openApiArray;
         }
 
-        private static IOpenApiAny CreateOpenApiObject(JsonElement jsonElement)
+        private static OpenApiObject CreateOpenApiObject(JsonElement jsonElement)
         {
             var openApiObject = new OpenApiObject();
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
@@ -15,8 +15,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 (schema?.ResolveType(schemaRepository) == "string") &&
                 !string.Equals(exampleString, "null");
 
-            var exampleAsJson = isStringType
-                    ? JsonSerializer.Serialize(exampleString)
+            var exampleAsJson = isStringType ?
+#if NET8_0_OR_GREATER
+                    JsonSerializer.Serialize(exampleString, CustomJsonSerializerContext.Default.String)
+#else
+                    JsonSerializer.Serialize(exampleString)
+#endif
                     : exampleString;
 
             var example = OpenApiAnyFactory.CreateFromJson(exampleAsJson);


### PR DESCRIPTION
Use the JSON source generator with `net8.0` to make XML comments' example generation compatible with native AoT.

Relates to #2985.
