### PR TITLE
Add package README

### DIFF
--- a/src/Swashbuckle.AspNetCore/Swashbuckle.AspNetCore.nuspec
+++ b/src/Swashbuckle.AspNetCore/Swashbuckle.AspNetCore.nuspec
@@ -8,6 +8,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">$licenseExpression$</license>
     <projectUrl>$projectUrl$</projectUrl>
+    <readme>docs\package-readme.md</readme>
     <description>$description$</description>
     <tags>$tags$</tags>
     <repository type="$repositoryType$" url="$repositoryUrl$" />
@@ -23,5 +24,6 @@
   <files>
     <file src="Swashbuckle.AspNetCore.props" target="build\Swashbuckle.AspNetCore.props" />
     <file src="Swashbuckle.AspNetCore.props" target="buildMultiTargeting\Swashbuckle.AspNetCore.props" />
+    <file src="..\..\package-readme.md" target="docs\" />
   </files>
 </package>


### PR DESCRIPTION
Add missing package readme for Swashbuckle.AspNetCore to [avoid warning on publish](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/actions/runs/12008985504/job/33473214694#step:4:16).

```console
Run dotnet nuget push "*.nupkg" --api-key *** --skip-duplicate --source https://api.nuget.org/v3/index.json
Pushing Swashbuckle.AspNetCore.7.1.0.nupkg to 'https://www.nuget.org/api/v2/package'...
  PUT https://www.nuget.org/api/v2/package/
warn : Readme missing. Go to https://aka.ms/nuget-include-readme learn How to include a readme file within the package.
  Created https://www.nuget.org/api/v2/package/ 258ms
Your package was pushed.
```

The solution used for all the other packages doesn't work for this meta-package as it uses a `.nuspec` file so the MSBuild properties don't apply.