### PR TITLE
SwaggerGen - Improved handling of dictionaries with enum key

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -350,16 +350,18 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private OpenApiSchema CreateDictionarySchema(DataContract dataContract, SchemaRepository schemaRepository)
         {
-            if (dataContract.DictionaryKeys != null)
+            var knownKeysProperties = dataContract.DictionaryKeys?.ToDictionary(
+                name => name,
+                _ => GenerateSchema(dataContract.DictionaryValueType, schemaRepository));
+
+            if (knownKeysProperties?.Count > 0)
             {
                 // This is a special case where the set of key values is known (e.g. if the key type is an enum)
                 return new OpenApiSchema
                 {
                     Type = "object",
-                    Properties = dataContract.DictionaryKeys.ToDictionary(
-                        name => name,
-                        name => GenerateSchema(dataContract.DictionaryValueType, schemaRepository)),
-                    AdditionalPropertiesAllowed = false,
+                    Properties = knownKeysProperties,
+                    AdditionalPropertiesAllowed = false
                 };
             }
             else

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -122,6 +122,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
         [Theory]
         [InlineData(typeof(IDictionary<string, int>), "integer")]
+        [InlineData(typeof(IDictionary<EmptyIntEnum, int>), "integer")]
         [InlineData(typeof(IReadOnlyDictionary<string, bool>), "boolean")]
         [InlineData(typeof(IDictionary), null)]
         [InlineData(typeof(ExpandoObject), null)]

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/Enums.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/Enums.cs
@@ -14,6 +14,10 @@
         Value8 = 8,
     }
 
+    public enum EmptyIntEnum:int
+    {
+    }
+
     public enum IntEnum:int
     {
         Value2 = 2,


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

When enum used as a key for the dictionary contains no values defined, the dictionary schema becomes an object with no properties. In such case SchemaGenerator should build schema based on dictionary key and value type rather than known key values (which are unknown in fact).

## Details on the issue fix or feature implementation

SchemaGenerator was modified to use "special case where the set of key values is known" only if the collection of known dictionary keys is not empty.
