### PR TITLE
Replace IdentityServer4 with Duende.IdentityServer (#3008)

### DIFF
--- a/test/WebSites/OAuth2Integration/AuthServer/Config.cs
+++ b/test/WebSites/OAuth2Integration/AuthServer/Config.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
-using IdentityServer4.Models;
-using IdentityServer4.Test;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Test;
 
 namespace OAuth2Integration.AuthServer
 {
@@ -31,15 +31,12 @@ namespace OAuth2Integration.AuthServer
 
         internal static IEnumerable<ApiResource> ApiResources()
         {
-            yield return new ApiResource
+            return new List<ApiResource>
             {
-                Name = "api",
-                DisplayName = "API",
-                Scopes =
-                [
-                    new Scope("readAccess", "Access read operations"),
-                    new Scope("writeAccess", "Access write operations")
-                ]
+                new ApiResource("api", "API")
+                {
+                    Scopes = { "readAccess", "writeAccess" }
+                }
             };
         }
 

--- a/test/WebSites/OAuth2Integration/AuthServer/Controllers/AccountController.cs
+++ b/test/WebSites/OAuth2Integration/AuthServer/Controllers/AccountController.cs
@@ -1,9 +1,9 @@
 ﻿using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
+using Duende.IdentityServer;
+using Duende.IdentityServer.Test;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
-using IdentityServer4;
-using IdentityServer4.Test;
+using Microsoft.AspNetCore.Mvc;
 
 namespace OAuth2Integration.AuthServer.Controllers
 {
@@ -22,12 +22,11 @@ namespace OAuth2Integration.AuthServer.Controllers
         public IActionResult Login(string returnUrl)
         {
             var viewModel = new LoginViewModel { Username = "joebloggs", Password = "pass123", ReturnUrl = returnUrl };
-
             return View("/AuthServer/Views/Login.cshtml", viewModel);
         }
 
         [HttpPost("login")]
-        public async Task<IActionResult> Login([FromForm]LoginViewModel viewModel)
+        public async Task<IActionResult> Login([FromForm] LoginViewModel viewModel)
         {
             if (!_userStore.ValidateCredentials(viewModel.Username, viewModel.Password))
             {

--- a/test/WebSites/OAuth2Integration/AuthServer/Controllers/ConsentController.cs
+++ b/test/WebSites/OAuth2Integration/AuthServer/Controllers/ConsentController.cs
@@ -28,7 +28,7 @@ namespace OAuth2Integration.AuthServer.Controllers
             {
                 ReturnUrl = returnUrl,
                 ClientName = request.Client.ClientName,
-                ScopesRequested = request.ValidatedResources?.Resources?.ApiScopes ?? new List<ApiScope>()
+                ScopesRequested = request.ValidatedResources?.Resources?.ApiScopes ?? []
             };
 
             return View("/AuthServer/Views/Consent.cshtml", viewModel);

--- a/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
+++ b/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
@@ -12,17 +12,17 @@
 
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="6.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="6.0.36" />
     <PackageReference Include="Duende.IdentityServer" VersionOverride="6.0.5" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="8.0.12" />
     <PackageReference Include="Duende.IdentityServer" VersionOverride="7.0.8" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="8.0.12" />
     <PackageReference Include="Duende.IdentityServer" VersionOverride="7.0.8" />
   </ItemGroup>
 

--- a/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
+++ b/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
@@ -1,13 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFrameworks>net9.0;net8.0;net6.0</TargetFrameworks>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="IdentityServer4" />
-    <PackageReference Include="IdentityServer4.AccessTokenValidation" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.Swagger\Swashbuckle.AspNetCore.Swagger.csproj" />
@@ -15,12 +10,20 @@
     <ProjectReference Include="..\..\..\src\Swashbuckle.AspNetCore.SwaggerUI\Swashbuckle.AspNetCore.SwaggerUI.csproj" />
   </ItemGroup>
 
-  <!--
-    This is just a sample for testing - updating to Duende.IdentityServer can be done at some point in the future.
-    See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3008.
-  -->
-  <ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-55p7-v223-x366" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-ff4q-64jc-gx98" />
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="6.0.5" />
+    <PackageReference Include="Duende.IdentityServer" VersionOverride="6.0.5" />
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="8.0.11" />
+    <PackageReference Include="Duende.IdentityServer" VersionOverride="7.0.8" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="8.0.11" />
+    <PackageReference Include="Duende.IdentityServer" VersionOverride="7.0.8" />
+  </ItemGroup>
+
 </Project>

--- a/test/WebSites/OAuth2Integration/ResourceServer/Controllers/ProductsController.cs
+++ b/test/WebSites/OAuth2Integration/ResourceServer/Controllers/ProductsController.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 
 namespace OAuth2Integration.ResourceServer.Controllers
 {
@@ -33,7 +33,7 @@ namespace OAuth2Integration.ResourceServer.Controllers
 
         [HttpPost]
         [Authorize("writeAccess")]
-        public void CreateProduct([FromBody]Product product)
+        public void CreateProduct([FromBody] Product product)
         {
         }
 
@@ -53,6 +53,6 @@ namespace OAuth2Integration.ResourceServer.Controllers
 
     public enum ProductStatus
     {
-        InStock, ComingSoon 
+        InStock, ComingSoon
     }
 }

--- a/test/WebSites/OAuth2Integration/Startup.cs
+++ b/test/WebSites/OAuth2Integration/Startup.cs
@@ -46,7 +46,7 @@ namespace OAuth2Integration
                         ValidateAudience = true,
                         ValidateLifetime = true,
                         ValidAudience = "api",
-                        ValidIssuer = "https://localhost:5001/auth-server/",
+                        ValidIssuer = options.Authority,
                     };
                 });
 

--- a/test/WebSites/OAuth2Integration/Startup.cs
+++ b/test/WebSites/OAuth2Integration/Startup.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,7 +23,7 @@ namespace OAuth2Integration
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            // Register IdentityServer services to power OAuth2.0 flows
+            // Register Duende IdentityServer services to power OAuth2.0 flows
             services.AddIdentityServer()
                 .AddDeveloperSigningCredential()
                 .AddInMemoryClients(AuthServer.Config.Clients())
@@ -36,11 +35,19 @@ namespace OAuth2Integration
             // See https://learn.microsoft.com/aspnet/core/security/authorization/limitingidentitybyscheme
             services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
                 .AddCookie()
-                .AddIdentityServerAuthentication(c =>
+                .AddJwtBearer("Bearer", options =>
                 {
-                    c.Authority = "https://localhost:5001/auth-server/";
-                    c.RequireHttpsMetadata = false;
-                    c.ApiName = "api";
+                    options.Authority = "https://localhost:5001/auth-server/";
+                    options.RequireHttpsMetadata = false;
+                    options.Audience = "api";
+                    options.TokenValidationParameters = new Microsoft.IdentityModel.Tokens.TokenValidationParameters
+                    {
+                        ValidateIssuer = true,
+                        ValidateAudience = true,
+                        ValidateLifetime = true,
+                        ValidAudience = "api",
+                        ValidIssuer = "https://localhost:5001/auth-server/",
+                    };
                 });
 
             // Configure named auth policies that map directly to OAuth2.0 scopes


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore! Open source is only as strong as its contributors. -->

# Pull Request

Fixes https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3008

## The issue or feature being addressed

This PR replaces **IdentityServer4** with **Duende.IdentityServer**.

## Details on the issue fix or feature implementation

- **Replaced** `IdentityServer4` with `Duende.IdentityServer` in project dependencies.
- **Updated** the OAuth2Integration code to be compatible with Duende.IdentityServer.
- **Verified** that all existing integration tests are passing.