### PR TITLE
Fix nested types nullable context check

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.401",
+    "version": "8.0.0",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "8.0.401",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
@@ -136,7 +136,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private static bool GetNullableFallbackValue(this MemberInfo memberInfo)
         {
             var declaringTypes = memberInfo.DeclaringType.IsNested
-                ? GetDeclaringTypeChain(memberInfo)
+                ? new Type[] { memberInfo.DeclaringType, memberInfo.DeclaringType.DeclaringType }
                 : new Type[] { memberInfo.DeclaringType };
 
             foreach (var declaringType in declaringTypes)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
@@ -136,7 +136,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private static bool GetNullableFallbackValue(this MemberInfo memberInfo)
         {
             var declaringTypes = memberInfo.DeclaringType.IsNested
-                ? new Type[] { memberInfo.DeclaringType, memberInfo.DeclaringType.DeclaringType }
+                ? GetDeclaringTypeChain(memberInfo)
                 : new Type[] { memberInfo.DeclaringType };
 
             foreach (var declaringType in declaringTypes)
@@ -161,6 +161,20 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             }
 
             return false;
+        }
+
+        private static Type[] GetDeclaringTypeChain(MemberInfo memberInfo)
+        {
+            var chain = new List<Type>();
+            var currentType = memberInfo.DeclaringType;
+
+            while (currentType != null)
+            {
+                chain.Add(currentType);
+                currentType = currentType.DeclaringType;
+            }
+
+            return chain.ToArray();
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
@@ -136,7 +136,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private static bool GetNullableFallbackValue(this MemberInfo memberInfo)
         {
             var declaringTypes = memberInfo.DeclaringType.IsNested
-                ? new Type[] { memberInfo.DeclaringType, memberInfo.DeclaringType.DeclaringType }
+                ? GetDeclaringTypeChain(memberInfo)
                 : new Type[] { memberInfo.DeclaringType };
 
             foreach (var declaringType in declaringTypes)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/MemberInfoExtensions.cs
@@ -137,7 +137,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             var declaringTypes = memberInfo.DeclaringType.IsNested
                 ? GetDeclaringTypeChain(memberInfo)
-                : new Type[] { memberInfo.DeclaringType };
+                : new List<Type>(1) { memberInfo.DeclaringType };
 
             foreach (var declaringType in declaringTypes)
             {
@@ -163,7 +163,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             return false;
         }
 
-        private static Type[] GetDeclaringTypeChain(MemberInfo memberInfo)
+        private static List<Type> GetDeclaringTypeChain(MemberInfo memberInfo)
         {
             var chain = new List<Type>();
             var currentType = memberInfo.DeclaringType;
@@ -174,7 +174,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 currentType = currentType.DeclaringType;
             }
 
-            return chain.ToArray();
+            return chain;
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -982,6 +982,28 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.SubTypeWithNestedSubType.Nested), nameof(TypeWithNullableContextAnnotated.SubTypeWithNestedSubType.Nested.NullableString), true)]
+        [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.SubTypeWithNestedSubType.Nested), nameof(TypeWithNullableContextAnnotated.SubTypeWithNestedSubType.Nested.NonNullableString), false)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.SubTypeWithNestedSubType.Nested), nameof(TypeWithNullableContextAnnotated.SubTypeWithNestedSubType.Nested.NullableString), true)]
+        [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.SubTypeWithNestedSubType.Nested), nameof(TypeWithNullableContextAnnotated.SubTypeWithNestedSubType.Nested.NonNullableString), false)]
+        public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes_NestedWithinNested(
+            Type declaringType,
+            string subType,
+            string propertyName,
+            bool expectedNullable)
+        {
+            var subject = Subject(
+                configureGenerator: c => c.SupportNonNullableReferenceTypes = true
+            );
+            var schemaRepository = new SchemaRepository();
+
+            subject.GenerateSchema(declaringType, schemaRepository);
+
+            var propertySchema = schemaRepository.Schemas[subType].Properties[propertyName];
+            Assert.Equal(expectedNullable, propertySchema.Nullable);
+        }
+
+        [Theory]
         [InlineData(typeof(TypeWithNullableContextAnnotated))]
         [InlineData(typeof(TypeWithNullableContextNotAnnotated))]
         public void GenerateSchema_Works_IfNotProvidingMvcOptions(Type type)

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableContext.cs
@@ -48,6 +48,7 @@ namespace Swashbuckle.AspNetCore.TestSupport
 
         public List<SubTypeWithOneNullableContent>? NullableList { get; set; }
         public List<SubTypeWithOneNonNullableContent> NonNullableList { get; set; } = default!;
+        public SubTypeWithNestedSubType NestedWithNested { get; set; } = default!;
 
         public Dictionary<string, string>? NullableDictionaryInNonNullableContent { get; set; }
         public Dictionary<string, string> NonNullableDictionaryInNonNullableContent { get; set; } = default!;
@@ -87,6 +88,17 @@ namespace Swashbuckle.AspNetCore.TestSupport
         public class SubTypeWithOneNonNullableContent
         {
             public string NonNullableString { get; set; } = default!;
+        }
+
+        public class SubTypeWithNestedSubType
+        {
+            public Nested NestedProperty { get; set; } = default!;
+
+            public class Nested
+            {
+                public string? NullableString { get; set; }
+                public string NonNullableString { get; set; } = default!;
+            }
         }
     }
 
@@ -128,6 +140,7 @@ namespace Swashbuckle.AspNetCore.TestSupport
 
         public List<SubTypeWithOneNullableContent>? NullableList { get; set; }
         public List<SubTypeWithOneNonNullableContent> NonNullableList { get; set; } = default!;
+        public SubTypeWithNestedSubType NestedWithNested { get; set; } = default!;
 
         public Dictionary<string, string>? NullableDictionaryInNonNullableContent { get; set; }
         public Dictionary<string, string> NonNullableDictionaryInNonNullableContent { get; set; } = default!;
@@ -167,6 +180,17 @@ namespace Swashbuckle.AspNetCore.TestSupport
         public class SubTypeWithOneNonNullableContent
         {
             public string NonNullableString { get; set; } = default!;
+        }
+
+        public class SubTypeWithNestedSubType
+        {
+            public Nested NestedProperty { get; set; } = default!;
+
+            public class Nested
+            {
+                public string? NullableString { get; set; }
+                public string NonNullableString { get; set; } = default!;
+            }
         }
     }
 #nullable restore


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

Fixes #3040

## Details on the issue fix or feature implementation

We have to address the case when model type is nested-within-nested. In this case for nullable context analysis we have to traverse the whole declaring type chain

In issue example NullableContextAttribute is on the outer class
Sharplab example: https://sharplab.io/#v2:D4AQTAjAsAUCDMACciDCiDetE+UkALIgLIAUAlJtrgL6x0ywKIBOApgMYD2LAJogC0uXCKSEiAdOLCIAMmwBubADYQANMggAGOYpUQAygBcWASwB2AcwAKLLgAdysLDFx5WnHv2ljhYKcJI8krKYBog2rohYMZmVrYOTq64Lm5uzOzcfIKBpBE6wSrwsRY2do4A3NQ4DDRAA
