### PR TITLE
fix: Pass props to multi targeting

### DIFF
--- a/src/Swashbuckle.AspNetCore/Swashbuckle.AspNetCore.nuspec
+++ b/src/Swashbuckle.AspNetCore/Swashbuckle.AspNetCore.nuspec
@@ -22,5 +22,6 @@
   </metadata>
   <files>
     <file src="Swashbuckle.AspNetCore.props" target="build\Swashbuckle.AspNetCore.props" />
+    <file src="Swashbuckle.AspNetCore.props" target="buildMultiTargeting\Swashbuckle.AspNetCore.props" />
   </files>
 </package>


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

This PR fixes #2706 by passing the defined `Swashbuckle.AspNetCore.props` file to the `buildMultiTargeting` directory, which is used for outer builds (Multi targeting). 

## Details on the issue fix or feature implementation

The props file defines that the `OpenApiGenerateDocumentsOnBuild` property is false by default if it's not set. However, this was not set for multi targeting projects. So the document was generated during the build. 
