### PR TITLE
Apply ParameterFilters and RequestBodyFilters for WithOpenApi endpoints

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -312,7 +312,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             OpenApiOperation operation =
 #if NET6_0_OR_GREATER
-                GenerateOpenApiOperationFromMetadata(apiDescription, schemaRepository);
+                await GenerateOpenApiOperationFromMetadataAsync(apiDescription, schemaRepository);
 #else
                 null;
 #endif
@@ -390,7 +390,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         }
 
 #if NET6_0_OR_GREATER
-        private OpenApiOperation GenerateOpenApiOperationFromMetadata(ApiDescription apiDescription, SchemaRepository schemaRepository)
+        private async Task<OpenApiOperation> GenerateOpenApiOperationFromMetadataAsync(ApiDescription apiDescription, SchemaRepository schemaRepository)
         {
             var metadata = apiDescription.ActionDescriptor?.EndpointMetadata;
             var operation = metadata?.OfType<OpenApiOperation>().SingleOrDefault();
@@ -406,12 +406,19 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 var apiParameter = apiDescription.ParameterDescriptions.SingleOrDefault(desc => desc.Name == parameter.Name && !desc.IsFromBody() && !desc.IsFromForm() && !desc.IsIllegalHeaderParameter());
                 if (apiParameter is not null)
                 {
-                    parameter.Schema = GenerateSchema(
-                        apiParameter.Type,
-                        schemaRepository,
-                        apiParameter.PropertyInfo(),
-                        apiParameter.ParameterInfo(),
-                        apiParameter.RouteInfo);
+                    var (parameterAndContext, filterContext) = GenerateParameterAndContext(apiParameter, schemaRepository);
+                    parameter.Schema = parameterAndContext.Schema;
+                    parameter.Description = parameterAndContext.Description;
+
+                    foreach (var filter in _options.ParameterAsyncFilters)
+                    {
+                        await filter.ApplyAsync(parameter, filterContext, CancellationToken.None);
+                    }
+
+                    foreach (var filter in _options.ParameterFilters)
+                    {
+                        filter.Apply(parameter, filterContext);
+                    }
                 }
             }
 
@@ -425,6 +432,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     var countOfParameters = requestParameters.Count();
                     if (countOfParameters > 0)
                     {
+                        ApiParameterDescription bodyParameterDescription = null;
                         if (countOfParameters == 1)
                         {
                             var requestParameter = requestParameters.First();
@@ -433,6 +441,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                                 schemaRepository,
                                 requestParameter.PropertyInfo(),
                                 requestParameter.ParameterInfo()), content);
+
+                            bodyParameterDescription = requestParameter.IsFromBody() ? requestParameter : null;
                         }
                         else
                         {
@@ -446,6 +456,22 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                                     s.ParameterInfo()), content))
                                 .ToList()
                             };
+                        }
+
+                        var filterContext = new RequestBodyFilterContext(
+                        bodyParameterDescription: bodyParameterDescription,
+                        formParameterDescriptions: bodyParameterDescription is null ? requestParameters : null,
+                        schemaGenerator: _schemaGenerator,
+                        schemaRepository: schemaRepository);
+
+                        foreach (var filter in _options.RequestBodyAsyncFilters)
+                        {
+                            await filter.ApplyAsync(operation.RequestBody, filterContext, CancellationToken.None);
+                        }
+
+                        foreach (var filter in _options.RequestBodyFilters)
+                        {
+                            filter.Apply(operation.RequestBody, filterContext);
                         }
                     }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -13,9 +13,9 @@ using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
-using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Swagger;
 using Swashbuckle.AspNetCore.SwaggerGen.Test.Fixtures;
 using Swashbuckle.AspNetCore.TestSupport;
@@ -246,13 +246,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
-        public void GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperation()
+        public void GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationAndAppliesFilters()
         {
             var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithConsumesAttribute));
             var actionDescriptor = new ActionDescriptor
             {
-                EndpointMetadata = new List<object>()
-                {
+                EndpointMetadata =
+                [
                     new OpenApiOperation
                     {
                         OperationId = "OperationIdSetInMetadata",
@@ -262,43 +262,73 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                             {
                                 ["application/someMediaType"] = new()
                             }
-                        }
+                        },
+                        Parameters = [ new() {
+                            Name = "paramQuery",
+                            In = ParameterLocation.Query
+                        }]
                     }
-                },
+                ],
                 RouteValues = new Dictionary<string, string>
                 {
                     ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
                 }
             };
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create(
                         actionDescriptor,
                         methodInfo,
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new[]
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription()
                             {
                                 Name = "param",
                                 Source = BindingSource.Body,
                                 ModelMetadata = ModelMetadataFactory.CreateForType(typeof(TestDto))
+                            },
+                            new ApiParameterDescription()
+                            {
+                                Name ="paramQuery",
+                                Source = BindingSource.Query,
+                                ModelMetadata = ModelMetadataFactory.CreateForType(typeof(string)),
+                                Type = typeof(string)
                             }
-                        }),
+                        ]),
+                ],
+                options: new()
+                {
+                    ParameterFilters = [new TestParameterFilter()],
+                    RequestBodyFilters = [new TestRequestBodyFilter()],
+                    SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                    {
+                        ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                    }
                 }
             );
 
             var document = subject.GetSwagger("v1");
 
-            Assert.Equal("OperationIdSetInMetadata", document.Paths["/resource"].Operations[OperationType.Post].OperationId);
-            var content = Assert.Single(document.Paths["/resource"].Operations[OperationType.Post].RequestBody.Content);
+            var operation = document.Paths["/resource"].Operations[OperationType.Post];
+            Assert.Equal("OperationIdSetInMetadata", operation.OperationId);
+            var content = Assert.Single(operation.RequestBody.Content);
             Assert.Equal("application/someMediaType", content.Key);
             Assert.Null(content.Value.Schema.Type);
             Assert.NotNull(content.Value.Schema.Reference);
             Assert.Equal("TestDto", content.Value.Schema.Reference.Id);
+            Assert.Equal(2, operation.RequestBody.Extensions.Count);
+            Assert.Equal("bar", ((OpenApiString)operation.RequestBody.Extensions["X-foo"]).Value);
+            Assert.Equal("v1", ((OpenApiString)operation.RequestBody.Extensions["X-docName"]).Value);
+            Assert.NotEmpty(operation.Parameters);
+            Assert.Equal("paramQuery", operation.Parameters[0].Name);
+            Assert.Equal(2, operation.Parameters[0].Extensions.Count);
+            Assert.Equal("bar", ((OpenApiString)operation.Parameters[0].Extensions["X-foo"]).Value);
+            Assert.Equal("v1", ((OpenApiString)operation.Parameters[0].Extensions["X-docName"]).Value);
+
         }
 
         [Fact]

--- a/test/WebSites/WebApi/EndPoints/SwaggerAnnotationsEndpoints.cs
+++ b/test/WebSites/WebApi/EndPoints/SwaggerAnnotationsEndpoints.cs
@@ -14,7 +14,8 @@ namespace WebApi.EndPoints
         {
             var group = app.MapGroup("/annotations").WithTags("Annotations");
 
-            group.MapPost("/fruit/{id}", CreateFruit);
+            group.MapPost("/fruit/{id}", CreateFruit)
+                .WithOpenApi();
 
             group.MapGet("/AsParameters", ([AsParameters] AsParametersRecord record) =>
             {


### PR DESCRIPTION
Fixes issue #3037
It applies the existing ParameterFilters and RequestBodyFilters for an endpoint that calls the WithOpenApi extension method of aspnetcore
