### PR TITLE
second level inheritance for UseAllOf

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -475,12 +475,18 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             baseTypeDataContract = null;
 
             var baseType = dataContract.UnderlyingType.BaseType;
+            while (baseType != null && baseType != typeof(object))
+            {
+                if (_generatorOptions.SubTypesSelector(baseType).Contains(dataContract.UnderlyingType))
+                {
+                    baseTypeDataContract = GetDataContractFor(baseType);
+                    return true;
+                }
 
-            if (baseType == null || baseType == typeof(object) || !_generatorOptions.SubTypesSelector(baseType).Contains(dataContract.UnderlyingType))
-                return false;
+                baseType = baseType.BaseType;
+            }
 
-            baseTypeDataContract = GetDataContractFor(baseType);
-            return true;
+            return false;
         }
 
         private bool TryGetDiscriminatorFor(

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -582,6 +582,29 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var schema = subject.GenerateSchema(typeof(BaseType), schemaRepository);
 
             Assert.Equal(new[] { "SubType1", "BaseType" }, schemaRepository.Schemas.Keys);
+
+            var subSchema = schemaRepository.Schemas["SubType1"];
+            Assert.NotNull(subSchema.AllOf);
+            Assert.Equal(2, subSchema.AllOf.Count);
+        }
+
+        [Fact]
+        public void GenerateSchema_SecondLevelInheritance_SubTypesSelector()
+        {
+            var subject = Subject(configureGenerator: c =>
+            {
+                c.UseAllOfForInheritance = true;
+                c.SubTypesSelector = (type) => type == typeof(BaseSecondLevelType) ? new[] { typeof(SubSubSecondLevelType) } : Array.Empty<Type>();
+            });
+            var schemaRepository = new SchemaRepository();
+
+            var schema = subject.GenerateSchema(typeof(BaseSecondLevelType), schemaRepository);
+
+            Assert.Equal(new[] { "SubSubSecondLevelType", "BaseSecondLevelType" }, schemaRepository.Schemas.Keys);
+
+            var subSchema = schemaRepository.Schemas["SubSubSecondLevelType"];
+            Assert.NotNull(subSchema.AllOf);
+            Assert.Equal(2, subSchema.AllOf.Count);
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/BaseSecondLevelType.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/BaseSecondLevelType.cs
@@ -1,0 +1,17 @@
+﻿namespace Swashbuckle.AspNetCore.TestSupport
+{
+    public class BaseSecondLevelType
+    {
+        public string BaseProperty { get; set; }
+    }
+
+    public class SubSecondLevelType : BaseSecondLevelType
+    {
+        public int Property1 { get; set; }
+    }
+
+    public class SubSubSecondLevelType : SubSecondLevelType
+    {
+        public int Property2 { get; set; }
+    }
+}


### PR DESCRIPTION
## The issue or feature being addressed

The `UseAllOfForInheritance` option of schema generator only accounts for direct parents. It makes impossible to generate correct discriminator information for a big inheritance tree. 

## Example
data class structure:
```C#
[SwaggerDiscriminator("discriminator")]
[SwaggerSubType(typeof(SubSubType), DiscriminatorValue = nameof(SubSubType))]
abstract public class BaseType
{
}

abstract public class SubType : BaseType
{
}

public class SubSubType : SubType
{
    public int Property { get; set; }
}
```

Swagger generator options:
```C#
builder.Services.AddSwaggerGen(
    options =>
    {
        options.UseAllOfForInheritance();
        options.UseOneOfForPolymorphism();
        options.EnableAnnotations(true, true);
    });
```

Generated components of the json:
```json
"components": {
    "schemas": {
      "SubSubType": {
        "type": "object",
        "properties": {
          "property": {
            "type": "integer",
            "format": "int32"
          }
        },
        "additionalProperties": false
      }
    }
  }
```

It doesn't include `discriminator` and `BaseType` definition.

If we remove `SubType` and make `SubSubType` child of `BaseType` we would get the expected generated components:
```json
"components": {
    "schemas": {
      "BaseType": {
        "required": [
          "discriminator"
        ],
        "type": "object",
        "properties": {
          "discriminator": {
            "type": "string"
          }
        },
        "additionalProperties": false,
        "discriminator": {
          "propertyName": "discriminator",
          "mapping": {
            "SubSubType": "#/components/schemas/SubSubType"
          }
        }
      },
      "SubSubType": {
        "allOf": [
          {
            "$ref": "#/components/schemas/BaseType"
          },
          {
            "type": "object",
            "properties": {
              "property": {
                "type": "integer",
                "format": "int32"
              }
            },
            "additionalProperties": false
          }
        ]
      }
    }
  }
```

## Details on the issue fix or feature implementation

This PR checks all parents until it finds the one which has this class defined as sub type. I added same assertions to test with one level assertions. 
