### PR TITLE
Humanize multi line code tag

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
@@ -101,7 +101,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private static string HumanizeMultilineCodeTags(this string text)
         {
-            return MultilineCodeTag().Replace(text, (match) => "```" + match.Groups["display"].Value + "```");
+            return MultilineCodeTag().Replace(text, match =>
+            {
+                var codeText = match.Groups["display"].Value;
+                if (LineBreaks().IsMatch(codeText))
+                    return $"```{codeText.TrimEnd()}{Environment.NewLine}```";
+
+                return $"```{codeText}```";
+            });
         }
 
         private static string HumanizeParaTags(this string text)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
@@ -104,10 +104,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             return MultilineCodeTag().Replace(text, match =>
             {
                 var codeText = match.Groups["display"].Value;
-                if (LineBreaks().IsMatch(codeText))
-                    return $"```{codeText.TrimEnd()}{Environment.NewLine}```";
-
-                return $"```{codeText}```";
+                return LineBreaks().IsMatch(codeText)
+                    ? $"```{codeText.TrimEnd()}{Environment.NewLine}```"
+                    : $"```{codeText}```";
             });
         }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Net;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
@@ -10,7 +11,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         public static string Humanize(string text)
         {
             if (text == null)
-                throw new ArgumentNullException("text");
+                throw new ArgumentNullException(nameof(text));
 
             //Call DecodeXml at last to avoid entities like &lt and &gt to break valid xml
 
@@ -106,12 +107,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 var codeText = match.Groups["display"].Value;
                 if (LineBreaks().IsMatch(codeText))
                 {
-                    if (codeText.StartsWith("\r") || codeText.StartsWith("\n"))
+                    var builder = new StringBuilder().Append("```");
+                    if (!codeText.StartsWith("\r") && !codeText.StartsWith("\n"))
                     {
-                        return $"```{codeText.TrimEnd()}{Environment.NewLine}```";
+                        builder.AppendLine();
                     }
 
-                    return $"```{Environment.NewLine}{codeText.TrimEnd()}{Environment.NewLine}```";
+                    return builder.AppendLine(codeText.TrimEnd())
+                        .Append("```")
+                        .ToString();
                 }
 
                 return $"```{codeText}```";

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
@@ -104,9 +104,17 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             return MultilineCodeTag().Replace(text, match =>
             {
                 var codeText = match.Groups["display"].Value;
-                return LineBreaks().IsMatch(codeText)
-                    ? $"```{codeText.TrimEnd()}{Environment.NewLine}```"
-                    : $"```{codeText}```";
+                if (LineBreaks().IsMatch(codeText))
+                {
+                    if (codeText.StartsWith("\r") || codeText.StartsWith("\n"))
+                    {
+                        return $"```{codeText.TrimEnd()}{Environment.NewLine}```";
+                    }
+
+                    return $"```{Environment.NewLine}{codeText.TrimEnd()}{Environment.NewLine}```";
+                }
+
+                return $"```{codeText}```";
             });
         }
 

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_DotNet6_startupType=Basic.Startup_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_DotNet6_startupType=Basic.Startup_swaggerRequestUri=v1.verified.txt
@@ -87,6 +87,31 @@
         "x-purpose": "test"
       }
     },
+    "/products/all": {
+      "get": {
+        "tags": [
+          "CrudActions"
+        ],
+        "summary": "Get all products",
+        "description": "```\r\n            {\r\n              \"Id\":1,\r\n              \"Description\":\"\",\r\n              \"Status\": 0,\r\n              \"Status2\": 1\r\n            }\r\n```",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Product"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-purpose": "test"
+      }
+    },
     "/products/{id}": {
       "get": {
         "tags": [

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.verified.txt
@@ -87,6 +87,31 @@
         "x-purpose": "test"
       }
     },
+    "/products/all": {
+      "get": {
+        "tags": [
+          "CrudActions"
+        ],
+        "summary": "Get all products",
+        "description": "```\r\n            {\r\n              \"Id\":1,\r\n              \"Description\":\"\",\r\n              \"Status\": 0,\r\n              \"Status2\": 1\r\n            }\r\n```",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Product"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-purpose": "test"
+      }
+    },
     "/products/{id}": {
       "get": {
         "tags": [

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
@@ -172,7 +172,16 @@ A line of text",
 
             var output = XmlCommentsTextHelper.Humanize(input);
 
-            Assert.Equal("```\r\n   {\r\n    \"Prop1\":1,\r\n    \"Prop2\":[]\r\n   }\r\n```", output, false, true);
+            var expected = string.Join("\r\n",
+            [
+                "```",
+                "   {",
+                "    \"Prop1\":1,",
+                "    \"Prop2\":[]",
+                "   }",
+                "```"
+            ]);
+            Assert.Equal(expected, output, false, true);
         }
 
         [Fact]
@@ -187,7 +196,16 @@ A line of text",
 
             var output = XmlCommentsTextHelper.Humanize(input);
 
-            Assert.Equal("```\r\n{\r\n    \"Prop1\":1,\r\n    \"Prop2\":[]\r\n   }\r\n```", output, false, true);
+            var expected = string.Join("\r\n",
+            [
+                "```",
+                "{",
+                "    \"Prop1\":1,",
+                "    \"Prop2\":[]",
+                "   }",
+                "```"
+            ]);
+            Assert.Equal(expected, output, false, true);
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
@@ -158,5 +158,21 @@ A line of text",
 
             Assert.Equal("\r\nThis is a paragraph. MultiLined.\r\n\r\nThis is a paragraph.", output, false, true);
         }
+
+        [Fact]
+        public void Humanize_CodeMultiLineTag()
+        {
+            const string input = @"
+            <code>
+               {
+                ""Prop1"":1,
+                ""Prop2"":[]
+               }
+            </code>";
+
+            var output = XmlCommentsTextHelper.Humanize(input);
+
+            Assert.Equal("```\r\n   {\r\n    \"Prop1\":1,\r\n    \"Prop2\":[]\r\n   }\r\n```", output, false, true);
+        }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
@@ -174,5 +174,20 @@ A line of text",
 
             Assert.Equal("```\r\n   {\r\n    \"Prop1\":1,\r\n    \"Prop2\":[]\r\n   }\r\n```", output, false, true);
         }
+
+        [Fact]
+        public void Humanize_CodeMultiLineTag_OnSameLine()
+        {
+            const string input = @"
+            <code>{
+                ""Prop1"":1,
+                ""Prop2"":[]
+               }
+            </code>";
+
+            var output = XmlCommentsTextHelper.Humanize(input);
+
+            Assert.Equal("```\r\n{\r\n    \"Prop1\":1,\r\n    \"Prop2\":[]\r\n   }\r\n```", output, false, true);
+        }
     }
 }

--- a/test/WebSites/Basic/Controllers/CrudActionsController.cs
+++ b/test/WebSites/Basic/Controllers/CrudActionsController.cs
@@ -32,13 +32,14 @@ namespace Basic.Controllers
             return product;
         }
 
-        //TODO: consider removing this endpoint before opening PR
         /// <summary>Get all products</summary>
         /// <remarks>
         /// <code>
         /// {
-        ///        "Prop1":1,
-        ///        "Prop2":[]
+        ///   "Id":1,
+        ///   "Description":"",
+        ///   "Status": 0,
+        ///   "Status2": 1
         /// }
         /// </code>
         /// </remarks>

--- a/test/WebSites/Basic/Controllers/CrudActionsController.cs
+++ b/test/WebSites/Basic/Controllers/CrudActionsController.cs
@@ -16,13 +16,13 @@ namespace Basic.Controllers
         /// </summary>
         /// <remarks>
         /// ## Heading 1
-        ///
+        /// 
         ///     POST /products
         ///     {
         ///         "id": "123",
         ///         "description": "Some product"
         ///     }
-        ///
+        /// 
         /// </remarks>
         /// <param name="product"></param>
         /// <returns></returns>

--- a/test/WebSites/Basic/Controllers/CrudActionsController.cs
+++ b/test/WebSites/Basic/Controllers/CrudActionsController.cs
@@ -16,13 +16,13 @@ namespace Basic.Controllers
         /// </summary>
         /// <remarks>
         /// ## Heading 1
-        /// 
+        ///
         ///     POST /products
         ///     {
         ///         "id": "123",
         ///         "description": "Some product"
         ///     }
-        /// 
+        ///
         /// </remarks>
         /// <param name="product"></param>
         /// <returns></returns>
@@ -30,6 +30,22 @@ namespace Basic.Controllers
         public Product Create([FromBody, Required]Product product)
         {
             return product;
+        }
+
+        //TODO: consider removing this endpoint before opening PR
+        /// <summary>Get all products</summary>
+        /// <remarks>
+        /// <code>
+        /// {
+        ///        "Prop1":1,
+        ///        "Prop2":[]
+        /// }
+        /// </code>
+        /// </remarks>
+        [HttpGet("all")]
+        public List<Product> GetAll()
+        {
+            return [];
         }
 
         /// <summary>


### PR DESCRIPTION
## The issue or feature being addressed

Resolves #3069

## Details on the issue fix or feature implementation

for some reason swagger ui `<pre><code>` is cutting first line from code block

```
<code>this content is cutted
{
   "Id": 1
}
</code>
```

here's how `GetAll` looks like

![image](https://github.com/user-attachments/assets/7e8ffba9-0b1a-4540-b4e7-45ba3b06a2e1)
