### PR TITLE
Humanize multiline para tag

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
@@ -106,12 +106,16 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private static string HumanizeParaTags(this string text)
         {
-            return ParaTag().Replace(text, (match) => "<br>" + match.Groups["display"].Value);
+            return ParaTag().Replace(text, match =>
+            {
+                var paraText = "<br>" + match.Groups["display"].Value.TrimStart();
+                return LineBreaks().Replace(paraText, _ => string.Empty);
+            }).Replace("\r\n<br>", "<br>");
         }
 
         private static string HumanizeBrTags(this string text)
         {
-            return BrTag().Replace(text, m => Environment.NewLine);
+            return BrTag().Replace(text, _ => Environment.NewLine);
         }
 
         private static string DecodeXml(this string text)
@@ -125,6 +129,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private const string ParaTagPattern = @"<para>(?<display>.+?)</para>";
         private const string HrefPattern = @"<see href=\""(.*)\"">(.*)<\/see>";
         private const string BrPattern = @"(<br ?\/?>)"; // handles <br>, <br/>, <br />
+        private const string LineBreaksPattern = @"\r\n?|\n";
 
 #if NET7_0_OR_GREATER
         [GeneratedRegex(RefTagPattern)]
@@ -144,6 +149,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         [GeneratedRegex(BrPattern)]
         private static partial Regex BrTag();
+
+        [GeneratedRegex(LineBreaksPattern)]
+        private static partial Regex LineBreaks();
 #else
         private static readonly Regex _refTag = new(RefTagPattern);
         private static readonly Regex _codeTag = new(CodeTagPattern);
@@ -151,6 +159,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private static readonly Regex _paraTag = new(ParaTagPattern, RegexOptions.Singleline);
         private static readonly Regex _hrefTag = new(HrefPattern);
         private static readonly Regex _brTag = new(BrPattern);
+        private static readonly Regex _lineBreaks = new(LineBreaksPattern);
 
         private static Regex RefTag() => _refTag;
         private static Regex CodeTag() => _codeTag;
@@ -158,6 +167,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private static Regex ParaTag() => _paraTag;
         private static Regex HrefTag() => _hrefTag;
         private static Regex BrTag() => _brTag;
+        private static Regex LineBreaks() => _lineBreaks;
 #endif
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
@@ -108,9 +108,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
             return ParaTag().Replace(text, match =>
             {
-                var paraText = "<br>" + match.Groups["display"].Value.TrimStart();
+                var paraText = "<br>" + match.Groups["display"].Value.Trim();
                 return LineBreaks().Replace(paraText, _ => string.Empty);
-            }).Replace("\r\n<br>", "<br>");
+            });
         }
 
         private static string HumanizeBrTags(this string text)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
@@ -129,7 +129,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         private const string ParaTagPattern = @"<para>(?<display>.+?)</para>";
         private const string HrefPattern = @"<see href=\""(.*)\"">(.*)<\/see>";
         private const string BrPattern = @"(<br ?\/?>)"; // handles <br>, <br/>, <br />
-        private const string LineBreaksPattern = @"\r\n?|\n";
+        private const string LineBreaksPattern = @"\r?\n";
 
 #if NET7_0_OR_GREATER
         [GeneratedRegex(RefTagPattern)]

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_DotNet6_startupType=Basic.Startup_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_DotNet6_startupType=Basic.Startup_swaggerRequestUri=v1.verified.txt
@@ -174,6 +174,7 @@
           "CrudActions"
         ],
         "summary": "Updates some properties of a specific product",
+        "description": "\r\nOnly provided properties will be updated,                    other remain unchanged.\r\n\r\nIdentifier must be non-default value\r\n\r\nBody must be specified",
         "operationId": "PatchProduct",
         "parameters": [
           {

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.verified.txt
@@ -174,6 +174,7 @@
           "CrudActions"
         ],
         "summary": "Updates some properties of a specific product",
+        "description": "\r\nOnly provided properties will be updated,                    other remain unchanged.\r\n\r\nIdentifier must be non-default value\r\n\r\nBody must be specified",
         "operationId": "PatchProduct",
         "parameters": [
           {

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.cs
@@ -36,7 +36,9 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
 
             using var swaggerResponse = await client.GetAsync(swaggerRequestUri);
             var swagger = await swaggerResponse.Content.ReadAsStringAsync();
-            await Verifier.Verify(swagger).UseParameters(startupType, GetVersion(swaggerRequestUri));
+            await Verifier.Verify(swagger)
+                .UseParameters(startupType, GetVersion(swaggerRequestUri))
+                .ScrubLinesWithReplace(x => x.ReplaceLineEndings());
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.cs
@@ -36,9 +36,9 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
 
             using var swaggerResponse = await client.GetAsync(swaggerRequestUri);
             var swagger = await swaggerResponse.Content.ReadAsStringAsync();
-            await Verifier.Verify(swagger.ReplaceLineEndings())
+            await Verifier.Verify(swagger)
                 .UseParameters(startupType, GetVersion(swaggerRequestUri))
-                .ScrubLinesWithReplace(x => x.ReplaceLineEndings());
+                .ScrubLinesWithReplace(x => x.ReplaceLineEndings("\r\n"));
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.cs
@@ -118,7 +118,7 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
         /// </summary>
         private static string NormalizeLineBreaks(string swagger)
         {
-            return WindowsNewLineRegex().Replace(swagger, "\\r\\n");
+            return UnixNewLineRegex().Replace(swagger, "\\r\\n");
         }
 
         private static string GetVersion(string swaggerUi) =>
@@ -131,7 +131,7 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
         private static partial Regex VersionRegex();
 
         [GeneratedRegex(@"(?<!\\r)\\n")]
-        private static partial Regex WindowsNewLineRegex();
+        private static partial Regex UnixNewLineRegex();
 #endif
     }
 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.cs
@@ -129,9 +129,9 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
 
         [GeneratedRegex("/\\w+/([\\w+\\d+.-]+)/")]
         private static partial Regex VersionRegex();
+#endif
 
         [GeneratedRegex(@"(?<!\\r)\\n")]
         private static partial Regex UnixNewLineRegex();
-#endif
     }
 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Net.Http;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using VerifyXunit;
@@ -115,22 +114,11 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
         }
 
         /// <summary>
-        /// Normalize '\n' strings into '\r\n' which is expected linebreak in Verify verified.txt files.
+        /// Normalize "\n" strings into "\r\n" which is expected linebreak in Verify verified.txt files.
         /// </summary>
-        private static StringBuilder NormalizeLineBreaks(string swagger)
+        private static string NormalizeLineBreaks(string swagger)
         {
-            var output = new StringBuilder(swagger.Length);
-            for (var i = 0; i < swagger.Length; i++)
-            {
-                if (swagger[i] == '\\' && i > 0 && i < swagger.Length - 1 && swagger[i+1] == 'n' && swagger[i - 1] != 'r')
-                {
-                    output.Append("\\r");
-                }
-
-                output.Append(swagger[i]);
-            }
-
-            return output;
+            return WindowsNewLineRegex().Replace(swagger, "\\r\\n");
         }
 
         private static string GetVersion(string swaggerUi) =>
@@ -141,6 +129,9 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
 
         [GeneratedRegex("/\\w+/([\\w+\\d+.-]+)/")]
         private static partial Regex VersionRegex();
+
+        [GeneratedRegex(@"(?<!\\r)\\n")]
+        private static partial Regex WindowsNewLineRegex();
 #endif
     }
 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.cs
@@ -36,7 +36,7 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
 
             using var swaggerResponse = await client.GetAsync(swaggerRequestUri);
             var swagger = await swaggerResponse.Content.ReadAsStringAsync();
-            await Verifier.Verify(swagger)
+            await Verifier.Verify(swagger.ReplaceLineEndings())
                 .UseParameters(startupType, GetVersion(swaggerRequestUri))
                 .ScrubLinesWithReplace(x => x.ReplaceLineEndings());
         }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
@@ -134,6 +134,7 @@ A line of text",
         [InlineData(@"Returns a <see langword=""null""/> item.", "Returns a null item.")]
         [InlineData(@"<see href=""https://www.iso.org/iso-4217-currency-codes.html"">ISO currency code</see>", "[ISO currency code](https://www.iso.org/iso-4217-currency-codes.html)")]
         [InlineData("First line.<br />Second line.<br/>Third line.<br>Fourth line.", "First line.\r\nSecond line.\r\nThird line.\r\nFourth line.")]
+        [InlineData("<para> one </para><para> two </para>","\r\none\r\ntwo")]
         public void Humanize_HumanizesInlineTags(
             string input,
             string expectedOutput)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
@@ -141,5 +141,21 @@ A line of text",
 
             Assert.Equal(expectedOutput, output, false, true);
         }
+
+        [Fact]
+        public void Humanize_ParaMultiLineTags()
+        {
+            const string input = @"
+            <para>
+             This is a paragraph.
+             MultiLined.
+            </para>
+            <para>         This is a paragraph</para>.";
+
+            var output = XmlCommentsTextHelper.Humanize(input);
+
+            const string expectedOutput = "\r\nThis is a paragraph. MultiLined.\r\nThis is a paragraph.";
+            Assert.Equal(expectedOutput, output, false, true);
+        }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
@@ -129,7 +129,7 @@ A line of text",
         [InlineData("<c>DoWork</c> is a method in <c>TestClass</c>.", "`DoWork` is a method in `TestClass`.")]
         [InlineData("<code>DoWork</code> is a method in <code>\nTestClass\n</code>.", "```DoWork``` is a method in ```\nTestClass\n```.")]
         [InlineData("<para>This is a paragraph</para>.", "\r\nThis is a paragraph.")]
-        [InlineData("<para>   This is a paragraph   </para>.", "\r\nThis is a paragraph   .")]
+        [InlineData("<para>   This is a paragraph   </para>.", "\r\nThis is a paragraph.")]
         [InlineData("GET /Todo?iscomplete=true&amp;owner=mike", "GET /Todo?iscomplete=true&owner=mike")]
         [InlineData(@"Returns a <see langword=""null""/> item.", "Returns a null item.")]
         [InlineData(@"<see href=""https://www.iso.org/iso-4217-currency-codes.html"">ISO currency code</see>", "[ISO currency code](https://www.iso.org/iso-4217-currency-codes.html)")]
@@ -151,7 +151,7 @@ A line of text",
              This is a paragraph.
              MultiLined.
             </para>
-            <para>         This is a paragraph</para>.";
+            <para>         This is a paragraph     </para>.";
 
             var output = XmlCommentsTextHelper.Humanize(input);
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
@@ -129,6 +129,7 @@ A line of text",
         [InlineData("<c>DoWork</c> is a method in <c>TestClass</c>.", "`DoWork` is a method in `TestClass`.")]
         [InlineData("<code>DoWork</code> is a method in <code>\nTestClass\n</code>.", "```DoWork``` is a method in ```\nTestClass\n```.")]
         [InlineData("<para>This is a paragraph</para>.", "\r\nThis is a paragraph.")]
+        [InlineData("<para>   This is a paragraph   </para>.", "\r\nThis is a paragraph   .")]
         [InlineData("GET /Todo?iscomplete=true&amp;owner=mike", "GET /Todo?iscomplete=true&owner=mike")]
         [InlineData(@"Returns a <see langword=""null""/> item.", "Returns a null item.")]
         [InlineData(@"<see href=""https://www.iso.org/iso-4217-currency-codes.html"">ISO currency code</see>", "[ISO currency code](https://www.iso.org/iso-4217-currency-codes.html)")]
@@ -154,8 +155,7 @@ A line of text",
 
             var output = XmlCommentsTextHelper.Humanize(input);
 
-            const string expectedOutput = "\r\nThis is a paragraph. MultiLined.\r\nThis is a paragraph.";
-            Assert.Equal(expectedOutput, output, false, true);
+            Assert.Equal("\r\nThis is a paragraph. MultiLined.\r\nThis is a paragraph.", output, false, true);
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
@@ -155,7 +155,7 @@ A line of text",
 
             var output = XmlCommentsTextHelper.Humanize(input);
 
-            Assert.Equal("\r\nThis is a paragraph. MultiLined.\r\nThis is a paragraph.", output, false, true);
+            Assert.Equal("\r\nThis is a paragraph. MultiLined.\r\n\r\nThis is a paragraph.", output, false, true);
         }
     }
 }

--- a/test/WebSites/Basic/Controllers/CrudActionsController.cs
+++ b/test/WebSites/Basic/Controllers/CrudActionsController.cs
@@ -16,13 +16,13 @@ namespace Basic.Controllers
         /// </summary>
         /// <remarks>
         /// ## Heading 1
-        ///
+        /// 
         ///     POST /products
         ///     {
         ///         "id": "123",
         ///         "description": "Some product"
         ///     }
-        ///
+        /// 
         /// </remarks>
         /// <param name="product"></param>
         /// <returns></returns>

--- a/test/WebSites/Basic/Controllers/CrudActionsController.cs
+++ b/test/WebSites/Basic/Controllers/CrudActionsController.cs
@@ -76,7 +76,8 @@ namespace Basic.Controllers
         ///         Only provided properties will be updated (case-sensitive),
         ///         other remain unchanged.
         ///     </para>
-        ///     <para>       Identifier must be non-default value</para>
+        ///     <para>       Identifier must be non-default value     </para>
+        ///     <para>Body must be specified</para>
         /// </remarks>
         /// <param name="id" example="333"></param>
         /// <param name="updates"></param>

--- a/test/WebSites/Basic/Controllers/CrudActionsController.cs
+++ b/test/WebSites/Basic/Controllers/CrudActionsController.cs
@@ -16,13 +16,13 @@ namespace Basic.Controllers
         /// </summary>
         /// <remarks>
         /// ## Heading 1
-        /// 
+        ///
         ///     POST /products
         ///     {
         ///         "id": "123",
         ///         "description": "Some product"
         ///     }
-        /// 
+        ///
         /// </remarks>
         /// <param name="product"></param>
         /// <returns></returns>
@@ -71,6 +71,13 @@ namespace Basic.Controllers
         /// <summary>
         /// Updates some properties of a specific product
         /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         Only provided properties will be updated (case-sensitive),
+        ///         other remain unchanged.
+        ///     </para>
+        ///     <para>       Identifier must be non-default value</para>
+        /// </remarks>
         /// <param name="id" example="333"></param>
         /// <param name="updates"></param>
         [HttpPatch("{id}", Name = "PatchProduct")]

--- a/test/WebSites/Basic/Controllers/CrudActionsController.cs
+++ b/test/WebSites/Basic/Controllers/CrudActionsController.cs
@@ -73,7 +73,7 @@ namespace Basic.Controllers
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///         Only provided properties will be updated (case-sensitive),
+        ///         Only provided properties will be updated,
         ///         other remain unchanged.
         ///     </para>
         ///     <para>       Identifier must be non-default value     </para>


### PR DESCRIPTION
## The issue or feature being addressed

Fixes #3009

## Details on the issue fix or feature implementation

Swagger.ui (or Redoc, I'm not sure) are displaying `\r\n   ` as `<pre>` tag.

PR changes making sure that <para> text is **trimmed** and all line breaks are ignored
