### PR TITLE
Refactor filter descriptor type checks in SwaggerGen

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSwaggerGeneratorOptions.cs
@@ -36,12 +36,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             foreach (var filterDescriptor in _swaggerGenOptions.ParameterFilterDescriptors)
             {
-                if (filterDescriptor.Type.IsAssignableTo(typeof(IParameterFilter)))
+                if (filterDescriptor.IsAssignableTo(typeof(IParameterFilter)))
                 {
                     options.ParameterFilters.Add(GetOrCreateFilter<IParameterFilter>(filterDescriptor));
                 }
 
-                if (filterDescriptor.Type.IsAssignableTo(typeof(IParameterAsyncFilter)))
+                if (filterDescriptor.IsAssignableTo(typeof(IParameterAsyncFilter)))
                 {
                     options.ParameterAsyncFilters.Add(GetOrCreateFilter<IParameterAsyncFilter>(filterDescriptor));
                 }
@@ -49,12 +49,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             foreach (var filterDescriptor in _swaggerGenOptions.RequestBodyFilterDescriptors)
             {
-                if (filterDescriptor.Type.IsAssignableTo(typeof(IRequestBodyFilter)))
+                if (filterDescriptor.IsAssignableTo(typeof(IRequestBodyFilter)))
                 {
                     options.RequestBodyFilters.Add(GetOrCreateFilter<IRequestBodyFilter>(filterDescriptor));
                 }
 
-                if (filterDescriptor.Type.IsAssignableTo(typeof(IRequestBodyAsyncFilter)))
+                if (filterDescriptor.IsAssignableTo(typeof(IRequestBodyAsyncFilter)))
                 {
                     options.RequestBodyAsyncFilters.Add(GetOrCreateFilter<IRequestBodyAsyncFilter>(filterDescriptor));
                 }
@@ -62,12 +62,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             foreach (var filterDescriptor in _swaggerGenOptions.OperationFilterDescriptors)
             {
-                if (filterDescriptor.Type.IsAssignableTo(typeof(IOperationFilter)))
+                if (filterDescriptor.IsAssignableTo(typeof(IOperationFilter)))
                 {
                     options.OperationFilters.Add(GetOrCreateFilter<IOperationFilter>(filterDescriptor));
                 }
 
-                if (filterDescriptor.Type.IsAssignableTo(typeof(IOperationAsyncFilter)))
+                if (filterDescriptor.IsAssignableTo(typeof(IOperationAsyncFilter)))
                 {
                     options.OperationAsyncFilters.Add(GetOrCreateFilter<IOperationAsyncFilter>(filterDescriptor));
                 }
@@ -75,12 +75,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             foreach (var filterDescriptor in _swaggerGenOptions.DocumentFilterDescriptors)
             {
-                if (filterDescriptor.Type.IsAssignableTo(typeof(IDocumentFilter)))
+                if (filterDescriptor.IsAssignableTo(typeof(IDocumentFilter)))
                 {
                     options.DocumentFilters.Add(GetOrCreateFilter<IDocumentFilter>(filterDescriptor));
                 }
 
-                if (filterDescriptor.Type.IsAssignableTo(typeof(IDocumentAsyncFilter)))
+                if (filterDescriptor.IsAssignableTo(typeof(IDocumentAsyncFilter)))
                 {
                     options.DocumentAsyncFilters.Add(GetOrCreateFilter<IDocumentAsyncFilter>(filterDescriptor));
                 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptions.cs
@@ -32,5 +32,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         public object[] Arguments { get; set; }
 
         public object FilterInstance { get; set; }
+
+        internal bool IsAssignableTo(Type type)
+        {
+            return FilterInstance != null && type.IsInstanceOfType(FilterInstance) ||
+                   Type != null && Type.IsAssignableTo(type);
+        }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptions.cs
@@ -35,8 +35,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         internal bool IsAssignableTo(Type type)
         {
-            return FilterInstance != null && type.IsInstanceOfType(FilterInstance) ||
-                   Type != null && Type.IsAssignableTo(type);
+            return (FilterInstance != null && type.IsInstanceOfType(FilterInstance)) ||
+                   (Type != null && Type.IsAssignableTo(type));
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -370,7 +370,6 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.SchemaFilterDescriptors.Add(new FilterDescriptor
             {
-                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }
@@ -428,7 +427,6 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.ParameterFilterDescriptors.Add(new FilterDescriptor
             {
-                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }
@@ -448,7 +446,6 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.ParameterFilterDescriptors.Add(new FilterDescriptor
             {
-                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }
@@ -506,7 +503,6 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.RequestBodyFilterDescriptors.Add(new FilterDescriptor
             {
-                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }
@@ -526,7 +522,6 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.RequestBodyFilterDescriptors.Add(new FilterDescriptor
             {
-                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }
@@ -584,7 +579,6 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.OperationFilterDescriptors.Add(new FilterDescriptor
             {
-                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }
@@ -604,7 +598,6 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.OperationFilterDescriptors.Add(new FilterDescriptor
             {
-                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }
@@ -663,7 +656,6 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.DocumentFilterDescriptors.Add(new FilterDescriptor
             {
-                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }
@@ -684,7 +676,6 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.DocumentFilterDescriptors.Add(new FilterDescriptor
             {
-                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -370,6 +370,7 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.SchemaFilterDescriptors.Add(new FilterDescriptor
             {
+                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }
@@ -427,6 +428,7 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.ParameterFilterDescriptors.Add(new FilterDescriptor
             {
+                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }
@@ -446,6 +448,7 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.ParameterFilterDescriptors.Add(new FilterDescriptor
             {
+                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }
@@ -503,6 +506,7 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.RequestBodyFilterDescriptors.Add(new FilterDescriptor
             {
+                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }
@@ -522,6 +526,7 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.RequestBodyFilterDescriptors.Add(new FilterDescriptor
             {
+                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }
@@ -579,6 +584,7 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.OperationFilterDescriptors.Add(new FilterDescriptor
             {
+                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }
@@ -598,6 +604,7 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.OperationFilterDescriptors.Add(new FilterDescriptor
             {
+                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }
@@ -656,6 +663,7 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.DocumentFilterDescriptors.Add(new FilterDescriptor
             {
+                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }
@@ -676,6 +684,7 @@ namespace Microsoft.Extensions.DependencyInjection
             if (filterInstance == null) throw new ArgumentNullException(nameof(filterInstance));
             swaggerGenOptions.DocumentFilterDescriptors.Add(new FilterDescriptor
             {
+                Type = typeof(TFilter),
                 FilterInstance = filterInstance
             });
         }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSwaggerGeneratorOptionsTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSwaggerGeneratorOptionsTests.cs
@@ -412,4 +412,32 @@ public static class ConfigureSwaggerGeneratorOptionsTests
         Assert.Equal(2, swaggerGeneratorOptions.DocumentAsyncFilters.Count);
         Assert.NotSame(swaggerGeneratorOptions.DocumentAsyncFilters.First(), swaggerGeneratorOptions.DocumentAsyncFilters.Last());
     }
+
+    [Fact]
+    public static void AddingFilterDescriptorWithFilterInstance_WhenConfiguringOptions_NoExceptionIsThrown()
+    {
+        var webhostingEnvironment = Substitute.For<IWebHostEnvironment>();
+        webhostingEnvironment.ApplicationName.Returns("Swashbuckle.AspNetCore.SwaggerGen.Test");
+
+        var options = new SwaggerGenOptions();
+        options.OperationFilterDescriptors.Add(
+            new FilterDescriptor()
+            {
+                // Before this PR, leaving Type to null would cause an exception when checking for `Type.IsAssignableTo(...)`
+                // Type = null,
+                FilterInstance = new TestOperationFilter(),
+            });
+
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+        var configureSwaggerGeneratorOptions = new ConfigureSwaggerGeneratorOptions(
+            Options.Create(options),
+            serviceProvider,
+            webhostingEnvironment);
+        var swaggerGeneratorOptions = new SwaggerGeneratorOptions();
+
+        configureSwaggerGeneratorOptions.Configure(swaggerGeneratorOptions);
+
+        Assert.Single(swaggerGeneratorOptions.OperationFilters);
+    }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSwaggerGeneratorOptionsTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSwaggerGeneratorOptionsTests.cs
@@ -423,8 +423,7 @@ public static class ConfigureSwaggerGeneratorOptionsTests
         options.OperationFilterDescriptors.Add(
             new FilterDescriptor()
             {
-                // Before this PR, leaving Type to null would cause an exception when checking for `Type.IsAssignableTo(...)`
-                // Type = null,
+                Type = null,
                 FilterInstance = new TestOperationFilter(),
             });
 


### PR DESCRIPTION
# Pull Request

Given that the public API allows to register a filter in this form without any specific validation on not assigning the Type property:

```csharp
genOptions.OperationFilterDescriptors.Add(new FilterDescriptor
{
    // Type = typeof(TdpHeaderParameter),
    FilterInstance = new TdpHeaderParameter(IRequestContext.UserIdKey, "The user ID."),
});
```

in which case, opening the swagger UI returns a `NullReferenceException` (in developer error page) with no reference to user source code.

Looking into the library source code, I found out that the "proper" way to do the registration is:

```csharp
genOptions.AddOperationFilterInstance(
    new TdpHeaderParameter(IRequestContext.TenantIdKey, "The tenant ID."));
```

but I just felt that the first option should also be available with minimal behavior changes, given that it is a possible choice in the public API.

## The issue or feature being addressed

> NOTE: I didn't create a specific issue

## Details on the issue fix or feature implementation

I added an alternative validation on the filter type for when the `FilterInstance` is set but not the `Type` of the `FilterDescriptor`.
