### PR TITLE
Fix #3184 - fix JWT version for .NET 9

### DIFF
--- a/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
+++ b/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="8.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="9.0.1" />
     <PackageReference Include="Duende.IdentityServer" VersionOverride="7.0.8" />
   </ItemGroup>
 

--- a/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
+++ b/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
@@ -13,17 +13,17 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="6.0.36" />
-    <PackageReference Include="Duende.IdentityServer" VersionOverride="6.0.5" />
+    <PackageReference Include="Duende.IdentityServer" VersionOverride="6.3.10" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="8.0.12" />
-    <PackageReference Include="Duende.IdentityServer" VersionOverride="7.0.8" />
+    <PackageReference Include="Duende.IdentityServer" VersionOverride="7.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="9.0.1" />
-    <PackageReference Include="Duende.IdentityServer" VersionOverride="7.0.8" />
+    <PackageReference Include="Duende.IdentityServer" VersionOverride="7.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Fix typo from #3184 for .NET 9
- Update `Duende.IdentityServer` versions