### PR TITLE
Fixes nullability problems with dictionaries

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
@@ -67,7 +67,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             if (memberType.IsValueType) return false;
 
             var nullableAttribute = memberInfo.GetNullableAttribute();
-            var valueArgument = memberType.GetGenericArguments()[1];
+            var genericArguments = memberType.GetGenericArguments();
+
+            if (genericArguments.Length != 2)
+            {
+                return false;
+            }
+
+            var valueArgument = genericArguments[1];
             var valueArgumentIsNullable = valueArgument.IsGenericType && valueArgument.GetGenericTypeDefinition() == typeof(Nullable<>);
 
             if (nullableAttribute == null)
@@ -79,7 +86,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             {
                 if (field.GetValue(nullableAttribute) is byte[] flags)
                 {
-                    // Ref.: https://github.com/dotnet/roslyn/blob/main/docs/features/nullable-metadata.md
+                    // See https://github.com/dotnet/roslyn/blob/af7b0ebe2b0ed5c335a928626c25620566372dd1/docs/features/nullable-metadata.md
                     if (flags.Length == 2)  // Value in the dictionary is a value type.
                     {
                         return !valueArgumentIsNullable;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
@@ -90,7 +90,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     // See https://github.com/dotnet/roslyn/blob/af7b0ebe2b0ed5c335a928626c25620566372dd1/docs/features/nullable-metadata.md
                     // Observations in the debugger show that the arity of the flags array is 3 only if all 3 items are reference types, i.e.
                     // Dictionary<string, object> would have arity 3 (one for the Dictionary, one for the string key, one for the object value),
-                    // however Dictionary<string, int> would have arity 2 (one for the Dictionary, one for the string key, the value type value is skipped).
+                    // however Dictionary<string, int> would have arity 2 (one for the Dictionary, one for the string key), the value is skipped
+                    // due it being a value type.
                     if (flags.Length == 2)  // Value in the dictionary is a value type.
                     {
                         return !valueArgumentIsNullable;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
@@ -12,6 +12,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private const string NullableFlagsFieldName = "NullableFlags";
         private const string NullableContextAttributeFullTypeName = "System.Runtime.CompilerServices.NullableContextAttribute";
         private const string FlagFieldName = "Flag";
+        private const int NotAnnotated = 1; // See https://github.com/dotnet/roslyn/blob/af7b0ebe2b0ed5c335a928626c25620566372dd1/docs/features/nullable-metadata.md?plain=1#L40
 
         public static IEnumerable<object> GetInlineAndMetadataAttributes(this MemberInfo memberInfo)
         {
@@ -50,7 +51,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             if (nullableAttribute.GetType().GetField(NullableFlagsFieldName) is FieldInfo field &&
                 field.GetValue(nullableAttribute) is byte[] flags &&
-                flags.Length >= 1 && flags[0] == 1)
+                flags.Length >= 1 && flags[0] == NotAnnotated)
             {
                 return true;
             }
@@ -87,13 +88,16 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 if (field.GetValue(nullableAttribute) is byte[] flags)
                 {
                     // See https://github.com/dotnet/roslyn/blob/af7b0ebe2b0ed5c335a928626c25620566372dd1/docs/features/nullable-metadata.md
+                    // Observations in the debugger show that the arity of the flags array is 3 only if all 3 items are reference types, i.e.
+                    // Dictionary<string, object> would have arity 3 (one for the Dictionary, one for the string key, one for the object value),
+                    // however Dictionary<string, int> would have arity 2 (one for the Dictionary, one for the string key, the value type value is skipped).
                     if (flags.Length == 2)  // Value in the dictionary is a value type.
                     {
                         return !valueArgumentIsNullable;
                     }
                     else if (flags.Length == 3) // Value in the dictionary is a reference type.
                     {
-                        return flags[2] == 1;   // 1 means "Not annotated".
+                        return flags[2] == NotAnnotated;
                     }
                 }
             }
@@ -126,7 +130,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 if (nullableContext != null)
                 {
                     if (nullableContext.GetType().GetField(FlagFieldName) is FieldInfo field &&
-                    field.GetValue(nullableContext) is byte flag && flag == 1)
+                    field.GetValue(nullableContext) is byte flag && flag == NotAnnotated)
                     {
                         return true;
                     }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -101,13 +101,21 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 // NullableAttribute behaves differently for Dictionaries
                 if (schema.AdditionalPropertiesAllowed && modelType.IsGenericType)
                 {
-                    var genericTypes = modelType.GetInterfaces().Concat(new[] { modelType }).Where(t => t.IsGenericType);
+                    var genericTypes = modelType
+                        .GetInterfaces()
+#if NETSTANDARD2_0
+                        .Concat(new[] { modelType })
+#else
+                        .Append(modelType)
+#endif
+                        .Where(t => t.IsGenericType)
+                        .ToArray();
 
-                    var dictionaryType =
+                    var isDictionaryType =
                         genericTypes.Any(t => t.GetGenericTypeDefinition() == typeof(IDictionary<,>)) ||
                         genericTypes.Any(t => t.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>));
 
-                    if (dictionaryType)
+                    if (isDictionaryType)
                     {
                         schema.AdditionalProperties.Nullable = !memberInfo.IsDictionaryValueNonNullable();
                     }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -99,10 +99,18 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 }
 
                 // NullableAttribute behaves differently for Dictionaries
-                if (schema.AdditionalPropertiesAllowed && modelType.IsGenericType &&
-                    modelType.GetGenericTypeDefinition() == typeof(Dictionary<,>))
+                if (schema.AdditionalPropertiesAllowed && modelType.IsGenericType)
                 {
-                    schema.AdditionalProperties.Nullable = !memberInfo.IsDictionaryValueNonNullable();
+                    var genericTypes = modelType.GetInterfaces().Concat(new[] { modelType }).Where(t => t.IsGenericType);
+
+                    var dictionaryType =
+                        genericTypes.Any(t => t.GetGenericTypeDefinition() == typeof(IDictionary<,>)) ||
+                        genericTypes.Any(t => t.GetGenericTypeDefinition() == typeof(IReadOnlyDictionary<,>));
+
+                    if (dictionaryType)
+                    {
+                        schema.AdditionalProperties.Nullable = !memberInfo.IsDictionaryValueNonNullable();
+                    }
                 }
 
                 schema.ApplyValidationAttributes(customAttributes);

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -744,6 +744,30 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableIReadOnlyDictionaryInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableIReadOnlyDictionaryInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableIReadOnlyDictionaryInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableIReadOnlyDictionaryInNullableContent), true, true)]
+        public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations_IReadOnlyDictionary(
+            Type declaringType,
+            string propertyName,
+            bool expectedNullableProperty,
+            bool expectedNullableContent)
+        {
+            var subject = Subject(
+                configureGenerator: c => c.SupportNonNullableReferenceTypes = true
+            );
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = subject.GenerateSchema(declaringType, schemaRepository);
+
+            var propertySchema = schemaRepository.Schemas[referenceSchema.Reference.Id].Properties[propertyName];
+            var contentSchema = schemaRepository.Schemas[referenceSchema.Reference.Id].Properties[propertyName].AdditionalProperties;
+            Assert.Equal(expectedNullableProperty, propertySchema.Nullable);
+            Assert.Equal(expectedNullableContent, contentSchema.Nullable);
+        }
+
+        [Theory]
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.SubTypeWithOneNullableContent), nameof(TypeWithNullableContext.NullableString), true)]
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContext.NonNullableString), false)]
         public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypesInDictionary_NullableAttribute_Compiler_Optimizations_Situations(

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -696,10 +696,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableDictionaryWithNonNullableContent), true, false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableDictionaryWithNonNullableContent), false, false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableDictionaryWithNullableContent), false, true)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableDictionaryWithNullableContent), true, true)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableDictionaryInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableDictionaryInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableDictionaryInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableDictionaryInNullableContent), true, true)]
         public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations(
             Type declaringType,
             string propertyName,

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -720,6 +720,30 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableIDictionaryInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableIDictionaryInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableIDictionaryInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableIDictionaryInNullableContent), true, true)]
+        public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations_IDictionary(
+            Type declaringType,
+            string propertyName,
+            bool expectedNullableProperty,
+            bool expectedNullableContent)
+        {
+            var subject = Subject(
+                configureGenerator: c => c.SupportNonNullableReferenceTypes = true
+            );
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = subject.GenerateSchema(declaringType, schemaRepository);
+
+            var propertySchema = schemaRepository.Schemas[referenceSchema.Reference.Id].Properties[propertyName];
+            var contentSchema = schemaRepository.Schemas[referenceSchema.Reference.Id].Properties[propertyName].AdditionalProperties;
+            Assert.Equal(expectedNullableProperty, propertySchema.Nullable);
+            Assert.Equal(expectedNullableContent, contentSchema.Nullable);
+        }
+
+        [Theory]
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.SubTypeWithOneNullableContent), nameof(TypeWithNullableContext.NullableString), true)]
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContext.NonNullableString), false)]
         public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypesInDictionary_NullableAttribute_Compiler_Optimizations_Situations(

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -768,6 +768,78 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableDictionaryWithValueTypeInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableDictionaryWithValueTypeInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableDictionaryWithValueTypeInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableDictionaryWithValueTypeInNullableContent), true, true)]
+        public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations_DictionaryWithValueType(
+                    Type declaringType,
+                    string propertyName,
+                    bool expectedNullableProperty,
+                    bool expectedNullableContent)
+        {
+            var subject = Subject(
+                configureGenerator: c => c.SupportNonNullableReferenceTypes = true
+            );
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = subject.GenerateSchema(declaringType, schemaRepository);
+
+            var propertySchema = schemaRepository.Schemas[referenceSchema.Reference.Id].Properties[propertyName];
+            var contentSchema = schemaRepository.Schemas[referenceSchema.Reference.Id].Properties[propertyName].AdditionalProperties;
+            Assert.Equal(expectedNullableProperty, propertySchema.Nullable);
+            Assert.Equal(expectedNullableContent, contentSchema.Nullable);
+        }
+
+        [Theory]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableIDictionaryWithValueTypeInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableIDictionaryWithValueTypeInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableIDictionaryWithValueTypeInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableIDictionaryWithValueTypeInNullableContent), true, true)]
+        public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations_IDictionaryWithValueType(
+            Type declaringType,
+            string propertyName,
+            bool expectedNullableProperty,
+            bool expectedNullableContent)
+        {
+            var subject = Subject(
+                configureGenerator: c => c.SupportNonNullableReferenceTypes = true
+            );
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = subject.GenerateSchema(declaringType, schemaRepository);
+
+            var propertySchema = schemaRepository.Schemas[referenceSchema.Reference.Id].Properties[propertyName];
+            var contentSchema = schemaRepository.Schemas[referenceSchema.Reference.Id].Properties[propertyName].AdditionalProperties;
+            Assert.Equal(expectedNullableProperty, propertySchema.Nullable);
+            Assert.Equal(expectedNullableContent, contentSchema.Nullable);
+        }
+
+        [Theory]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableIReadOnlyDictionaryWithValueTypeInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableIReadOnlyDictionaryWithValueTypeInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableIReadOnlyDictionaryWithValueTypeInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableIReadOnlyDictionaryWithValueTypeInNullableContent), true, true)]
+        public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations_IReadOnlyDictionaryWithValueType(
+            Type declaringType,
+            string propertyName,
+            bool expectedNullableProperty,
+            bool expectedNullableContent)
+        {
+            var subject = Subject(
+                configureGenerator: c => c.SupportNonNullableReferenceTypes = true
+            );
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = subject.GenerateSchema(declaringType, schemaRepository);
+
+            var propertySchema = schemaRepository.Schemas[referenceSchema.Reference.Id].Properties[propertyName];
+            var contentSchema = schemaRepository.Schemas[referenceSchema.Reference.Id].Properties[propertyName].AdditionalProperties;
+            Assert.Equal(expectedNullableProperty, propertySchema.Nullable);
+            Assert.Equal(expectedNullableContent, contentSchema.Nullable);
+        }
+
+        [Theory]
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.SubTypeWithOneNullableContent), nameof(TypeWithNullableContext.NullableString), true)]
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContext.NonNullableString), false)]
         public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypesInDictionary_NullableAttribute_Compiler_Optimizations_Situations(

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -700,7 +700,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableDictionaryInNonNullableContent), false, false)]
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableDictionaryInNullableContent), false, true)]
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableDictionaryInNullableContent), true, true)]
-        public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations(
+        public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations_Dictionary(
             Type declaringType,
             string propertyName,
             bool expectedNullableProperty,

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -773,10 +773,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableDictionaryWithValueTypeInNullableContent), false, true)]
         [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableDictionaryWithValueTypeInNullableContent), true, true)]
         public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations_DictionaryWithValueType(
-                    Type declaringType,
-                    string propertyName,
-                    bool expectedNullableProperty,
-                    bool expectedNullableContent)
+            Type declaringType,
+            string propertyName,
+            bool expectedNullableProperty,
+            bool expectedNullableContent)
         {
             var subject = Subject(
                 configureGenerator: c => c.SupportNonNullableReferenceTypes = true

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
@@ -30,20 +30,20 @@ namespace Swashbuckle.AspNetCore.TestSupport
         public IReadOnlyDictionary<string, string?> NonNullableIReadOnlyDictionaryInNullableContent { get; set; } = default!;
         public IReadOnlyDictionary<string, string?>? NullableIReadOnlyDictionaryInNullableContent { get; set; }
 
-        public Dictionary<string, string>? NullableDictionaryWithValueTypeInNonNullableContent { get; set; }
-        public Dictionary<string, string> NonNullableDictionaryWithValueTypeInNonNullableContent { get; set; } = default!;
-        public Dictionary<string, string?> NonNullableDictionaryWithValueTypeInNullableContent { get; set; } = default!;
-        public Dictionary<string, string?>? NullableDictionaryWithValueTypeInNullableContent { get; set; }
+        public Dictionary<string, int>? NullableDictionaryWithValueTypeInNonNullableContent { get; set; }
+        public Dictionary<string, int> NonNullableDictionaryWithValueTypeInNonNullableContent { get; set; } = default!;
+        public Dictionary<string, int?> NonNullableDictionaryWithValueTypeInNullableContent { get; set; } = default!;
+        public Dictionary<string, int?>? NullableDictionaryWithValueTypeInNullableContent { get; set; }
 
-        public IDictionary<string, string>? NullableIDictionaryWithValueTypeInNonNullableContent { get; set; }
-        public IDictionary<string, string> NonNullableIDictionaryWithValueTypeInNonNullableContent { get; set; } = default!;
-        public IDictionary<string, string?> NonNullableIDictionaryWithValueTypeInNullableContent { get; set; } = default!;
-        public IDictionary<string, string?>? NullableIDictionaryWithValueTypeInNullableContent { get; set; }
+        public IDictionary<string, int>? NullableIDictionaryWithValueTypeInNonNullableContent { get; set; }
+        public IDictionary<string, int> NonNullableIDictionaryWithValueTypeInNonNullableContent { get; set; } = default!;
+        public IDictionary<string, int?> NonNullableIDictionaryWithValueTypeInNullableContent { get; set; } = default!;
+        public IDictionary<string, int?>? NullableIDictionaryWithValueTypeInNullableContent { get; set; }
 
-        public IReadOnlyDictionary<string, string>? NullableIReadOnlyDictionaryWithValueTypeInNonNullableContent { get; set; }
-        public IReadOnlyDictionary<string, string> NonNullableIReadOnlyDictionaryWithValueTypeInNonNullableContent { get; set; } = default!;
-        public IReadOnlyDictionary<string, string?> NonNullableIReadOnlyDictionaryWithValueTypeInNullableContent { get; set; } = default!;
-        public IReadOnlyDictionary<string, string?>? NullableIReadOnlyDictionaryWithValueTypeInNullableContent { get; set; }
+        public IReadOnlyDictionary<string, int>? NullableIReadOnlyDictionaryWithValueTypeInNonNullableContent { get; set; }
+        public IReadOnlyDictionary<string, int> NonNullableIReadOnlyDictionaryWithValueTypeInNonNullableContent { get; set; } = default!;
+        public IReadOnlyDictionary<string, int?> NonNullableIReadOnlyDictionaryWithValueTypeInNullableContent { get; set; } = default!;
+        public IReadOnlyDictionary<string, int?>? NullableIReadOnlyDictionaryWithValueTypeInNullableContent { get; set; }
 
         public class SubTypeWithOneNullableContent
         {

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
@@ -30,6 +30,21 @@ namespace Swashbuckle.AspNetCore.TestSupport
         public IReadOnlyDictionary<string, string?> NonNullableIReadOnlyDictionaryInNullableContent { get; set; } = default!;
         public IReadOnlyDictionary<string, string?>? NullableIReadOnlyDictionaryInNullableContent { get; set; }
 
+        public Dictionary<string, string>? NullableDictionaryWithValueTypeInNonNullableContent { get; set; }
+        public Dictionary<string, string> NonNullableDictionaryWithValueTypeInNonNullableContent { get; set; } = default!;
+        public Dictionary<string, string?> NonNullableDictionaryWithValueTypeInNullableContent { get; set; } = default!;
+        public Dictionary<string, string?>? NullableDictionaryWithValueTypeInNullableContent { get; set; }
+
+        public IDictionary<string, string>? NullableIDictionaryWithValueTypeInNonNullableContent { get; set; }
+        public IDictionary<string, string> NonNullableIDictionaryWithValueTypeInNonNullableContent { get; set; } = default!;
+        public IDictionary<string, string?> NonNullableIDictionaryWithValueTypeInNullableContent { get; set; } = default!;
+        public IDictionary<string, string?>? NullableIDictionaryWithValueTypeInNullableContent { get; set; }
+
+        public IReadOnlyDictionary<string, string>? NullableIReadOnlyDictionaryWithValueTypeInNonNullableContent { get; set; }
+        public IReadOnlyDictionary<string, string> NonNullableIReadOnlyDictionaryWithValueTypeInNonNullableContent { get; set; } = default!;
+        public IReadOnlyDictionary<string, string?> NonNullableIReadOnlyDictionaryWithValueTypeInNullableContent { get; set; } = default!;
+        public IReadOnlyDictionary<string, string?>? NullableIReadOnlyDictionaryWithValueTypeInNullableContent { get; set; }
+
         public class SubTypeWithOneNullableContent
         {
             public string? NullableString { get; set; }

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
@@ -20,6 +20,11 @@ namespace Swashbuckle.AspNetCore.TestSupport
         public Dictionary<string, string?> NonNullableDictionaryInNullableContent { get; set; } = default!;
         public Dictionary<string, string?>? NullableDictionaryInNullableContent { get; set; }
 
+        public IDictionary<string, string>? NullableIDictionaryInNonNullableContent { get; set; }
+        public IDictionary<string, string> NonNullableIDictionaryInNonNullableContent { get; set; } = default!;
+        public IDictionary<string, string?> NonNullableIDictionaryInNullableContent { get; set; } = default!;
+        public IDictionary<string, string?>? NullableIDictionaryInNullableContent { get; set; }
+
         public class SubTypeWithOneNullableContent
         {
             public string? NullableString { get; set; }

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
@@ -15,10 +15,10 @@ namespace Swashbuckle.AspNetCore.TestSupport
         public List<SubTypeWithOneNullableContent>? NullableList { get; set; }
         public List<SubTypeWithOneNonNullableContent> NonNullableList { get; set; } = default!;
 
-        public Dictionary<string, string>? NullableDictionaryWithNonNullableContent { get; set; }
-        public Dictionary<string, string> NonNullableDictionaryWithNonNullableContent { get; set; } = default!;
-        public Dictionary<string, string?> NonNullableDictionaryWithNullableContent { get; set; } = default!;
-        public Dictionary<string, string?>? NullableDictionaryWithNullableContent { get; set; }
+        public Dictionary<string, string>? NullableDictionaryInNonNullableContent { get; set; }
+        public Dictionary<string, string> NonNullableDictionaryInNonNullableContent { get; set; } = default!;
+        public Dictionary<string, string?> NonNullableDictionaryInNullableContent { get; set; } = default!;
+        public Dictionary<string, string?>? NullableDictionaryInNullableContent { get; set; }
 
         public class SubTypeWithOneNullableContent
         {

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
@@ -25,6 +25,11 @@ namespace Swashbuckle.AspNetCore.TestSupport
         public IDictionary<string, string?> NonNullableIDictionaryInNullableContent { get; set; } = default!;
         public IDictionary<string, string?>? NullableIDictionaryInNullableContent { get; set; }
 
+        public IReadOnlyDictionary<string, string>? NullableIReadOnlyDictionaryInNonNullableContent { get; set; }
+        public IReadOnlyDictionary<string, string> NonNullableIReadOnlyDictionaryInNonNullableContent { get; set; } = default!;
+        public IReadOnlyDictionary<string, string?> NonNullableIReadOnlyDictionaryInNullableContent { get; set; } = default!;
+        public IReadOnlyDictionary<string, string?>? NullableIReadOnlyDictionaryInNullableContent { get; set; }
+
         public class SubTypeWithOneNullableContent
         {
             public string? NullableString { get; set; }


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
Fixes #3022 

<!-- Please include the existing GitHub issue number where relevant, e.g. "Fixes #123" -->

## Details on the issue fix or feature implementation
Fixes both issues described in the bug, namely:
1) Correctly describing `Dictionary<string, int>?` as having the `int` value being NON nullable in `additionalProperties`
2) Support `IDictionary<,>` and `IReadOnlyDictionary<,>` in addition to `Dictionary<,>` so that the behavior is consistent across interface vs concrete

<!-- Information about your changes -->
