### PR TITLE
Add CreateFromJson options overload

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,7 +42,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseArtifactsOutput>true</UseArtifactsOutput>
-    <VersionPrefix>7.2.1</VersionPrefix>
+    <VersionPrefix>7.3.0</VersionPrefix>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(GITHUB_ACTIONS)' != '' ">

--- a/src/Swashbuckle.AspNetCore.ReDoc/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Swashbuckle.AspNetCore.ReDoc/PublicAPI/PublicAPI.Shipped.txt
@@ -56,6 +56,8 @@ Swashbuckle.AspNetCore.ReDoc.ReDocOptions.HeadContent.get -> string
 Swashbuckle.AspNetCore.ReDoc.ReDocOptions.HeadContent.set -> void
 Swashbuckle.AspNetCore.ReDoc.ReDocOptions.IndexStream.get -> System.Func<System.IO.Stream>
 Swashbuckle.AspNetCore.ReDoc.ReDocOptions.IndexStream.set -> void
+Swashbuckle.AspNetCore.ReDoc.ReDocOptions.JsonSerializerOptions.get -> System.Text.Json.JsonSerializerOptions
+Swashbuckle.AspNetCore.ReDoc.ReDocOptions.JsonSerializerOptions.set -> void
 Swashbuckle.AspNetCore.ReDoc.ReDocOptions.ReDocOptions() -> void
 Swashbuckle.AspNetCore.ReDoc.ReDocOptions.RoutePrefix.get -> string
 Swashbuckle.AspNetCore.ReDoc.ReDocOptions.RoutePrefix.set -> void

--- a/src/Swashbuckle.AspNetCore.ReDoc/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.ReDoc/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,2 +1,0 @@
-Swashbuckle.AspNetCore.ReDoc.ReDocOptions.JsonSerializerOptions.get -> System.Text.Json.JsonSerializerOptions
-Swashbuckle.AspNetCore.ReDoc.ReDocOptions.JsonSerializerOptions.set -> void

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Shipped.txt
@@ -1,8 +1,12 @@
 Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions
 Microsoft.Extensions.DependencyInjection.SwaggerGenServiceCollectionExtensions
+static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.AddDocumentAsyncFilterInstance<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, TFilter filterInstance) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.AddDocumentFilterInstance<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, TFilter filterInstance) -> void
+static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.AddOperationAsyncFilterInstance<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, TFilter filterInstance) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.AddOperationFilterInstance<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, TFilter filterInstance) -> void
+static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.AddParameterAsyncFilterInstance<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, TFilter filterInstance) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.AddParameterFilterInstance<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, TFilter filterInstance) -> void
+static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.AddRequestBodyAsyncFilterInstance<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, TFilter filterInstance) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.AddRequestBodyFilterInstance<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, TFilter filterInstance) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.AddSchemaFilterInstance<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, TFilter filterInstance) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.AddSecurityDefinition(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, string name, Microsoft.OpenApi.Models.OpenApiSecurityScheme securityScheme) -> void
@@ -11,6 +15,7 @@ static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.AddS
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.CustomOperationIds(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, System.Func<Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription, string> operationIdSelector) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.CustomSchemaIds(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, System.Func<System.Type, string> schemaIdSelector) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.DescribeAllParametersInCamelCase(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions) -> void
+static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.DocumentAsyncFilter<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, params object[] arguments) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.DocInclusionPredicate(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, System.Func<string, Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription, bool> predicate) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.DocumentFilter<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, params object[] arguments) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.GeneratePolymorphicSchemas(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, System.Func<System.Type, System.Collections.Generic.IEnumerable<System.Type>> subTypesResolver = null, System.Func<System.Type, string> discriminatorSelector = null) -> void
@@ -23,9 +28,12 @@ static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.Infe
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.MapType(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, System.Type type, System.Func<Microsoft.OpenApi.Models.OpenApiSchema> schemaFactory) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.MapType<T>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, System.Func<Microsoft.OpenApi.Models.OpenApiSchema> schemaFactory) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.NonNullableReferenceTypesAsRequired(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions) -> void
+static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.OperationAsyncFilter<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, params object[] arguments) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.OperationFilter<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, params object[] arguments) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.OrderActionsBy(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, System.Func<Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription, string> sortKeySelector) -> void
+static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.ParameterAsyncFilter<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, params object[] arguments) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.ParameterFilter<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, params object[] arguments) -> void
+static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.RequestBodyAsyncFilter<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, params object[] arguments) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.RequestBodyFilter<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, params object[] arguments) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.ResolveConflictingActions(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, System.Func<System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription>, Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription> resolver) -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.SchemaFilter<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, params object[] arguments) -> void
@@ -266,6 +274,8 @@ Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.ParameterAsyncFilters.
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.ParameterAsyncFilters.set -> void
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.ParameterFilters.get -> System.Collections.Generic.IList<Swashbuckle.AspNetCore.SwaggerGen.IParameterFilter>
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.ParameterFilters.set -> void
+Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.PathGroupSelector.get -> System.Func<Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription, string>
+Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.PathGroupSelector.set -> void
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.RequestBodyAsyncFilters.get -> System.Collections.Generic.IList<Swashbuckle.AspNetCore.SwaggerGen.IRequestBodyAsyncFilter>
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.RequestBodyAsyncFilters.set -> void
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.RequestBodyFilters.get -> System.Collections.Generic.List<Swashbuckle.AspNetCore.SwaggerGen.IRequestBodyFilter>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,10 +1,1 @@
-static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.AddDocumentAsyncFilterInstance<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, TFilter filterInstance) -> void
-static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.AddOperationAsyncFilterInstance<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, TFilter filterInstance) -> void
-static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.AddParameterAsyncFilterInstance<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, TFilter filterInstance) -> void
-static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.AddRequestBodyAsyncFilterInstance<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, TFilter filterInstance) -> void
-static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.DocumentAsyncFilter<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, params object[] arguments) -> void
-static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.OperationAsyncFilter<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, params object[] arguments) -> void
-static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.ParameterAsyncFilter<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, params object[] arguments) -> void
-static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.RequestBodyAsyncFilter<TFilter>(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, params object[] arguments) -> void
-Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.PathGroupSelector.get -> System.Func<Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription, string>
-Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.PathGroupSelector.set -> void
+static Swashbuckle.AspNetCore.SwaggerGen.OpenApiAnyFactory.CreateFromJson(string json, System.Text.Json.JsonSerializerOptions options) -> Microsoft.OpenApi.Any.IOpenApiAny

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/OpenApiAnyFactory.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/OpenApiAnyFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System;
+using System.Text.Json;
 using Microsoft.OpenApi.Any;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
@@ -6,19 +7,22 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     public static class OpenApiAnyFactory
     {
         public static IOpenApiAny CreateFromJson(string json)
+            => CreateFromJson(json, null);
+
+        public static IOpenApiAny CreateFromJson(string json, JsonSerializerOptions options)
         {
             try
             {
-                var jsonElement = JsonSerializer.Deserialize<JsonElement>(json);
-
-                return CreateFromJsonElement(jsonElement);
+                var element = JsonSerializer.Deserialize<JsonElement>(json, options);
+                return CreateFromJsonElement(element);
             }
-            catch { }
-
-            return null;
+            catch (Exception)
+            {
+                return null;
+            }
         }
 
-        private static IOpenApiAny CreateOpenApiArray(JsonElement jsonElement)
+        private static OpenApiArray CreateOpenApiArray(JsonElement jsonElement)
         {
             var openApiArray = new OpenApiArray();
 
@@ -30,7 +34,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             return openApiArray;
         }
 
-        private static IOpenApiAny CreateOpenApiObject(JsonElement jsonElement)
+        private static OpenApiObject CreateOpenApiObject(JsonElement jsonElement)
         {
             var openApiObject = new OpenApiObject();
 

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/PublicAPI/PublicAPI.Shipped.txt
@@ -60,6 +60,8 @@ Swashbuckle.AspNetCore.SwaggerUI.ConfigObject.OAuth2RedirectUrl.get -> string
 Swashbuckle.AspNetCore.SwaggerUI.ConfigObject.OAuth2RedirectUrl.set -> void
 Swashbuckle.AspNetCore.SwaggerUI.ConfigObject.PersistAuthorization.get -> bool
 Swashbuckle.AspNetCore.SwaggerUI.ConfigObject.PersistAuthorization.set -> void
+Swashbuckle.AspNetCore.SwaggerUI.ConfigObject.Plugins.get -> System.Collections.Generic.IList<string>
+Swashbuckle.AspNetCore.SwaggerUI.ConfigObject.Plugins.set -> void
 Swashbuckle.AspNetCore.SwaggerUI.ConfigObject.ShowCommonExtensions.get -> bool
 Swashbuckle.AspNetCore.SwaggerUI.ConfigObject.ShowCommonExtensions.set -> void
 Swashbuckle.AspNetCore.SwaggerUI.ConfigObject.ShowExtensions.get -> bool

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,2 +1,0 @@
-Swashbuckle.AspNetCore.SwaggerUI.ConfigObject.Plugins.get -> System.Collections.Generic.IList<string>
-Swashbuckle.AspNetCore.SwaggerUI.ConfigObject.Plugins.set -> void


### PR DESCRIPTION
- Add overload to `OpenApiAnyFactory.CreateFromJson()` that supports passing in a `JsonSerializerOptions` as a workaround for #3217 (see https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3217#issuecomment-2585784829).
- Use concrete types as suggested by analyzers.
- Move unshipped APIs to shipped.
- Bump version to 7.3.0.

Tested it unblocks #3217 manually.
