### PR TITLE
Initialize Urls property with an empty collection

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -71,7 +71,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
         /// One or more Swagger JSON endpoints (url and name) to power the UI
         /// </summary>
         [JsonPropertyName("urls")]
-        public IEnumerable<UrlDescriptor> Urls { get; set; } = null;
+        public IEnumerable<UrlDescriptor> Urls { get; set; } = Enumerable.Empty<UrlDescriptor>();
 
         /// <summary>
         /// If set to true, enables deep linking for tags and operations


### PR DESCRIPTION
Updated the `Urls` property in `ConfigObject` to initialize with `Enumerable.Empty<UrlDescriptor>()` instead of `null`. This change ensures the property is always a valid collection, eliminating the need for null checks and preventing potential null reference exceptions when accessing or iterating over the property. Improves code safety and aligns with best practices for handling collections.
