### PR TITLE
Update Microsoft.NET.Test.Sdk

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="2.1.0" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.22" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.22" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.1.0" />


### PR DESCRIPTION
Maybe this will fix flaky windows GH Actions

`C:\Users\runneradmin\.nuget\packages\coverlet.msbuild\6.0.2\build\coverlet.msbuild.targets(72,5): error : The process cannot access the file 'D:\a\Swashbuckle.AspNetCore\Swashbuckle.AspNetCore\artifacts\coverage\coverage.net8.0.cobertura.xml' because it is being used by another process.`