### PR TITLE
Add native AoT support for ReDoc

### DIFF
--- a/src/Swashbuckle.AspNetCore.ReDoc/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.ReDoc/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Swashbuckle.AspNetCore.ReDoc.ReDocOptions.JsonSerializerOptions.get -> System.Text.Json.JsonSerializerOptions
+Swashbuckle.AspNetCore.ReDoc.ReDocOptions.JsonSerializerOptions.set -> void

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocOptions.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Swashbuckle.AspNetCore.ReDoc
@@ -32,7 +33,15 @@ namespace Swashbuckle.AspNetCore.ReDoc
         /// </summary>
         public string SpecUrl { get; set; } = null;
 
+        /// <summary>
+        /// Gets or sets the <see cref="ConfigObject"/> to use.
+        /// </summary>
         public ConfigObject ConfigObject { get; set; } = new ConfigObject();
+
+        /// <summary>
+        /// Gets or sets the optional <see cref="System.Text.Json.JsonSerializerOptions"/> to use.
+        /// </summary>
+        public JsonSerializerOptions JsonSerializerOptions { get; set; }
     }
 
     public class ConfigObject

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocOptionsJsonContext.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocOptionsJsonContext.cs
@@ -1,0 +1,45 @@
+﻿#if NET6_0_OR_GREATER
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Swashbuckle.AspNetCore.ReDoc;
+
+[JsonSerializable(typeof(ConfigObject))]
+// These primitive types are declared for common types that may be used with ConfigObject.AdditionalItems. See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2884.
+[JsonSerializable(typeof(bool))]
+[JsonSerializable(typeof(byte))]
+[JsonSerializable(typeof(sbyte))]
+[JsonSerializable(typeof(short))]
+[JsonSerializable(typeof(ushort))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(int?))]
+[JsonSerializable(typeof(uint))]
+[JsonSerializable(typeof(long))]
+[JsonSerializable(typeof(ulong))]
+[JsonSerializable(typeof(float))]
+[JsonSerializable(typeof(double))]
+[JsonSerializable(typeof(decimal))]
+[JsonSerializable(typeof(char))]
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(DateTime))]
+[JsonSerializable(typeof(DateTimeOffset))]
+[JsonSerializable(typeof(TimeSpan))]
+[JsonSerializable(typeof(JsonArray))]
+[JsonSerializable(typeof(JsonObject))]
+[JsonSerializable(typeof(JsonDocument))]
+#if NET7_0_OR_GREATER
+[JsonSerializable(typeof(DateOnly))]
+[JsonSerializable(typeof(TimeOnly))]
+#endif
+#if NET8_0_OR_GREATER
+[JsonSerializable(typeof(Half))]
+[JsonSerializable(typeof(Int128))]
+[JsonSerializable(typeof(UInt128))]
+#endif
+[JsonSourceGenerationOptions(
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal sealed partial class ReDocOptionsJsonContext : JsonSerializerContext;
+#endif

--- a/src/Swashbuckle.AspNetCore.ReDoc/Swashbuckle.AspNetCore.ReDoc.csproj
+++ b/src/Swashbuckle.AspNetCore.ReDoc/Swashbuckle.AspNetCore.ReDoc.csproj
@@ -10,6 +10,10 @@
     <SignAssembly>true</SignAssembly>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
 
   <ItemGroup>
     <None Remove="index.css" />

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -22,7 +22,7 @@ using IWebHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
 
 namespace Swashbuckle.AspNetCore.SwaggerUI
 {
-    public partial class SwaggerUIMiddleware
+    public class SwaggerUIMiddleware
     {
         private const string EmbeddedFileNamespace = "Swashbuckle.AspNetCore.SwaggerUI.node_modules.swagger_ui_dist";
 
@@ -110,8 +110,12 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
 
         private static void RespondWithRedirect(HttpResponse response, string location)
         {
-            response.StatusCode = 301;
+            response.StatusCode = StatusCodes.Status301MovedPermanently;
+#if NET6_0_OR_GREATER
+            response.Headers.Location = location;
+#else
             response.Headers["Location"] = location;
+#endif
         }
 
         private async Task RespondWithFile(HttpResponse response, string fileName)

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
@@ -1,5 +1,8 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Swashbuckle.AspNetCore.ReDoc;
 using Xunit;
 using ReDocApp = ReDoc;
 
@@ -79,6 +82,72 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
             Assert.Equal(HttpStatusCode.OK, htmlResponse.StatusCode);
             Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
             Assert.Contains(swaggerPath, content);
+        }
+
+        [Fact]
+        public void ReDocOptions_Extensions()
+        {
+            // Arrange
+            var options = new ReDocOptions();
+
+            // Act and Assert
+            Assert.NotNull(options.IndexStream);
+            Assert.Null(options.JsonSerializerOptions);
+            Assert.Null(options.SpecUrl);
+            Assert.Equal("API Docs", options.DocumentTitle);
+            Assert.Equal(string.Empty, options.HeadContent);
+            Assert.Equal("api-docs", options.RoutePrefix);
+
+            Assert.NotNull(options.ConfigObject);
+            Assert.NotNull(options.ConfigObject.AdditionalItems);
+            Assert.Empty(options.ConfigObject.AdditionalItems);
+            Assert.Null(options.ConfigObject.ScrollYOffset);
+            Assert.Equal("all", options.ConfigObject.ExpandResponses);
+            Assert.False(options.ConfigObject.DisableSearch);
+            Assert.False(options.ConfigObject.HideDownloadButton);
+            Assert.False(options.ConfigObject.HideHostname);
+            Assert.False(options.ConfigObject.HideLoading);
+            Assert.False(options.ConfigObject.NativeScrollbars);
+            Assert.False(options.ConfigObject.NoAutoAuth);
+            Assert.False(options.ConfigObject.OnlyRequiredInSamples);
+            Assert.False(options.ConfigObject.PathInMiddlePanel);
+            Assert.False(options.ConfigObject.RequiredPropsFirst);
+            Assert.False(options.ConfigObject.SortPropsAlphabetically);
+            Assert.False(options.ConfigObject.UntrustedSpec);
+
+            // Act
+            options.DisableSearch();
+            options.EnableUntrustedSpec();
+            options.ExpandResponses("response");
+            options.HideDownloadButton();
+            options.HideHostname();
+            options.HideLoading();
+            options.InjectStylesheet("custom.css", "screen and (max-width: 700px)");
+            options.NativeScrollbars();
+            options.NoAutoAuth();
+            options.OnlyRequiredInSamples();
+            options.PathInMiddlePanel();
+            options.RequiredPropsFirst();
+            options.ScrollYOffset(42);
+            options.SortPropsAlphabetically();
+            options.SpecUrl("spec.json");
+
+            // Assert
+            Assert.Equal("<link href='custom.css' rel='stylesheet' media='screen and (max-width: 700px)' type='text/css' />" + Environment.NewLine, options.HeadContent);
+            Assert.Equal("spec.json", options.SpecUrl);
+            Assert.Equal("response", options.ConfigObject.ExpandResponses);
+            Assert.Equal(42, options.ConfigObject.ScrollYOffset);
+            Assert.True(options.ConfigObject.DisableSearch);
+            Assert.True(options.ConfigObject.HideDownloadButton);
+            Assert.True(options.ConfigObject.HideHostname);
+            Assert.True(options.ConfigObject.HideLoading);
+            Assert.True(options.ConfigObject.NativeScrollbars);
+            Assert.True(options.ConfigObject.NoAutoAuth);
+            Assert.True(options.ConfigObject.OnlyRequiredInSamples);
+            Assert.True(options.ConfigObject.PathInMiddlePanel);
+            Assert.True(options.ConfigObject.RequiredPropsFirst);
+            Assert.True(options.ConfigObject.SortPropsAlphabetically);
+            Assert.True(options.ConfigObject.UntrustedSpec);
         }
     }
 }

--- a/test/WebSites/WebApi.Aot/Program.cs
+++ b/test/WebSites/WebApi.Aot/Program.cs
@@ -1,7 +1,11 @@
 using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Routing.Constraints;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateSlimBuilder(args);
+
+builder.Services.Configure<RouteOptions>(
+    options => options.SetParameterPolicy<RegexInlineRouteConstraint>("regex"));
 
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
@@ -41,6 +45,8 @@ todosApi.MapGet("/{id}", (int id) =>
 
 app.UseSwagger();
 app.UseSwaggerUI();
+app.UseReDoc();
+
 app.MapSwagger();
 
 app.Run();

--- a/test/WebSites/WebApi.Aot/WebApi.Aot.csproj
+++ b/test/WebSites/WebApi.Aot/WebApi.Aot.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.ReDoc\Swashbuckle.AspNetCore.ReDoc.csproj" />
     <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerGen\Swashbuckle.AspNetCore.SwaggerGen.csproj" />
     <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerUI\Swashbuckle.AspNetCore.SwaggerUI.csproj" />
   </ItemGroup>


### PR DESCRIPTION
- Add support for using the ReDoc middleware in native AoT applications.
- Add missing test coverage for ReDoc extensions.
- Fix some code analysis suggestions.
- Fix native AoT test app exception on start-up (see #2951).
