### PR TITLE
Push NuGet symbols to NuGet.org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,3 +197,7 @@ jobs:
     - name: Push NuGet packages to NuGet.org
       run: |
         dotnet nuget push "*.nupkg" --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate --source https://api.nuget.org/v3/index.json
+
+    - name: Push NuGet symbols to NuGet.org
+      run: |
+        dotnet nuget push "*.snupkg" --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Symbols are not published in nuget.org after https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/3168:
https://www.nuget.org/packages/Swashbuckle.AspNetCore/
![image](https://github.com/user-attachments/assets/2ecf3e07-a0e7-4609-b56e-12a5a555cc35)


Fixes https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3165