### PR TITLE
Types with TryParse must be set with type string

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -590,14 +590,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             var isRequired = apiParameter.IsRequiredParameter();
 
-            var type = apiParameter.Type;
+            var type = apiParameter.ModelMetadata?.ModelType;
 
             if (type is not null
                 && type == typeof(string)
-                && apiParameter.ModelMetadata?.ModelType is not null
-                && apiParameter.ModelMetadata.ModelType != type)
+                && apiParameter.Type is not null
+                && (Nullable.GetUnderlyingType(apiParameter.Type) ?? apiParameter.Type).IsEnum)
             {
-                type = apiParameter.ModelMetadata.ModelType;
+                type = apiParameter.Type;
             }
 
             var schema = (type != null)

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_For_WebApi_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_For_WebApi_swaggerRequestUri=v1.verified.txt
@@ -170,6 +170,35 @@
         }
       }
     },
+    "/TypeWithTryParse/{tryParse}": {
+      "get": {
+        "tags": [
+          "WebApi"
+        ],
+        "parameters": [
+          {
+            "name": "tryParse",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/WithOpenApi/weatherforecast": {
       "get": {
         "tags": [

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.TypesAreRenderedCorrectly.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.TypesAreRenderedCorrectly.verified.txt
@@ -170,6 +170,35 @@
         }
       }
     },
+    "/TypeWithTryParse/{tryParse}": {
+      "get": {
+        "tags": [
+          "WebApi"
+        ],
+        "parameters": [
+          {
+            "name": "tryParse",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/WithOpenApi/weatherforecast": {
       "get": {
         "tags": [

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeController.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Swashbuckle.AspNetCore.Annotations;
 using Swashbuckle.AspNetCore.SwaggerGen.Test.Fixtures;
+using Swashbuckle.AspNetCore.TestSupport;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
@@ -108,6 +109,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void ActionHavingFromFormAttributeButNotWithIFormFile([FromForm] string param1, IFormFile param2)
         { }
         public void ActionHavingFromFormAttributeWithSwaggerIgnore([FromForm] SwaggerIngoreAnnotatedType param1)
+        { }
+        public void ActionHavingEnum(IntEnum param1)
         { }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -2020,6 +2020,38 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
+        public void GetSwagger_Works_As_Expected_When_TypeIsEnum_AndModelMetadataTypeIsString()
+        {
+            var subject = Subject(
+                apiDescriptions:
+                [
+                   ApiDescriptionFactory.Create<FakeController>(
+                        c => nameof(c.ActionHavingEnum),
+                        groupName: "v1",
+                        httpMethod: "POST",
+                        relativePath: "resource",
+                        parameterDescriptions:
+                        [
+                            new ApiParameterDescription
+                            {
+                                Name = "param1",
+                                Source = BindingSource.Query,
+                                Type = typeof(IntEnum),
+                                ModelMetadata = ModelMetadataFactory.CreateForType(typeof(string))
+                            }
+                        ])
+                ]
+            );
+            var document = subject.GetSwagger("v1");
+
+            var operation = document.Paths["/resource"].Operations[OperationType.Post];
+            Assert.Equal("param1", operation.Parameters[0].Name);
+            Assert.NotNull(operation.Parameters[0].Schema);
+            Assert.NotNull(operation.Parameters[0].Schema.Reference);
+            Assert.Equal(typeof(IntEnum).Name, operation.Parameters[0].Schema.Reference.Id);
+        }
+
+        [Fact]
         public void GetSwagger_Copies_Description_From_GeneratedSchema()
         {
             var propertyEnum = typeof(TypeWithDefaultAttributeOnEnum).GetProperty(nameof(TypeWithDefaultAttributeOnEnum.EnumWithDefault));

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.GetSwagger_Works_As_Expected_When_TypeIsEnum_AndModelMetadataTypeIsString.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.GetSwagger_Works_As_Expected_When_TypeIsEnum_AndModelMetadataTypeIsString.verified.txt
@@ -1,0 +1,84 @@
+﻿{
+  Info: {
+    Title: Test API,
+    Version: V1
+  },
+  Paths: {
+    /resource: {
+      Operations: {
+        Post: {
+          Tags: [
+            {
+              Name: Fake,
+              UnresolvedReference: false
+            }
+          ],
+          Parameters: [
+            {
+              UnresolvedReference: false,
+              Name: param1,
+              In: Query,
+              Required: false,
+              Deprecated: false,
+              AllowEmptyValue: false,
+              Style: Form,
+              Explode: true,
+              AllowReserved: false,
+              Schema: {
+                ReadOnly: false,
+                WriteOnly: false,
+                AdditionalPropertiesAllowed: true,
+                Nullable: false,
+                Deprecated: false,
+                UnresolvedReference: false,
+                Reference: {
+                  IsFragrament: false,
+                  Type: Schema,
+                  Id: IntEnum,
+                  IsExternal: false,
+                  IsLocal: true,
+                  ReferenceV3: #/components/schemas/IntEnum,
+                  ReferenceV2: #/definitions/IntEnum
+                }
+              }
+            }
+          ],
+          Responses: {
+            200: {
+              Description: OK,
+              UnresolvedReference: false
+            }
+          },
+          Deprecated: false
+        }
+      },
+      UnresolvedReference: false
+    }
+  },
+  Components: {
+    Schemas: {
+      IntEnum: {
+        Type: integer,
+        Format: int32,
+        ReadOnly: false,
+        WriteOnly: false,
+        AdditionalPropertiesAllowed: true,
+        Enum: [
+          {
+            Value: 2
+          },
+          {
+            Value: 4
+          },
+          {
+            Value: 8
+          }
+        ],
+        Nullable: false,
+        Deprecated: false,
+        UnresolvedReference: false
+      }
+    }
+  },
+  HashCode: F2B8FE01A8D273C628EBD9F65C7F1E80622E3C5CBBB8F150E247A34C4558F617F1D056F7B1113ABE978F9E433A9FBCA1C65A6387FB918AF00AFB54E6F5A47C5D
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.cs
@@ -1105,6 +1105,35 @@ public class SwaggerGeneratorVerifyTests
     }
 
     [Fact]
+    public Task GetSwagger_Works_As_Expected_When_TypeIsEnum_AndModelMetadataTypeIsString()
+    {
+        var subject = Subject(
+            apiDescriptions:
+            [
+               ApiDescriptionFactory.Create<FakeController>(
+                        c => nameof(c.ActionHavingEnum),
+                        groupName: "v1",
+                        httpMethod: "POST",
+                        relativePath: "resource",
+                        parameterDescriptions:
+                        [
+                            new ApiParameterDescription
+                            {
+                                Name = "param1",
+                                Source = BindingSource.Query,
+                                Type = typeof(IntEnum),
+                                ModelMetadata = ModelMetadataFactory.CreateForType(typeof(string))
+                            }
+                        ])
+            ]
+        );
+
+        var document = subject.GetSwagger("v1");
+
+        return Verifier.Verify(document);
+    }
+
+    [Fact]
     public Task GetSwagger_Copies_Description_From_GeneratedSchema()
     {
         var propertyEnum = typeof(TypeWithDefaultAttributeOnEnum).GetProperty(nameof(TypeWithDefaultAttributeOnEnum.EnumWithDefault));

--- a/test/WebSites/WebApi/EndPoints/OpenApiEndpoints.cs
+++ b/test/WebSites/WebApi/EndPoints/OpenApiEndpoints.cs
@@ -70,6 +70,11 @@ namespace WebApi.EndPoints
                 return $"{file.FileName}{tags}";
             }).WithOpenApi();
 
+            app.MapGet("/TypeWithTryParse/{tryParse}", (TypeWithTryParse tryParse) =>
+            {
+                return tryParse.Name;
+            }).WithOpenApi();
+
             return app;
         }
     }
@@ -82,4 +87,18 @@ namespace WebApi.EndPoints
     record class Address(string Street, string City, string State, string ZipCode);
     sealed record OrganizationCustomExchangeRatesDto([property: JsonRequired] CurrenciesRate[] CurrenciesRates);
     sealed record CurrenciesRate([property: JsonRequired] string CurrencyFrom, [property: JsonRequired] string CurrencyTo, double Rate);
+    record TypeWithTryParse(string Name)
+    {
+        public static bool TryParse(string value, out TypeWithTryParse? result)
+        {
+            if (value is null)
+            {
+                result = null;
+                return false;
+            }
+
+            result = new TypeWithTryParse(value);
+            return true;
+        }
+    }
 }


### PR DESCRIPTION
Fixes #3105
It's not a full rollback of #2980..  But almost, now it takes into account the Enum if the apiParameter.Type is Enum