### PR TITLE
Do not fill the RequestBody description with the first parameter of a…

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsRequestBodyFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsRequestBodyFilter.cs
@@ -162,7 +162,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 requestBody.Description = summary;
             }
 
-            if (requestBody.Content?.Count is 0 || !string.IsNullOrEmpty(example))
+            if (requestBody.Content?.Count is 0 || string.IsNullOrEmpty(example))
             {
                 return;
             }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_Basic_DotNet_6.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_Basic_DotNet_6.verified.txt
@@ -571,6 +571,7 @@
         tags: [
           FromFormParams
         ],
+        summary: Form parameters with description,
         requestBody: {
           content: {
             application/x-www-form-urlencoded: {
@@ -578,14 +579,26 @@
                 type: object,
                 properties: {
                   name: {
-                    type: string
+                    type: string,
+                    description: Summary for Name,
+                    example: MyName
                   },
                   phoneNumbers: {
                     type: array,
                     items: {
                       type: integer,
                       format: int32
-                    }
+                    },
+                    description: Sumary for PhoneNumbers
+                  },
+                  formFile: {
+                    type: string,
+                    description: Description for file,
+                    format: binary
+                  },
+                  text: {
+                    type: string,
+                    description: Description for Text
                   }
                 }
               },
@@ -594,6 +607,12 @@
                   style: form
                 },
                 phoneNumbers: {
+                  style: form
+                },
+                formFile: {
+                  style: form
+                },
+                text: {
                   style: form
                 }
               }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_Basic_DotNet_8.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_Basic_DotNet_8.verified.txt
@@ -571,6 +571,7 @@
         tags: [
           FromFormParams
         ],
+        summary: Form parameters with description,
         requestBody: {
           content: {
             application/x-www-form-urlencoded: {
@@ -578,14 +579,26 @@
                 type: object,
                 properties: {
                   name: {
-                    type: string
+                    type: string,
+                    description: Summary for Name,
+                    example: MyName
                   },
                   phoneNumbers: {
                     type: array,
                     items: {
                       type: integer,
                       format: int32
-                    }
+                    },
+                    description: Sumary for PhoneNumbers
+                  },
+                  formFile: {
+                    type: string,
+                    description: Description for file,
+                    format: binary
+                  },
+                  text: {
+                    type: string,
+                    description: Description for Text
                   }
                 }
               },
@@ -594,6 +607,12 @@
                   style: form
                 },
                 phoneNumbers: {
+                  style: form
+                },
+                formFile: {
+                  style: form
+                },
+                text: {
                   style: form
                 }
               }

--- a/test/WebSites/Basic/Controllers/FromFormParamsController.cs
+++ b/test/WebSites/Basic/Controllers/FromFormParamsController.cs
@@ -40,7 +40,6 @@ namespace Basic.Controllers
         /// <summary>
         /// Sumary for PhoneNumbers
         /// </summary>
-
         public IEnumerable<int> PhoneNumbers { get; set; }
     }
 

--- a/test/WebSites/Basic/Controllers/FromFormParamsController.cs
+++ b/test/WebSites/Basic/Controllers/FromFormParamsController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
@@ -6,9 +7,17 @@ namespace Basic.Controllers
 {
     public class FromFormParamsController
     {
+        /// <summary>
+        /// Form parameters with description
+        /// </summary>
+        /// <param name="form">Description for whole object</param>
+        /// <param name="formFile">Description for file</param>
+        /// <param name="text">Description for Text</param>
+        /// <returns></returns>
+        /// <exception cref="System.NotImplementedException"></exception>
         [HttpPost("registrations")]
         [Consumes("application/x-www-form-urlencoded")]
-        public IActionResult PostForm([FromForm] RegistrationForm form)
+        public IActionResult PostForm([FromForm] RegistrationForm form, IFormFile formFile, [FromForm] string text)
         {
             throw new System.NotImplementedException();
         }
@@ -22,7 +31,15 @@ namespace Basic.Controllers
 
     public class RegistrationForm
     {
+        /// <summary>
+        /// Summary for Name
+        /// </summary>
+        /// <example>MyName</example>
         public string Name { get; set; }
+
+        /// <summary>
+        /// Sumary for PhoneNumbers
+        /// </summary>
 
         public IEnumerable<int> PhoneNumbers { get; set; }
     }


### PR DESCRIPTION
Fixes the issues #3038 and #2062.
Better to document each member of a FromForm independently and do it only on the properties.
The original commit that deleted the possibility of documenting a parameter of a FromForm request was this one:https://github.com/domaindrivendev/Swashbuckle.AspNetCore/commit/c1fb18c2c2f864285a7b811a147d8a9ed8c17993.

As you see in the SchemaFilter it deleted the posibility of documenting a Parameter of a FromForm request. My first try was just to look for it again, but it generated duplicated nodes description. For a parameter it ended up documenting the parameter itself and the Schema.. So I opted to just document the Parameter in the RequestBodyFilter (For C# parameters, because the properties were already set)
