### PR TITLE
Fix missing form parameter XML documentation

### DIFF
--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithXmlComments.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithXmlComments.cs
@@ -1,54 +1,48 @@
-﻿using Swashbuckle.AspNetCore.TestSupport;
-using System;
+﻿using Microsoft.AspNetCore.Mvc;
 
-namespace Swashbuckle.AspNetCore.SwaggerGen.Test
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test;
+
+/// <summary>
+/// Summary for FakeControllerWithXmlComments
+/// </summary>
+/// <response code="default">Description for default response</response>
+public class FakeControllerWithXmlComments
 {
     /// <summary>
-    /// Summary for FakeControllerWithXmlComments
+    /// Summary for ActionWithSummaryAndRemarksTags
     /// </summary>
-    /// <response code="default">Description for default response</response>
-    public class FakeControllerWithXmlComments
+    /// <remarks>
+    /// Remarks for ActionWithSummaryAndRemarksTags
+    /// </remarks>
+    public void ActionWithSummaryAndRemarksTags()
     {
-        /// <summary>
-        /// Summary for ActionWithSummaryAndRemarksTags
-        /// </summary>
-        /// <remarks>
-        /// Remarks for ActionWithSummaryAndRemarksTags
-        /// </remarks>
-        public void ActionWithSummaryAndRemarksTags()
-        { }
+    }
 
-        /// <param name="param1" example="Example for &quot;param1&quot;">Description for param1</param>
-        /// <param name="param2" example="http://test.com/?param1=1&amp;param2=2">Description for param2</param>
-        public void ActionWithParamTags(string param1, string param2)
-        { }
+    /// <param name="param1" example="Example for &quot;param1&quot;">Description for param1</param>
+    /// <param name="param2" example="http://test.com/?param1=1&amp;param2=2">Description for param2</param>
+    public void ActionWithParamTags(string param1, string param2)
+    {
+    }
 
+    /// <response code="200">Description for 200 response</response>
+    /// <response code="400">Description for 400 response</response>
+    public void ActionWithResponseTags()
+    {
+    }
 
+    /// <summary>
+    /// An action with a JSON body
+    /// </summary>
+    /// <param name="name">Parameter from JSON body</param>
+    public void PostBody([FromBody] string name)
+    {
+    }
 
-        /// <response code="200">Description for 200 response</response>
-        /// <response code="400">Description for 400 response</response>
-        public void ActionWithResponseTags()
-        { }
-
-        ///// <param name="boolParam" example="true"></param>
-        ///// <param name="intParam" example="27"></param>
-        ///// <param name="longParam" example="4294967296"></param>
-        ///// <param name="floatParam" example="1.23"></param>
-        ///// <param name="doubleParam" example="1.25"></param>
-        ///// <param name="enumParam" example="2"></param>
-        ///// <param name="guidParam" example="1edab3d2-311a-4782-9ec9-a70d0478b82f"></param>
-        ///// <param name="stringParam" example="Example for StringProperty"></param>
-        ///// <param name="badExampleIntParam" example="goodbye"></param>
-        //public void ActionWithExampleParams(
-        //    bool boolParam,
-        //    int intParam,
-        //    long longParam,
-        //    float floatParam,
-        //    double doubleParam,
-        //    IntEnum enumParam,
-        //    Guid guidParam,
-        //    string stringParam,
-        //    int badExampleIntParam)
-        //{ }
+    /// <summary>
+    /// An action with a form body
+    /// </summary>
+    /// <param name="name">Parameter from form body</param>
+    public void PostForm([FromForm] string name)
+    {
     }
 }


### PR DESCRIPTION
- Fix form parameters not being annotated with XML documentation.
- Refactor filter to use modern C# and be slightly more efficient.
- Remove commented-out code in test controller.

Resolves #3018.
