### PR TITLE
Fix NotSupportedException in AoT test project

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiParameterDescriptionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiParameterDescriptionExtensions.cs
@@ -113,8 +113,17 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         internal static bool IsFromForm(this ApiParameterDescription apiParameter)
         {
+            bool isEnhancedModelMetadataSupported = true;
+
+#if NET9_0_OR_GREATER
+            if (AppContext.TryGetSwitch("Microsoft.AspNetCore.Mvc.ApiExplorer.IsEnhancedModelMetadataSupported", out var isEnabled))
+            {
+                isEnhancedModelMetadataSupported = isEnabled;
+            }
+#endif
+
             var source = apiParameter.Source;
-            var elementType = apiParameter.ModelMetadata?.ElementType;
+            var elementType = isEnhancedModelMetadataSupported ? apiParameter.ModelMetadata?.ElementType : null;
 
             return (source == BindingSource.Form || source == BindingSource.FormFile)
                 || (elementType != null && typeof(IFormFile).IsAssignableFrom(elementType));


### PR DESCRIPTION
Fix `NotSupportedException` being thrown with .NET 9
 when accessing `ModelMetadata.ElementType` in a native AoT application due to `Microsoft.AspNetCore.Mvc.ApiExplorer.IsEnhancedModelMetadataSupported` being disabled.

Found while investigating #3153.