### PR TITLE
Avoid exception checking nullability

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -27,7 +27,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
         }
 
-        public SchemaGenerator(SchemaGeneratorOptions generatorOptions, ISerializerDataContractResolver serializerDataContractResolver, IOptions<MvcOptions> mvcOptions)
+        public SchemaGenerator(
+            SchemaGeneratorOptions generatorOptions,
+            ISerializerDataContractResolver serializerDataContractResolver,
+            IOptions<MvcOptions> mvcOptions)
         {
             _generatorOptions = generatorOptions;
             _serializerDataContractResolver = serializerDataContractResolver;
@@ -104,7 +107,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     var genericTypes = modelType
                         .GetInterfaces()
 #if NETSTANDARD2_0
-                        .Concat(new[] { modelType })
+                        .Concat([modelType])
 #else
                         .Append(modelType)
 #endif
@@ -309,7 +312,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             };
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            // For backcompat only - EnumValues is obsolete
+            // For backwards compatibility only - EnumValues is obsolete
             if (dataContract.EnumValues != null)
             {
                 schema.Enum = dataContract.EnumValues

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/MemberInfoExtensionsTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/MemberInfoExtensionsTests.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen;
+
+#nullable enable
+
+public static class MemberInfoExtensionsTests
+{
+    [Theory]
+    [InlineData(typeof(MyClass), nameof(MyClass.DictionaryInt32NonNullable), true)]
+    [InlineData(typeof(MyClass), nameof(MyClass.DictionaryInt32Nullable), false)]
+    [InlineData(typeof(MyClass), nameof(MyClass.DictionaryStringNonNullable), true)]
+    [InlineData(typeof(MyClass), nameof(MyClass.DictionaryStringNullable), false)]
+    [InlineData(typeof(MyClass), nameof(MyClass.IDictionaryInt32NonNullable), true)]
+    [InlineData(typeof(MyClass), nameof(MyClass.IDictionaryInt32Nullable), false)]
+    [InlineData(typeof(MyClass), nameof(MyClass.IDictionaryStringNonNullable), true)]
+    [InlineData(typeof(MyClass), nameof(MyClass.IDictionaryStringNullable), false)]
+    [InlineData(typeof(MyClass), nameof(MyClass.IReadOnlyDictionaryInt32NonNullable), true)]
+    [InlineData(typeof(MyClass), nameof(MyClass.IReadOnlyDictionaryInt32Nullable), false)]
+    [InlineData(typeof(MyClass), nameof(MyClass.IReadOnlyDictionaryStringNonNullable), true)]
+    [InlineData(typeof(MyClass), nameof(MyClass.IReadOnlyDictionaryStringNullable), false)]
+    [InlineData(typeof(MyClass), nameof(MyClass.StringDictionary), false)] // There is no way to inspect the nullability of the base class' TValue argument
+    [InlineData(typeof(MyClass), nameof(MyClass.NullableStringDictionary), false)]
+    [InlineData(typeof(MyClass), nameof(MyClass.SameTypesDictionary), true)]
+    [InlineData(typeof(MyClass), nameof(MyClass.CustomDictionaryStringNullable), false)]
+    [InlineData(typeof(MyClass), nameof(MyClass.CustomDictionaryStringNonNullable), true)]
+    public static void IsDictionaryValueNonNullable_Returns_Correct_Value(Type type, string memberName, bool expected)
+    {
+        // Arrange
+        var memberInfo = type.GetMember(memberName).First();
+
+        // Act
+        var actual = memberInfo.IsDictionaryValueNonNullable();
+
+        // Assert
+        Assert.Equal(expected, actual);
+    }
+
+    public class MyClass
+    {
+        public Dictionary<string, int> DictionaryInt32NonNullable { get; set; } = [];
+
+        public Dictionary<string, int?> DictionaryInt32Nullable { get; set; } = [];
+
+        public Dictionary<string, string> DictionaryStringNonNullable { get; set; } = [];
+
+        public Dictionary<string, string?> DictionaryStringNullable { get; set; } = [];
+
+        public IDictionary<string, int> IDictionaryInt32NonNullable { get; set; } = new Dictionary<string, int>();
+
+        public IDictionary<string, int?> IDictionaryInt32Nullable { get; set; } = new Dictionary<string, int?>();
+
+        public IDictionary<string, string> IDictionaryStringNonNullable { get; set; } = new Dictionary<string, string>();
+
+        public IDictionary<string, string?> IDictionaryStringNullable { get; set; } = new Dictionary<string, string?>();
+
+        public IReadOnlyDictionary<string, int> IReadOnlyDictionaryInt32NonNullable { get; set; } = new Dictionary<string, int>();
+
+        public IReadOnlyDictionary<string, int?> IReadOnlyDictionaryInt32Nullable { get; set; } = new Dictionary<string, int?>();
+
+        public IReadOnlyDictionary<string, string> IReadOnlyDictionaryStringNonNullable { get; set; } = new Dictionary<string, string>();
+
+        public IReadOnlyDictionary<string, string?> IReadOnlyDictionaryStringNullable { get; set; } = new Dictionary<string, string?>();
+
+        public StringDictionary StringDictionary { get; set; } = [];
+
+        public NullableStringDictionary NullableStringDictionary { get; set; } = [];
+
+        public SameTypesDictionary<string> SameTypesDictionary { get; set; } = [];
+
+        public CustomDictionary<string, string?> CustomDictionaryStringNullable { get; set; } = [];
+
+        public CustomDictionary<string, string> CustomDictionaryStringNonNullable { get; set; } = [];
+    }
+
+    public class StringDictionary : Dictionary<string, string>;
+
+    public class NullableStringDictionary : Dictionary<string, string?>;
+
+    public class SameTypesDictionary<T> : Dictionary<T, T> where T : notnull;
+
+    public class CustomDictionary<TKey, TValue> : Dictionary<TKey, TValue> where TKey : notnull;
+}


### PR DESCRIPTION
- Do not throw if we cannot determine the nullability of a dictionary. It's better to potentially be wrong, rather than be unable to generate a document at all.
- Clean-up some code analysis suggestions.

Resolves #3070.
Resolves #2793 (as it's the last linked issue).
