### PR TITLE
Fix JsonSerializerDataContractResolver so that it handles square arrays correctly

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
@@ -142,6 +142,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             }
 #endif
 
+            if (type.IsArray)
+            {
+                itemType = type.GetElementType();
+                return true;
+            }
+
             if (typeof(IEnumerable).IsAssignableFrom(type))
             {
                 itemType = typeof(object);

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -579,6 +579,18 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         }
 
         [Fact]
+        public void GenerateSchema_HandlesSquareArray()
+        {
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = Subject().GenerateSchema(typeof(string[,]), schemaRepository);
+
+            Assert.NotNull(referenceSchema.Items);
+            Assert.NotNull(referenceSchema.Items.Type);
+            Assert.Equal("string", referenceSchema.Items.Type);
+        }
+
+        [Fact]
         public void GenerateSchema_HandlesTypesWithOverriddenProperties()
         {
             var schemaRepository = new SchemaRepository();

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -1065,6 +1065,18 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Fact]
+        public void GenerateSchema_HandlesSquareArray()
+        {
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = Subject().GenerateSchema(typeof(string[,]), schemaRepository);
+
+            Assert.NotNull(referenceSchema.Items);
+            Assert.NotNull(referenceSchema.Items.Type);
+            Assert.Equal("string", referenceSchema.Items.Type);
+        }
+
+        [Fact]
         public void GenerateSchema_HandlesRecursion_IfCalledAgainWithinAFilter()
         {
             var subject = Subject(


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

Fix JsonSerializerDataContractResolver so that it handles square arrays correctly
Fixes #3244 
