### PR TITLE
Improve IncludeXmlComments performance (2)

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -541,13 +541,15 @@ namespace Microsoft.Extensions.DependencyInjection
             bool includeControllerXmlComments = false)
         {
             var xmlDoc = xmlDocFactory();
-            swaggerGenOptions.ParameterFilter<XmlCommentsParameterFilter>(xmlDoc);
-            swaggerGenOptions.RequestBodyFilter<XmlCommentsRequestBodyFilter>(xmlDoc);
-            swaggerGenOptions.OperationFilter<XmlCommentsOperationFilter>(xmlDoc);
-            swaggerGenOptions.SchemaFilter<XmlCommentsSchemaFilter>(xmlDoc);
+            var xmlDocMembers = XmlCommentsDocumentHelper.GetMemberDictionary(xmlDoc);
+
+            swaggerGenOptions.AddParameterFilterInstance(new XmlCommentsParameterFilter(xmlDocMembers));
+            swaggerGenOptions.AddRequestBodyFilterInstance(new XmlCommentsRequestBodyFilter(xmlDocMembers));
+            swaggerGenOptions.AddOperationFilterInstance(new XmlCommentsOperationFilter(xmlDocMembers));
+            swaggerGenOptions.AddSchemaFilterInstance(new XmlCommentsSchemaFilter(xmlDocMembers));
 
             if (includeControllerXmlComments)
-                swaggerGenOptions.DocumentFilter<XmlCommentsDocumentFilter>(xmlDoc, swaggerGenOptions.SwaggerGeneratorOptions);
+                swaggerGenOptions.AddDocumentFilterInstance(new XmlCommentsDocumentFilter(xmlDocMembers, swaggerGenOptions.SwaggerGeneratorOptions));
         }
 
         /// <summary>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -541,7 +541,7 @@ namespace Microsoft.Extensions.DependencyInjection
             bool includeControllerXmlComments = false)
         {
             var xmlDoc = xmlDocFactory();
-            var xmlDocMembers = XmlCommentsDocumentHelper.GetMemberDictionary(xmlDoc);
+            var xmlDocMembers = XmlCommentsDocumentHelper.CreateMemberDictionary(xmlDoc);
 
             swaggerGenOptions.AddParameterFilterInstance(new XmlCommentsParameterFilter(xmlDocMembers));
             swaggerGenOptions.AddRequestBodyFilterInstance(new XmlCommentsRequestBodyFilter(xmlDocMembers));

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XPathNavigatorExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XPathNavigatorExtensions.cs
@@ -1,0 +1,22 @@
+using System.Linq;
+using System.Xml.XPath;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen
+{
+    internal static class XPathNavigatorExtensions
+    {
+        internal static XPathNavigator SelectFirstChild(this XPathNavigator navigator, string name)
+        {
+            return navigator.SelectChildren(name, "")
+                    ?.Cast<XPathNavigator>()
+                    .FirstOrDefault();
+        }
+
+        internal static XPathNavigator SelectFirstChildWithAttribute(this XPathNavigator navigator, string childName, string attributeName, string attributeValue)
+        {
+            return navigator.SelectChildren(childName, "")
+                    ?.Cast<XPathNavigator>()
+                    .FirstOrDefault(n => n.GetAttribute(attributeName, "") == attributeValue);
+        }
+    }
+}

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XPathNavigatorExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XPathNavigatorExtensions.cs
@@ -1,22 +1,21 @@
 using System.Linq;
 using System.Xml.XPath;
 
-namespace Swashbuckle.AspNetCore.SwaggerGen
-{
-    internal static class XPathNavigatorExtensions
-    {
-        internal static XPathNavigator SelectFirstChild(this XPathNavigator navigator, string name)
-        {
-            return navigator.SelectChildren(name, "")
-                    ?.Cast<XPathNavigator>()
-                    .FirstOrDefault();
-        }
+namespace Swashbuckle.AspNetCore.SwaggerGen;
 
-        internal static XPathNavigator SelectFirstChildWithAttribute(this XPathNavigator navigator, string childName, string attributeName, string attributeValue)
-        {
-            return navigator.SelectChildren(childName, "")
-                    ?.Cast<XPathNavigator>()
-                    .FirstOrDefault(n => n.GetAttribute(attributeName, "") == attributeValue);
-        }
+internal static class XPathNavigatorExtensions
+{
+    internal static XPathNavigator SelectFirstChild(this XPathNavigator navigator, string name)
+    {
+        return navigator.SelectChildren(name, "")
+                ?.Cast<XPathNavigator>()
+                .FirstOrDefault();
+    }
+
+    internal static XPathNavigator SelectFirstChildWithAttribute(this XPathNavigator navigator, string childName, string attributeName, string attributeValue)
+    {
+        return navigator.SelectChildren(childName, "")
+                ?.Cast<XPathNavigator>()
+                .FirstOrDefault(n => n.GetAttribute(attributeName, "") == attributeValue);
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XPathNavigatorExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XPathNavigatorExtensions.cs
@@ -5,17 +5,29 @@ namespace Swashbuckle.AspNetCore.SwaggerGen;
 
 internal static class XPathNavigatorExtensions
 {
+    private const string EmptyNamespace = "";
+
+    internal static XPathNodeIterator SelectChildren(this XPathNavigator navigator, string name)
+    {
+        return navigator.SelectChildren(name, EmptyNamespace);
+    }
+
+    internal static string GetAttribute(this XPathNavigator navigator, string name)
+    {
+        return navigator.GetAttribute(name, EmptyNamespace);
+    }
+
     internal static XPathNavigator SelectFirstChild(this XPathNavigator navigator, string name)
     {
-        return navigator.SelectChildren(name, "")
+        return navigator.SelectChildren(name, EmptyNamespace)
                 ?.Cast<XPathNavigator>()
                 .FirstOrDefault();
     }
 
     internal static XPathNavigator SelectFirstChildWithAttribute(this XPathNavigator navigator, string childName, string attributeName, string attributeValue)
     {
-        return navigator.SelectChildren(childName, "")
+        return navigator.SelectChildren(childName, EmptyNamespace)
                 ?.Cast<XPathNavigator>()
-                .FirstOrDefault(n => n.GetAttribute(attributeName, "") == attributeValue);
+                .FirstOrDefault(n => n.GetAttribute(attributeName, EmptyNamespace) == attributeValue);
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XPathNavigatorExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XPathNavigatorExtensions.cs
@@ -20,14 +20,14 @@ internal static class XPathNavigatorExtensions
     internal static XPathNavigator SelectFirstChild(this XPathNavigator navigator, string name)
     {
         return navigator.SelectChildren(name, EmptyNamespace)
-                ?.Cast<XPathNavigator>()
+                ?.OfType<XPathNavigator>()
                 .FirstOrDefault();
     }
 
     internal static XPathNavigator SelectFirstChildWithAttribute(this XPathNavigator navigator, string childName, string attributeName, string attributeValue)
     {
         return navigator.SelectChildren(childName, EmptyNamespace)
-                ?.Cast<XPathNavigator>()
+                ?.OfType<XPathNavigator>()
                 .FirstOrDefault(n => n.GetAttribute(attributeName, EmptyNamespace) == attributeValue);
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentFilter.cs
@@ -42,7 +42,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             {
                 var memberName = XmlCommentsNodeNameHelper.GetMemberNameForType(nameAndType.Value);
 
-                if (!_xmlDocMembers.TryGetValue(memberName, out var typeNode)) continue;
+                if (!_xmlDocMembers.TryGetValue(memberName, out var typeNode))
+                {
+                    continue;
+                }
 
                 var summaryNode = typeNode.SelectFirstChild(SummaryTag);
                 if (summaryNode != null)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentFilter.cs
@@ -50,8 +50,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 var summaryNode = typeNode.SelectFirstChild(SummaryTag);
                 if (summaryNode != null)
                 {
-                    if (swaggerDoc.Tags == null)
-                        swaggerDoc.Tags = new List<OpenApiTag>();
+                    swaggerDoc.Tags ??= new List<OpenApiTag>();
 
                     swaggerDoc.Tags.Add(new OpenApiTag
                     {

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentFilter.cs
@@ -19,7 +19,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
         }
 
-        public XmlCommentsDocumentFilter(XPathDocument xmlDoc, SwaggerGeneratorOptions options) : this(XmlCommentsDocumentHelper.GetMemberDictionary(xmlDoc), options)
+        public XmlCommentsDocumentFilter(XPathDocument xmlDoc, SwaggerGeneratorOptions options) : this(XmlCommentsDocumentHelper.CreateMemberDictionary(xmlDoc), options)
         {
         }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentHelper.cs
@@ -6,7 +6,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     internal static class XmlCommentsDocumentHelper
     {
-        internal static IReadOnlyDictionary<string, XPathNavigator> GetMemberDictionary(XPathDocument xmlDoc)
+        internal static IReadOnlyDictionary<string, XPathNavigator> CreateMemberDictionary(XPathDocument xmlDoc)
         {
             var members = xmlDoc.CreateNavigator()
                 .SelectFirstChild("doc")

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentHelper.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Xml.XPath;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen
+{
+    internal static class XmlCommentsDocumentHelper
+    {
+        internal static IReadOnlyDictionary<string, XPathNavigator> GetMemberDictionary(XPathDocument xmlDoc)
+        {
+            var members = xmlDoc.CreateNavigator()
+                .SelectFirstChild("doc")
+                ?.SelectFirstChild("members")
+                ?.SelectChildren("member", "")
+                ?.OfType<XPathNavigator>();
+
+            if (members == null)
+            {
+                return new Dictionary<string, XPathNavigator>();
+            }
+
+            return members.ToDictionary(memberNode => memberNode.GetAttribute("name", ""));
+        }
+    }
+}

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentHelper.cs
@@ -6,7 +6,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     internal static class XmlCommentsDocumentHelper
     {
-        internal static IReadOnlyDictionary<string, XPathNavigator> CreateMemberDictionary(XPathDocument xmlDoc)
+        internal static Dictionary<string, XPathNavigator> CreateMemberDictionary(XPathDocument xmlDoc)
         {
             var members = xmlDoc.CreateNavigator()
                 .SelectFirstChild("doc")

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentHelper.cs
@@ -2,24 +2,23 @@
 using System.Linq;
 using System.Xml.XPath;
 
-namespace Swashbuckle.AspNetCore.SwaggerGen
+namespace Swashbuckle.AspNetCore.SwaggerGen;
+
+internal static class XmlCommentsDocumentHelper
 {
-    internal static class XmlCommentsDocumentHelper
+    internal static Dictionary<string, XPathNavigator> CreateMemberDictionary(XPathDocument xmlDoc)
     {
-        internal static Dictionary<string, XPathNavigator> CreateMemberDictionary(XPathDocument xmlDoc)
+        var members = xmlDoc.CreateNavigator()
+            .SelectFirstChild("doc")
+            ?.SelectFirstChild("members")
+            ?.SelectChildren("member")
+            ?.OfType<XPathNavigator>();
+
+        if (members == null)
         {
-            var members = xmlDoc.CreateNavigator()
-                .SelectFirstChild("doc")
-                ?.SelectFirstChild("members")
-                ?.SelectChildren("member")
-                ?.OfType<XPathNavigator>();
-
-            if (members == null)
-            {
-                return new Dictionary<string, XPathNavigator>();
-            }
-
-            return members.ToDictionary(memberNode => memberNode.GetAttribute("name"));
+            return new Dictionary<string, XPathNavigator>();
         }
+
+        return members.ToDictionary(memberNode => memberNode.GetAttribute("name"));
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentHelper.cs
@@ -11,7 +11,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             var members = xmlDoc.CreateNavigator()
                 .SelectFirstChild("doc")
                 ?.SelectFirstChild("members")
-                ?.SelectChildren("member", "")
+                ?.SelectChildren("member")
                 ?.OfType<XPathNavigator>();
 
             if (members == null)
@@ -19,7 +19,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 return new Dictionary<string, XPathNavigator>();
             }
 
-            return members.ToDictionary(memberNode => memberNode.GetAttribute("name", ""));
+            return members.ToDictionary(memberNode => memberNode.GetAttribute("name"));
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
@@ -2,25 +2,26 @@
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 
-namespace Swashbuckle.AspNetCore.SwaggerGen;
-
-internal static class XmlCommentsExampleHelper
+namespace Swashbuckle.AspNetCore.SwaggerGen
 {
-    public static IOpenApiAny Create(
-        SchemaRepository schemaRepository,
-        OpenApiSchema schema,
-        string exampleString)
+    internal static class XmlCommentsExampleHelper
     {
-        var isStringType =
-            (schema?.ResolveType(schemaRepository) == "string") &&
-            !string.Equals(exampleString, "null");
+        public static IOpenApiAny Create(
+            SchemaRepository schemaRepository,
+            OpenApiSchema schema,
+            string exampleString)
+        {
+            var isStringType =
+                (schema?.ResolveType(schemaRepository) == "string") &&
+                !string.Equals(exampleString, "null");
 
-        var exampleAsJson = isStringType
-                ? JsonSerializer.Serialize(exampleString)
-                : exampleString;
+            var exampleAsJson = isStringType
+                    ? JsonSerializer.Serialize(exampleString)
+                    : exampleString;
 
-        var example = OpenApiAnyFactory.CreateFromJson(exampleAsJson);
+            var example = OpenApiAnyFactory.CreateFromJson(exampleAsJson);
 
-        return example;
+            return example;
+        }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
@@ -2,26 +2,25 @@
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 
-namespace Swashbuckle.AspNetCore.SwaggerGen
+namespace Swashbuckle.AspNetCore.SwaggerGen;
+
+internal static class XmlCommentsExampleHelper
 {
-    internal static class XmlCommentsExampleHelper
+    public static IOpenApiAny Create(
+        SchemaRepository schemaRepository,
+        OpenApiSchema schema,
+        string exampleString)
     {
-        public static IOpenApiAny Create(
-            SchemaRepository schemaRepository,
-            OpenApiSchema schema,
-            string exampleString)
-        {
-            var isStringType =
-                (schema?.ResolveType(schemaRepository) == "string") &&
-                !string.Equals(exampleString, "null");
+        var isStringType =
+            (schema?.ResolveType(schemaRepository) == "string") &&
+            !string.Equals(exampleString, "null");
 
-            var exampleAsJson = isStringType
-                    ? JsonSerializer.Serialize(exampleString)
-                    : exampleString;
+        var exampleAsJson = isStringType
+                ? JsonSerializer.Serialize(exampleString)
+                : exampleString;
 
-            var example = OpenApiAnyFactory.CreateFromJson(exampleAsJson);
+        var example = OpenApiAnyFactory.CreateFromJson(exampleAsJson);
 
-            return example;
-        }
+        return example;
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsOperationFilter.cs
@@ -40,7 +40,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             if (!_xmlDocMembers.TryGetValue(typeMemberName, out var methodNode)) return;
 
-            var responseNodes = methodNode.SelectChildren("response", "");
+            var responseNodes = methodNode.SelectChildren("response");
             ApplyResponseTags(operation, responseNodes);
         }
 
@@ -58,7 +58,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             if (remarksNode != null)
                 operation.Description = XmlCommentsTextHelper.Humanize(remarksNode.InnerXml);
 
-            var responseNodes = methodNode.SelectChildren("response", "");
+            var responseNodes = methodNode.SelectChildren("response");
             ApplyResponseTags(operation, responseNodes);
         }
 
@@ -66,7 +66,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             while (responseNodes.MoveNext())
             {
-                var code = responseNodes.Current.GetAttribute("code", "");
+                var code = responseNodes.Current.GetAttribute("code");
                 if (!operation.Responses.TryGetValue(code, out var response))
                 {
                     response = new OpenApiResponse();

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsOperationFilter.cs
@@ -10,7 +10,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     {
         private readonly IReadOnlyDictionary<string, XPathNavigator> _xmlDocMembers;
 
-        public XmlCommentsOperationFilter(XPathDocument xmlDoc) : this(XmlCommentsDocumentHelper.GetMemberDictionary(xmlDoc))
+        public XmlCommentsOperationFilter(XPathDocument xmlDoc) : this(XmlCommentsDocumentHelper.CreateMemberDictionary(xmlDoc))
         {
         }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsOperationFilter.cs
@@ -1,17 +1,22 @@
-﻿using System;
+﻿using Microsoft.OpenApi.Models;
+using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Xml.XPath;
-using Microsoft.OpenApi.Models;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     public class XmlCommentsOperationFilter : IOperationFilter
     {
-        private readonly XPathNavigator _xmlNavigator;
+        private readonly IReadOnlyDictionary<string, XPathNavigator> _xmlDocMembers;
 
-        public XmlCommentsOperationFilter(XPathDocument xmlDoc)
+        public XmlCommentsOperationFilter(XPathDocument xmlDoc) : this(XmlCommentsDocumentHelper.GetMemberDictionary(xmlDoc))
         {
-            _xmlNavigator = xmlDoc.CreateNavigator();
+        }
+
+        internal XmlCommentsOperationFilter(IReadOnlyDictionary<string, XPathNavigator> xmlDocMembers)
+        {
+            _xmlDocMembers = xmlDocMembers;
         }
 
         public void Apply(OpenApiOperation operation, OperationFilterContext context)
@@ -32,26 +37,28 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private void ApplyControllerTags(OpenApiOperation operation, Type controllerType)
         {
             var typeMemberName = XmlCommentsNodeNameHelper.GetMemberNameForType(controllerType);
-            var responseNodes = _xmlNavigator.Select($"/doc/members/member[@name='{typeMemberName}']/response");
+
+            if (!_xmlDocMembers.TryGetValue(typeMemberName, out var methodNode)) return;
+
+            var responseNodes = methodNode.SelectChildren("response", "");
             ApplyResponseTags(operation, responseNodes);
         }
 
         private void ApplyMethodTags(OpenApiOperation operation, MethodInfo methodInfo)
         {
             var methodMemberName = XmlCommentsNodeNameHelper.GetMemberNameForMethod(methodInfo);
-            var methodNode = _xmlNavigator.SelectSingleNode($"/doc/members/member[@name='{methodMemberName}']");
 
-            if (methodNode == null) return;
+            if (!_xmlDocMembers.TryGetValue(methodMemberName, out var methodNode)) return;
 
-            var summaryNode = methodNode.SelectSingleNode("summary");
+            var summaryNode = methodNode.SelectFirstChild("summary");
             if (summaryNode != null)
                 operation.Summary = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml);
 
-            var remarksNode = methodNode.SelectSingleNode("remarks");
+            var remarksNode = methodNode.SelectFirstChild("remarks");
             if (remarksNode != null)
                 operation.Description = XmlCommentsTextHelper.Humanize(remarksNode.InnerXml);
 
-            var responseNodes = methodNode.Select("response");
+            var responseNodes = methodNode.SelectChildren("response", "");
             ApplyResponseTags(operation, responseNodes);
         }
 
@@ -60,9 +67,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             while (responseNodes.MoveNext())
             {
                 var code = responseNodes.Current.GetAttribute("code", "");
-                var response = operation.Responses.TryGetValue(code, out var operationResponse)
-                    ? operationResponse
-                    : operation.Responses[code] = new OpenApiResponse();
+                if (!operation.Responses.TryGetValue(code, out var response))
+                {
+                    response = new OpenApiResponse();
+                    operation.Responses[code] = response;
+                }
 
                 response.Description = XmlCommentsTextHelper.Humanize(responseNodes.Current.InnerXml);
             }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
@@ -9,7 +9,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     {
         private readonly IReadOnlyDictionary<string, XPathNavigator> _xmlDocMembers;
 
-        public XmlCommentsParameterFilter(XPathDocument xmlDoc) : this(XmlCommentsDocumentHelper.GetMemberDictionary(xmlDoc))
+        public XmlCommentsParameterFilter(XPathDocument xmlDoc) : this(XmlCommentsDocumentHelper.CreateMemberDictionary(xmlDoc))
         {
         }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
@@ -70,7 +70,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             {
                 parameter.Description = XmlCommentsTextHelper.Humanize(paramNode.InnerXml);
 
-                var example = paramNode.GetAttribute("example", "");
+                var example = paramNode.GetAttribute("example");
                 if (string.IsNullOrEmpty(example)) return;
 
                 parameter.Example = XmlCommentsExampleHelper.Create(context.SchemaRepository, parameter.Schema, example);

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsRequestBodyFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsRequestBodyFilter.cs
@@ -97,7 +97,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             {
                 requestBody.Description = XmlCommentsTextHelper.Humanize(paramNode.InnerXml);
 
-                var example = paramNode.GetAttribute("example", "");
+                var example = paramNode.GetAttribute("example");
                 if (!string.IsNullOrEmpty(example))
                 {
                     foreach (var mediaType in requestBody.Content.Values)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsRequestBodyFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsRequestBodyFilter.cs
@@ -10,7 +10,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     {
         private readonly IReadOnlyDictionary<string, XPathNavigator> _xmlDocMembers;
 
-        public XmlCommentsRequestBodyFilter(XPathDocument xmlDoc) : this(XmlCommentsDocumentHelper.GetMemberDictionary(xmlDoc))
+        public XmlCommentsRequestBodyFilter(XPathDocument xmlDoc) : this(XmlCommentsDocumentHelper.CreateMemberDictionary(xmlDoc))
         {
         }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
@@ -9,7 +9,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     {
         private readonly IReadOnlyDictionary<string, XPathNavigator> _xmlDocMembers;
 
-        public XmlCommentsSchemaFilter(XPathDocument xmlDoc) : this(XmlCommentsDocumentHelper.GetMemberDictionary(xmlDoc))
+        public XmlCommentsSchemaFilter(XPathDocument xmlDoc) : this(XmlCommentsDocumentHelper.CreateMemberDictionary(xmlDoc))
         {
         }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
@@ -58,7 +58,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     if (summaryNode != null)
                         schema.Description = XmlCommentsTextHelper.Humanize(summaryNode);
 
-                    var example = recordDefaultConstructorProperty.GetAttribute("example", string.Empty);
+                    var example = recordDefaultConstructorProperty.GetAttribute("example");
                     if (!string.IsNullOrEmpty(example))
                     {
                         TrySetExample(schema, context, example);

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsDocumentFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsDocumentFilterTests.cs
@@ -47,6 +47,39 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal("Summary for FakeControllerWithXmlComments", tag.Description);
         }
 
+        [Fact]
+        public void Apply_SetsTagDescription_FromControllerSummaryTags_OneControllerWithoutDescription()
+        {
+            var document = new OpenApiDocument();
+            var filterContext = new DocumentFilterContext(
+                new[]
+                {
+                    new ApiDescription
+                    {
+                        ActionDescriptor = new ControllerActionDescriptor
+                        {
+                            ControllerTypeInfo = typeof(FakeController).GetTypeInfo(),
+                            ControllerName = nameof(FakeController)
+                        }
+                    },
+                    new ApiDescription
+                    {
+                        ActionDescriptor = new ControllerActionDescriptor
+                        {
+                            ControllerTypeInfo = typeof(FakeControllerWithXmlComments).GetTypeInfo(),
+                            ControllerName = nameof(FakeControllerWithXmlComments)
+                        }
+                    }
+                },
+                null,
+                null);
+
+            Subject().Apply(document, filterContext);
+
+            var tag = Assert.Single(document.Tags);
+            Assert.Equal("Summary for FakeControllerWithXmlComments", tag.Description);
+        }
+
         private static XmlCommentsDocumentFilter Subject()
         {
             using (var xmlComments = File.OpenText($"{typeof(FakeControllerWithXmlComments).Assembly.GetName().Name}.xml"))


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

Fixes #2164

## Details on the issue fix or feature implementation

This is a rebase and enhancement of #2443  (thanks to @stevendarby, added you as co-author).

This significantly improves the performance of the XML comment filters. The original fix #2443 created a dictionary of the members to avoid iterating the whole XPath for every single item.

I made some further improvements by replacing all usages of `Select` and `SelectSingleNode` with `SelectChildren` (added some helper extensions for this). This completely avoids XPath expressions and [the documentation](https://learn.microsoft.com/en-us/dotnet/standard/data/xml/select-xml-data-using-xpathnavigator#optimized-selection-methods) even mentions `SelectChildren` being faster.

I made the new constructors internal for now (which is also why I changed `ParameterFilter` to `AddParameterFilterInstance` etc.. DI fails otherwise). It felt wrong to me to make these public, but I can make these public if you want.

### Tests

The existing tests imho already cover this code pretty well. I only added a test case for a bug I noticed in #2443  (there was a `return` instead of a `continue` in `XmlCommentsDocumentFilter`).

### Performance

#2443 already mentions significant improvements (25s -> 4s). With another local test case I have with a 1.5MB XML file, generation time decreases from ~1900ms to ~200ms.

[#2443](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/2443#issuecomment-2094261461) also mentions some concern about memory consumption, so I made some manual tests with a very big (30MB) XML document file: the XPathDocument itself already loads the document completely into memory which uses about 60 MB.  Creating the dictionary creates an additional 40MB. So there is some additional memory consumption, but considering that 30MB is pretty extreme and most files should be < 1MB, the memory increase should be negligible for most applications. In my local test case with a 1.5 MB File, memory consumption after GC.Collect increased by about 1MB.