### PR TITLE
Added Explode and Style to SwaggerParameter

### DIFF
--- a/src/Swashbuckle.AspNetCore.Annotations/AnnotationsParameterFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Annotations/AnnotationsParameterFilter.cs
@@ -30,7 +30,6 @@ namespace Swashbuckle.AspNetCore.Annotations
 
         private void ApplyParamAnnotations(OpenApiParameter parameter, ParameterInfo parameterInfo)
         {
-
             var swaggerParameterAttribute = parameterInfo.GetCustomAttribute<SwaggerParameterAttribute>();
 
             if (swaggerParameterAttribute != null)
@@ -44,6 +43,12 @@ namespace Swashbuckle.AspNetCore.Annotations
 
             if (swaggerParameterAttribute.RequiredFlag.HasValue)
                 parameter.Required = swaggerParameterAttribute.RequiredFlag.Value;
+
+            if (swaggerParameterAttribute.ExplodeFlag.HasValue)
+                parameter.Explode = swaggerParameterAttribute.ExplodeFlag.Value;
+
+            if (swaggerParameterAttribute.ParameterStyle.HasValue)
+                parameter.Style = swaggerParameterAttribute.ParameterStyle.Value;
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.Annotations/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.Annotations/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+Swashbuckle.AspNetCore.Annotations.SwaggerParameterAttribute.Explode.get -> bool
+Swashbuckle.AspNetCore.Annotations.SwaggerParameterAttribute.Explode.set -> void
+Swashbuckle.AspNetCore.Annotations.SwaggerParameterAttribute.Style.get -> string
+Swashbuckle.AspNetCore.Annotations.SwaggerParameterAttribute.Style.set -> void

--- a/src/Swashbuckle.AspNetCore.Annotations/SwaggerParameterAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.Annotations/SwaggerParameterAttribute.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Swashbuckle.AspNetCore.Annotations
 {
@@ -30,5 +32,37 @@ namespace Swashbuckle.AspNetCore.Annotations
         }
 
         internal bool? RequiredFlag { get; set; }
+
+        /// <summary>
+        /// Describes how the parameter value will be serialized depending on the type of
+        /// the parameter value. Default values (based on value of in): for query - form;
+        /// for path - simple; for header - simple; for cookie - form.
+        /// </summary>
+        public string Style
+        {
+            get { throw new InvalidOperationException($"Use {nameof(ParameterStyle)} instead"); }
+            set
+            {
+                ParameterStyle = Enum.TryParse(value, ignoreCase: true, out ParameterStyle result) ? result :
+                    throw new InvalidOperationException(
+                        message: $"Style '{value}' not defined in OpenAPI specification");
+            }
+        }
+
+        internal ParameterStyle? ParameterStyle { get; set; }
+
+        /// <summary>
+        /// When this is true, parameter values of type array or object generate separate parameters for
+        /// each value of the array or key-value pair of the map. For other types of parameters this property
+        /// has no effect. When style is form, the default value is true. For all other styles,
+        /// the default value is false.
+        /// </summary>
+        public bool Explode
+        {
+            get { throw new InvalidOperationException($"Use {nameof(ExplodeFlag)} instead"); }
+            set { ExplodeFlag = value; }
+        }
+
+        internal bool? ExplodeFlag { get; set; }
     }
 }

--- a/src/Swashbuckle.AspNetCore.Annotations/SwaggerParameterAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.Annotations/SwaggerParameterAttribute.cs
@@ -34,9 +34,8 @@ namespace Swashbuckle.AspNetCore.Annotations
         internal bool? RequiredFlag { get; set; }
 
         /// <summary>
-        /// Describes how the parameter value will be serialized depending on the type of
-        /// the parameter value. Default values (based on value of in): for query - form;
-        /// for path - simple; for header - simple; for cookie - form.
+        /// Describes how the parameter value will be serialized based on its type. 
+        /// If not set, default values are for: query - form; path - simple; header - simple; cookie - form.
         /// </summary>
         public string Style
         {
@@ -44,18 +43,16 @@ namespace Swashbuckle.AspNetCore.Annotations
             set
             {
                 ParameterStyle = Enum.TryParse(value, ignoreCase: true, out ParameterStyle result) ? result :
-                    throw new InvalidOperationException(
-                        message: $"Style '{value}' not defined in OpenAPI specification");
+                    throw new NotSupportedException($"'{value}' style is not supported");
             }
         }
 
         internal ParameterStyle? ParameterStyle { get; set; }
 
         /// <summary>
-        /// When this is true, parameter values of type array or object generate separate parameters for
-        /// each value of the array or key-value pair of the map. For other types of parameters this property
-        /// has no effect. When style is form, the default value is true. For all other styles,
-        /// the default value is false.
+        /// When true, array and object parameters are split into separate parameters. This has no 
+        /// effect on other parameter types. 
+        /// The default is true for form style and false for all other styles.
         /// </summary>
         public bool Explode
         {

--- a/test/Swashbuckle.AspNetCore.Annotations.Test/AnnotationsParameterFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.Annotations.Test/AnnotationsParameterFilterTests.cs
@@ -61,6 +61,43 @@ namespace Swashbuckle.AspNetCore.Annotations.Test
             Assert.True(parameter.Required);
         }
 
+        [Fact]
+        public void Apply_EnrichesParameterMetadata_IfPropertyDecoratedWithSwaggerParameterAttributeExplode()
+        {
+            var parameter = new OpenApiParameter { };
+            var parameterInfo = typeof(FakeControllerWithSwaggerAnnotations)
+                .GetMethod(nameof(FakeControllerWithSwaggerAnnotations.ActionWithSwaggerParameterAttributeExplode))
+                .GetParameters()[0];
+            var filterContext = new ParameterFilterContext(
+                apiParameterDescription: null,
+                schemaGenerator: null,
+                schemaRepository: null,
+                parameterInfo: parameterInfo);
+
+            Subject().Apply(parameter, filterContext);
+
+            Assert.True(parameter.Explode);
+        }
+
+        [Fact]
+        public void Apply_EnrichesParameterMetadata_IfPropertyDecoratedWithSwaggerParameterAttributeExplodeWithStyle()
+        {
+            var parameter = new OpenApiParameter { };
+            var parameterInfo = typeof(FakeControllerWithSwaggerAnnotations)
+                .GetMethod(nameof(FakeControllerWithSwaggerAnnotations.ActionWithSwaggerParameterAttributeExplodeWithStyle))
+                .GetParameters()[0];
+            var filterContext = new ParameterFilterContext(
+                apiParameterDescription: null,
+                schemaGenerator: null,
+                schemaRepository: null,
+                parameterInfo: parameterInfo);
+
+            Subject().Apply(parameter, filterContext);
+
+            Assert.True(parameter.Explode);
+            Assert.Equal(parameter.Style, ParameterStyle.Form);
+        }
+
         private AnnotationsParameterFilter Subject()
         {
             return new AnnotationsParameterFilter();

--- a/test/Swashbuckle.AspNetCore.Annotations.Test/AnnotationsRequestBodyFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.Annotations.Test/AnnotationsRequestBodyFilterTests.cs
@@ -72,7 +72,7 @@ namespace Swashbuckle.AspNetCore.Annotations.Test
 
             var requestBody = new OpenApiRequestBody { Required = true };
             var parameterInfo = typeof(FakeControllerWithSwaggerAnnotations)
-                .GetMethod(nameof(FakeControllerWithSwaggerAnnotations.ActionWithSwaggerRequestbodyAttributeDescriptionOnly))
+                .GetMethod(nameof(FakeControllerWithSwaggerAnnotations.ActionWithSwaggerRequestBodyAttributeDescriptionOnly))
                 .GetParameters()[0];
             var bodyParameterDescription = new ApiParameterDescription
             {

--- a/test/Swashbuckle.AspNetCore.Annotations.Test/Fixtures/FakeControllerWithSwaggerAnnotations.cs
+++ b/test/Swashbuckle.AspNetCore.Annotations.Test/Fixtures/FakeControllerWithSwaggerAnnotations.cs
@@ -25,6 +25,14 @@ namespace Swashbuckle.AspNetCore.Annotations.Test
             [SwaggerParameter("Description for param")] string param)
         { }
 
+        public void ActionWithSwaggerParameterAttributeExplode(
+            [SwaggerParameter("Description for param", Explode = true)] List<string> param)
+        { }
+
+        public void ActionWithSwaggerParameterAttributeExplodeWithStyle(
+            [SwaggerParameter("Description for param", Explode = true, Style = "form")] List<string> param)
+        { }
+
         public void ActionWithSwaggerSchemaAttribute(
             [SwaggerSchema("Description for param", Format = "date")] string param)
         { }
@@ -33,7 +41,7 @@ namespace Swashbuckle.AspNetCore.Annotations.Test
             [SwaggerRequestBody("Description for param", Required = true)] string param)
         { }
 
-        public void ActionWithSwaggerRequestbodyAttributeDescriptionOnly(
+        public void ActionWithSwaggerRequestBodyAttributeDescriptionOnly(
             [SwaggerRequestBody("Description for param")] string param)
         { }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

It is currently not possible to set **Explode** and **Style** on the parameter.

## Details on the issue fix or feature implementation

Added `bool Explode` and `string Style` with backing properties `bool? ExplodeFlag` and `Microsoft.OpenApi.Models.ParameterStyle? ParameterStyle` respectively. `AnnotationsParameterFilter` applies these two properties if set. 
