### PR TITLE
Use NullabilityInfoContext to determine dictionary value nullability

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
@@ -61,6 +61,19 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public static bool IsDictionaryValueNonNullable(this MemberInfo memberInfo)
         {
+#if NET6_0_OR_GREATER
+            var context = new NullabilityInfoContext();
+            var nullableInfo = memberInfo.MemberType == MemberTypes.Field
+                ? context.Create((FieldInfo)memberInfo)
+                : context.Create((PropertyInfo)memberInfo);
+
+            if (nullableInfo.GenericTypeArguments.Length != 2)
+            {
+                throw new InvalidOperationException("Expected Dictionary to have two generic type arguments.");
+            }
+
+            return nullableInfo.GenericTypeArguments[1].ReadState == NullabilityState.NotNull;
+#else
             var memberType = memberInfo.MemberType == MemberTypes.Field
                 ? ((FieldInfo)memberInfo).FieldType
                 : ((PropertyInfo)memberInfo).PropertyType;
@@ -104,6 +117,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             }
 
             return false;
+#endif
         }
 
         private static object GetNullableAttribute(this MemberInfo memberInfo)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
@@ -69,7 +69,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             if (nullableInfo.GenericTypeArguments.Length != 2)
             {
-                throw new InvalidOperationException("Expected Dictionary to have two generic type arguments.");
+                var length = nullableInfo.GenericTypeArguments.Length;
+                var type = nullableInfo.Type.FullName;
+                var container = memberInfo.DeclaringType.FullName;
+                var member = memberInfo.Name;
+                throw new InvalidOperationException($"Expected Dictionary to have two generic type arguments but it had {length}. Member: {container}.{member} Type: {type}.");
             }
 
             return nullableInfo.GenericTypeArguments[1].ReadState == NullabilityState.NotNull;

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -674,6 +674,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [Fact]
         public void TypeWithNullableContextAnnotated_IsAnnotated()
         {
+            // This is a sanity check to ensure that TypeWithNullableContextAnnotated
+            // is annotated with NullableContext(Flag=2) by the compiler. If this is no
+            // longer the case, you may need to add more of the Dummy properties to
+            // coerce the compiler.
+
             const string Name = "System.Runtime.CompilerServices.NullableContextAttribute";
 
             var nullableContext = typeof(TypeWithNullableContextAnnotated)
@@ -690,6 +695,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [Fact]
         public void TypeWithNullableContextNotAnnotated_IsNotAnnotated()
         {
+            // This is a sanity check to ensure that TypeWithNullableContextNotAnnotated
+            // is annotated with NullableContext(Flag=1) by the compiler. If this is no
+            // longer the case, you may need to add more of the Dummy properties to
+            // coerce the compiler.
+
             const string Name = "System.Runtime.CompilerServices.NullableContextAttribute";
 
             var nullableContext = typeof(TypeWithNullableContextNotAnnotated)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Dynamic;
 using System.Linq;
 using System.Net;
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
@@ -670,15 +671,55 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.NotNull(schema.Enum);
         }
 
+        [Fact]
+        public void TypeWithNullableContextAnnotated_IsAnnotated()
+        {
+            const string Name = "System.Runtime.CompilerServices.NullableContextAttribute";
+
+            var nullableContext = typeof(TypeWithNullableContextAnnotated)
+                .GetCustomAttributes()
+                .FirstOrDefault(attr => string.Equals(attr.GetType().FullName, Name));
+
+            Assert.NotNull(nullableContext);
+
+            var flag = nullableContext?.GetType().GetField("Flag")?.GetValue(nullableContext);
+
+            Assert.Equal((byte)2, flag);
+        }
+
+        [Fact]
+        public void TypeWithNullableContextNotAnnotated_IsNotAnnotated()
+        {
+            const string Name = "System.Runtime.CompilerServices.NullableContextAttribute";
+
+            var nullableContext = typeof(TypeWithNullableContextNotAnnotated)
+                .GetCustomAttributes()
+                .FirstOrDefault(attr => string.Equals(attr.GetType().FullName, Name));
+
+            Assert.NotNull(nullableContext);
+
+            var flag = nullableContext?.GetType().GetField("Flag")?.GetValue(nullableContext);
+
+            Assert.Equal((byte)1, flag);
+        }
+
         [Theory]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableInt), true)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableInt), false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableString), true)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableString), false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableArray), true)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableArray), false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableList), true)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableList), false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NullableInt), true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NonNullableInt), false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NullableString), true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NonNullableString), false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NullableArray), true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NonNullableArray), false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NullableList), true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NonNullableList), false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NullableInt), true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NonNullableInt), false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NullableString), true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NonNullableString), false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NullableArray), true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NonNullableArray), false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NullableList), true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NonNullableList), false)]
         public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes(
             Type declaringType,
             string propertyName,
@@ -696,10 +737,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableDictionaryInNonNullableContent), true, false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableDictionaryInNonNullableContent), false, false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableDictionaryInNullableContent), false, true)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableDictionaryInNullableContent), true, true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NullableDictionaryInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NonNullableDictionaryInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NonNullableDictionaryInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NullableDictionaryInNullableContent), true, true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NullableDictionaryInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NonNullableDictionaryInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NonNullableDictionaryInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NullableDictionaryInNullableContent), true, true)]
         public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations_Dictionary(
             Type declaringType,
             string propertyName,
@@ -720,10 +765,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableIDictionaryInNonNullableContent), true, false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableIDictionaryInNonNullableContent), false, false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableIDictionaryInNullableContent), false, true)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableIDictionaryInNullableContent), true, true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NullableIDictionaryInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NonNullableIDictionaryInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NonNullableIDictionaryInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NullableIDictionaryInNullableContent), true, true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NullableIDictionaryInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NonNullableIDictionaryInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NonNullableIDictionaryInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NullableIDictionaryInNullableContent), true, true)]
         public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations_IDictionary(
             Type declaringType,
             string propertyName,
@@ -744,10 +793,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableIReadOnlyDictionaryInNonNullableContent), true, false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableIReadOnlyDictionaryInNonNullableContent), false, false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableIReadOnlyDictionaryInNullableContent), false, true)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableIReadOnlyDictionaryInNullableContent), true, true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NullableIReadOnlyDictionaryInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NonNullableIReadOnlyDictionaryInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NonNullableIReadOnlyDictionaryInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NullableIReadOnlyDictionaryInNullableContent), true, true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NullableIReadOnlyDictionaryInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NonNullableIReadOnlyDictionaryInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NonNullableIReadOnlyDictionaryInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NullableIReadOnlyDictionaryInNullableContent), true, true)]
         public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations_IReadOnlyDictionary(
             Type declaringType,
             string propertyName,
@@ -768,10 +821,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableDictionaryWithValueTypeInNonNullableContent), true, false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableDictionaryWithValueTypeInNonNullableContent), false, false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableDictionaryWithValueTypeInNullableContent), false, true)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableDictionaryWithValueTypeInNullableContent), true, true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NullableDictionaryWithValueTypeInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NonNullableDictionaryWithValueTypeInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NonNullableDictionaryWithValueTypeInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NullableDictionaryWithValueTypeInNullableContent), true, true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NullableDictionaryWithValueTypeInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NonNullableDictionaryWithValueTypeInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NonNullableDictionaryWithValueTypeInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NullableDictionaryWithValueTypeInNullableContent), true, true)]
         public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations_DictionaryWithValueType(
             Type declaringType,
             string propertyName,
@@ -792,10 +849,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableIDictionaryWithValueTypeInNonNullableContent), true, false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableIDictionaryWithValueTypeInNonNullableContent), false, false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableIDictionaryWithValueTypeInNullableContent), false, true)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableIDictionaryWithValueTypeInNullableContent), true, true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NullableIDictionaryWithValueTypeInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NonNullableIDictionaryWithValueTypeInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NonNullableIDictionaryWithValueTypeInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NullableIDictionaryWithValueTypeInNullableContent), true, true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NullableIDictionaryWithValueTypeInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NonNullableIDictionaryWithValueTypeInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NonNullableIDictionaryWithValueTypeInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NullableIDictionaryWithValueTypeInNullableContent), true, true)]
         public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations_IDictionaryWithValueType(
             Type declaringType,
             string propertyName,
@@ -816,10 +877,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableIReadOnlyDictionaryWithValueTypeInNonNullableContent), true, false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableIReadOnlyDictionaryWithValueTypeInNonNullableContent), false, false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NonNullableIReadOnlyDictionaryWithValueTypeInNullableContent), false, true)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.NullableIReadOnlyDictionaryWithValueTypeInNullableContent), true, true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NullableIReadOnlyDictionaryWithValueTypeInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NonNullableIReadOnlyDictionaryWithValueTypeInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NonNullableIReadOnlyDictionaryWithValueTypeInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.NullableIReadOnlyDictionaryWithValueTypeInNullableContent), true, true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NullableIReadOnlyDictionaryWithValueTypeInNonNullableContent), true, false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NonNullableIReadOnlyDictionaryWithValueTypeInNonNullableContent), false, false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NonNullableIReadOnlyDictionaryWithValueTypeInNullableContent), false, true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.NullableIReadOnlyDictionaryWithValueTypeInNullableContent), true, true)]
         public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NullableAttribute_Compiler_Optimizations_Situations_IReadOnlyDictionaryWithValueType(
             Type declaringType,
             string propertyName,
@@ -840,8 +905,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.SubTypeWithOneNullableContent), nameof(TypeWithNullableContext.NullableString), true)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContext.NonNullableString), false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.SubTypeWithOneNullableContent), nameof(TypeWithNullableContextAnnotated.NullableString), true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContextAnnotated.NonNullableString), false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.SubTypeWithOneNullableContent), nameof(TypeWithNullableContextNotAnnotated.NullableString), true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContextNotAnnotated.NonNullableString), false)]
         public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypesInDictionary_NullableAttribute_Compiler_Optimizations_Situations(
             Type declaringType,
             string subType,
@@ -860,8 +927,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.SubTypeWithOneNullableContent), nameof(TypeWithNullableContext.NullableString), false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContext.NonNullableString), true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.SubTypeWithOneNullableContent), nameof(TypeWithNullableContextAnnotated.NullableString), false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContextAnnotated.NonNullableString), true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.SubTypeWithOneNullableContent), nameof(TypeWithNullableContextNotAnnotated.NullableString), false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContextNotAnnotated.NonNullableString), true)]
         public void GenerateSchema_SupportsOption_NonNullableReferenceTypesAsRequired_RequiredAttribute_Compiler_Optimizations_Situations(
             Type declaringType,
             string subType,
@@ -880,8 +949,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContext.NonNullableString), false)]
-        [InlineData(typeof(TypeWithNullableContext), nameof(TypeWithNullableContext.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContext.NonNullableString), true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContextAnnotated.NonNullableString), false)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContextAnnotated.NonNullableString), true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContextNotAnnotated.NonNullableString), false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContextNotAnnotated.NonNullableString), true)]
         public void GenerateSchema_SupportsOption_SuppressImplicitRequiredAttributeForNonNullableReferenceTypes(
             Type declaringType,
             string subType,
@@ -900,8 +971,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal(!suppress, propertyIsRequired);
         }
 
-        [Fact]
-        public void GenerateSchema_Works_IfNotProvidingMvcOptions()
+        [Theory]
+        [InlineData(typeof(TypeWithNullableContextAnnotated))]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated))]
+        public void GenerateSchema_Works_IfNotProvidingMvcOptions(Type type)
         {
             var generatorOptions = new SchemaGeneratorOptions
             {
@@ -913,10 +986,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var subject = new SchemaGenerator(generatorOptions, new JsonSerializerDataContractResolver(serializerOptions));
             var schemaRepository = new SchemaRepository();
 
-            subject.GenerateSchema(typeof(TypeWithNullableContext), schemaRepository);
+            subject.GenerateSchema(type, schemaRepository);
 
-            var subType = nameof(TypeWithNullableContext.SubTypeWithOneNonNullableContent);
-            var propertyName = nameof(TypeWithNullableContext.NonNullableString);
+            var subType = nameof(TypeWithNullableContextAnnotated.SubTypeWithOneNonNullableContent);
+            var propertyName = nameof(TypeWithNullableContextAnnotated.NonNullableString);
             var propertyIsRequired = schemaRepository.Schemas[subType].Required.Contains(propertyName);
             Assert.True(propertyIsRequired);
         }

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
@@ -11,12 +11,13 @@ namespace Swashbuckle.AspNetCore.TestSupport
     // Remember to mirror both types and use both types in tests.
 
     /// <summary>
-    /// We expect this type to receive NullableContext(1) (NotAnnotated) from the compiler.
+    /// We expect this type to receive NullableContext(Flag=1) (NotAnnotated) from the compiler.
     /// </summary>
     public class TypeWithNullableContextNotAnnotated
     {
-        // Dummies to affect the NullableContextAttribute value.
-        // It seems to default to the most common nullable state.
+        // Dummy properties to affect the NullableContextAttribute placed on the type.
+        // It seems to default to the most common nullable state, so we overwhelm
+        // it with non-nullable properties in order to coerce it.
         public string Dummy1 { get; } = default!;
         public string Dummy2 { get; } = default!;
         public string Dummy3 { get; } = default!;
@@ -90,12 +91,13 @@ namespace Swashbuckle.AspNetCore.TestSupport
     }
 
     /// <summary>
-    /// We expect this type to receive NullableContext(2) (Annotated) from the compiler.
+    /// We expect this type to receive NullableContext(Flag=2) (Annotated) from the compiler.
     /// </summary>
     public class TypeWithNullableContextAnnotated
     {
-        // Dummies to affect the NullableContextAttribute value.
-        // It seems to default to the most common nullable state.
+        // Dummy properties to affect the NullableContextAttribute placed on the type.
+        // It seems to default to the most common nullable state, so we overwhelm
+        // it with nullable properties in order to coerce it.
         public string? Dummy1 { get; set; }
         public string? Dummy2 { get; set; }
         public string? Dummy3 { get; set; }

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
@@ -3,8 +3,41 @@
 namespace Swashbuckle.AspNetCore.TestSupport
 {
 #nullable enable
-    public class TypeWithNullableContext
+
+    // These types are used to test our handling of nullable references types.
+    // NRT results in NullableContextAttribute and NullableAttribute being placed on
+    // types and members by the compiler.
+
+    // Remember to mirror both types and use both types in tests.
+
+    /// <summary>
+    /// We expect this type to receive NullableContext(1) (NotAnnotated) from the compiler.
+    /// </summary>
+    public class TypeWithNullableContextNotAnnotated
     {
+        // Dummies to affect the NullableContextAttribute value.
+        // It seems to default to the most common nullable state.
+        public string Dummy1 { get; } = default!;
+        public string Dummy2 { get; } = default!;
+        public string Dummy3 { get; } = default!;
+        public string Dummy4 { get; } = default!;
+        public string Dummy5 { get; } = default!;
+        public string Dummy6 { get; } = default!;
+        public string Dummy7 { get; } = default!;
+        public string Dummy8 { get; } = default!;
+        public string Dummy9 { get; } = default!;
+        public string Dummy10 { get; } = default!;
+        public string Dummy11 { get; set; } = default!;
+        public string Dummy12 { get; set; } = default!;
+        public string Dummy13 { get; set; } = default!;
+        public string Dummy14 { get; set; } = default!;
+        public string Dummy15 { get; set; } = default!;
+        public string Dummy16 { get; set; } = default!;
+        public string Dummy17 { get; set; } = default!;
+        public string Dummy18 { get; set; } = default!;
+        public string Dummy19 { get; set; } = default!;
+        public string Dummy20 { get; set; } = default!;
+
         public int? NullableInt { get; set; }
         public int NonNullableInt { get; set; }
         public string? NullableString { get; set; }
@@ -54,8 +87,85 @@ namespace Swashbuckle.AspNetCore.TestSupport
         {
             public string NonNullableString { get; set; } = default!;
         }
+    }
 
+    /// <summary>
+    /// We expect this type to receive NullableContext(2) (Annotated) from the compiler.
+    /// </summary>
+    public class TypeWithNullableContextAnnotated
+    {
+        // Dummies to affect the NullableContextAttribute value.
+        // It seems to default to the most common nullable state.
+        public string? Dummy1 { get; set; }
+        public string? Dummy2 { get; set; }
+        public string? Dummy3 { get; set; }
+        public string? Dummy4 { get; set; }
+        public string? Dummy5 { get; set; }
+        public string? Dummy6 { get; set; }
+        public string? Dummy7 { get; set; }
+        public string? Dummy8 { get; set; }
+        public string? Dummy9 { get; set; }
+        public string? Dummy10 { get; set; }
+        public string? Dummy11 { get; set; }
+        public string? Dummy12 { get; set; }
+        public string? Dummy13 { get; set; }
+        public string? Dummy14 { get; set; }
+        public string? Dummy15 { get; set; }
+        public string? Dummy16 { get; set; }
+        public string? Dummy17 { get; set; }
+        public string? Dummy18 { get; set; }
+        public string? Dummy19 { get; set; }
+        public string? Dummy20 { get; set; }
 
+        public int? NullableInt { get; set; }
+        public int NonNullableInt { get; set; }
+        public string? NullableString { get; set; }
+        public string NonNullableString { get; set; } = default!;
+        public int[]? NullableArray { get; set; }
+        public int[] NonNullableArray { get; set; } = default!;
+
+        public List<SubTypeWithOneNullableContent>? NullableList { get; set; }
+        public List<SubTypeWithOneNonNullableContent> NonNullableList { get; set; } = default!;
+
+        public Dictionary<string, string>? NullableDictionaryInNonNullableContent { get; set; }
+        public Dictionary<string, string> NonNullableDictionaryInNonNullableContent { get; set; } = default!;
+        public Dictionary<string, string?> NonNullableDictionaryInNullableContent { get; set; } = default!;
+        public Dictionary<string, string?>? NullableDictionaryInNullableContent { get; set; }
+
+        public IDictionary<string, string>? NullableIDictionaryInNonNullableContent { get; set; }
+        public IDictionary<string, string> NonNullableIDictionaryInNonNullableContent { get; set; } = default!;
+        public IDictionary<string, string?> NonNullableIDictionaryInNullableContent { get; set; } = default!;
+        public IDictionary<string, string?>? NullableIDictionaryInNullableContent { get; set; }
+
+        public IReadOnlyDictionary<string, string>? NullableIReadOnlyDictionaryInNonNullableContent { get; set; }
+        public IReadOnlyDictionary<string, string> NonNullableIReadOnlyDictionaryInNonNullableContent { get; set; } = default!;
+        public IReadOnlyDictionary<string, string?> NonNullableIReadOnlyDictionaryInNullableContent { get; set; } = default!;
+        public IReadOnlyDictionary<string, string?>? NullableIReadOnlyDictionaryInNullableContent { get; set; }
+
+        public Dictionary<string, int>? NullableDictionaryWithValueTypeInNonNullableContent { get; set; }
+        public Dictionary<string, int> NonNullableDictionaryWithValueTypeInNonNullableContent { get; set; } = default!;
+        public Dictionary<string, int?> NonNullableDictionaryWithValueTypeInNullableContent { get; set; } = default!;
+        public Dictionary<string, int?>? NullableDictionaryWithValueTypeInNullableContent { get; set; }
+
+        public IDictionary<string, int>? NullableIDictionaryWithValueTypeInNonNullableContent { get; set; }
+        public IDictionary<string, int> NonNullableIDictionaryWithValueTypeInNonNullableContent { get; set; } = default!;
+        public IDictionary<string, int?> NonNullableIDictionaryWithValueTypeInNullableContent { get; set; } = default!;
+        public IDictionary<string, int?>? NullableIDictionaryWithValueTypeInNullableContent { get; set; }
+
+        public IReadOnlyDictionary<string, int>? NullableIReadOnlyDictionaryWithValueTypeInNonNullableContent { get; set; }
+        public IReadOnlyDictionary<string, int> NonNullableIReadOnlyDictionaryWithValueTypeInNonNullableContent { get; set; } = default!;
+        public IReadOnlyDictionary<string, int?> NonNullableIReadOnlyDictionaryWithValueTypeInNullableContent { get; set; } = default!;
+        public IReadOnlyDictionary<string, int?>? NullableIReadOnlyDictionaryWithValueTypeInNullableContent { get; set; }
+
+        public class SubTypeWithOneNullableContent
+        {
+            public string? NullableString { get; set; }
+        }
+
+        public class SubTypeWithOneNonNullableContent
+        {
+            public string NonNullableString { get; set; } = default!;
+        }
     }
 #nullable restore
 }


### PR DESCRIPTION
A follow-up of #3022 (issue) and #3023 (PR).

The #3023 PR broke the behavior for many of our `IReadOnlyDictionary<string, string>` (and similar) members.

The reason is that the logic for reading and interpreting `NullableAttribute` and `NullableContextAttribute` flags is too simplified and is incorrect for several cases. It just happens to pass the current test cases because of the layout of the test type and its members.

## Too simplified
For example, it ignores the optimization of the flags array into a single byte if they are all the same value. An optimized `Dictionary<string, string>` has a single `[1]` flag, not two or three flags as the current logic expects.

It also does a lot of assumptions related to reference vs value types. An IDictionary itself can be a value type, as can the key, both of which would affect the length of the flag array. It should be checking the number of value types and the number of flags together.

It also doesn't seem to fully respect the `NullableContextAttribute` that's placed on the type containing the member. And the tests did not account for differences in the context value, as the testing type always only has a single flag. So the other flag value is not tested.

## My suggested change
For NET 6 and onwards we should rely on the official `NullabilityInfoContext` to tell us what is and isn't nullable. For earlier versions we can still have custom logic, which we can try to improve on if we want to put in the effort. But it will require a lot of effort to make it fully compliant and flexible.

The tests I added do not pass with the custom flag logic, but they do pass with the `NullabilityInfoContext` code.

The tests could be more flexible or enumerated in other more dynamic ways if you would like, to get the number of lines down, but I tried to follow the existing pattern of laying them all out in-line.