### PR TITLE
Upgrade to Microsoft.OpenApi v2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,14 +21,14 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.32" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="1.6.22" />
-    <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.22" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.0.0-preview5" />
+    <PackageVersion Include="Microsoft.OpenApi.Readers" Version="2.0.0-preview5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.2.0" />
     <PackageVersion Include="ReportGenerator" Version="5.4.1" />
-    <PackageVersion Include="System.Text.Json" Version="4.6.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="Verify.Xunit" Version="28.3.2" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.core" Version="2.9.2" />

--- a/perf/Swashbuckle.AspNetCore.Benchmarks/XmlCommentsBenchmark.cs
+++ b/perf/Swashbuckle.AspNetCore.Benchmarks/XmlCommentsBenchmark.cs
@@ -101,7 +101,7 @@ public class XmlCommentsBenchmark
         {
             Schema = new()
             {
-                Type = "string",
+                Type = JsonSchemaType.String,
                 Description = "schema-level description",
             },
         };
@@ -120,7 +120,7 @@ public class XmlCommentsBenchmark
                 {
                     Schema = new()
                     {
-                        Type = "string",
+                        Type = JsonSchemaType.String,
                     },
                 },
             },

--- a/src/Swashbuckle.AspNetCore.Annotations/AnnotationsOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Annotations/AnnotationsOperationFilter.cs
@@ -63,12 +63,13 @@ namespace Swashbuckle.AspNetCore.Annotations
             if (swaggerOperationAttribute.OperationId != null)
                 operation.OperationId = swaggerOperationAttribute.OperationId;
 
-            if (swaggerOperationAttribute.Tags != null)
-            {
-                operation.Tags = swaggerOperationAttribute.Tags
-                    .Select(tagName => new OpenApiTag { Name = tagName })
-                    .ToList();
-            }
+            // TODO Fix this
+            ////if (swaggerOperationAttribute.Tags != null)
+            ////{
+            ////    operation.Tags = swaggerOperationAttribute.Tags
+            ////        .Select(tagName => new OpenApiTag { Name = tagName })
+            ////        .ToList();
+            ////}
         }
 
         public static void ApplySwaggerOperationFilterAttributes(

--- a/src/Swashbuckle.AspNetCore.Annotations/AnnotationsOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Annotations/AnnotationsOperationFilter.cs
@@ -10,9 +10,9 @@ namespace Swashbuckle.AspNetCore.Annotations
     {
         public void Apply(OpenApiOperation operation, OperationFilterContext context)
         {
-            IEnumerable<object> controllerAttributes = Array.Empty<object>();
-            IEnumerable<object> actionAttributes = Array.Empty<object>();
-            IEnumerable<object> metadataAttributes = Array.Empty<object>();
+            IEnumerable<object> controllerAttributes = [];
+            IEnumerable<object> actionAttributes = [];
+            IEnumerable<object> metadataAttributes = [];
 
             if (context.MethodInfo != null)
             {
@@ -86,7 +86,7 @@ namespace Swashbuckle.AspNetCore.Annotations
             }
         }
 
-        private void ApplySwaggerResponseAttributes(
+        private static void ApplySwaggerResponseAttributes(
             OpenApiOperation operation,
             OperationFilterContext context,
             IEnumerable<object> controllerAndActionAttributes)
@@ -97,10 +97,7 @@ namespace Swashbuckle.AspNetCore.Annotations
             {
                 var statusCode = swaggerResponseAttribute.StatusCode.ToString();
 
-                if (operation.Responses == null)
-                {
-                    operation.Responses = new OpenApiResponses();
-                }
+                operation.Responses ??= [];
 
                 if (!operation.Responses.TryGetValue(statusCode, out OpenApiResponse response))
                 {

--- a/src/Swashbuckle.AspNetCore.ApiTesting/ApiTestRunnerBase.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/ApiTestRunnerBase.cs
@@ -3,12 +3,20 @@ using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Reader;
+using Microsoft.OpenApi.Readers;
 using Microsoft.OpenApi.Writers;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
     public abstract class ApiTestRunnerBase : IDisposable
     {
+        static ApiTestRunnerBase()
+        {
+            // TODO Make an assembly fixture
+            OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
+        }
+
         private readonly ApiTestRunnerOptions _options;
         private readonly RequestValidator _requestValidator;
         private readonly ResponseValidator _responseValidator;

--- a/src/Swashbuckle.AspNetCore.ApiTesting/ApiTestRunnerOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/ApiTestRunnerOptionsExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Readers;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
@@ -10,9 +9,12 @@ namespace Swashbuckle.AspNetCore.ApiTesting
         public static void AddOpenApiFile(this ApiTestRunnerOptions options, string documentName, string filePath)
         {
             using var fileStream = File.OpenRead(filePath);
+            using var memoryStream = new MemoryStream();
 
-            var openApiDocument = new OpenApiStreamReader().Read(fileStream, out var diagnostic);
-            options.OpenApiDocs.Add(documentName, openApiDocument);
+            fileStream.CopyTo(memoryStream);
+
+            var result = OpenApiDocument.Load(memoryStream);
+            options.OpenApiDocs.Add(documentName, result.Document);
         }
 
         public static OpenApiDocument GetOpenApiDocument(this ApiTestRunnerOptions options, string documentName)

--- a/src/Swashbuckle.AspNetCore.ApiTesting/ApiTestRunnerOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/ApiTestRunnerOptionsExtensions.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Readers;
-using System;
+﻿using System;
 using System.IO;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
@@ -9,17 +9,18 @@ namespace Swashbuckle.AspNetCore.ApiTesting
     {
         public static void AddOpenApiFile(this ApiTestRunnerOptions options, string documentName, string filePath)
         {
-            using (var fileStream = File.OpenRead(filePath))
-            {
-                var openApiDocument = new OpenApiStreamReader().Read(fileStream, out OpenApiDiagnostic diagnostic);
-                options.OpenApiDocs.Add(documentName, openApiDocument);
-            }
+            using var fileStream = File.OpenRead(filePath);
+
+            var openApiDocument = new OpenApiStreamReader().Read(fileStream, out var diagnostic);
+            options.OpenApiDocs.Add(documentName, openApiDocument);
         }
 
         public static OpenApiDocument GetOpenApiDocument(this ApiTestRunnerOptions options, string documentName)
         {
             if (!options.OpenApiDocs.TryGetValue(documentName, out OpenApiDocument document))
+            {
                 throw new InvalidOperationException($"Document with name '{documentName}' not found");
+            }
 
             return document;
         }

--- a/src/Swashbuckle.AspNetCore.ApiTesting/ApiTestRunnerOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/ApiTestRunnerOptionsExtensions.cs
@@ -12,6 +12,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting
             using var memoryStream = new MemoryStream();
 
             fileStream.CopyTo(memoryStream);
+            memoryStream.Seek(0, SeekOrigin.Begin);
 
             var result = OpenApiDocument.Load(memoryStream);
             options.OpenApiDocs.Add(documentName, result.Document);

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonContentValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonContentValidator.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
-    public class JsonContentValidator : IContentValidator
+    public sealed class JsonContentValidator : IContentValidator
     {
         private readonly JsonValidator _jsonValidator = new();
 

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonContentValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonContentValidator.cs
@@ -8,25 +8,22 @@ namespace Swashbuckle.AspNetCore.ApiTesting
 {
     public class JsonContentValidator : IContentValidator
     {
-        private readonly JsonValidator _jsonValidator;
+        private readonly JsonValidator _jsonValidator = new();
 
-        public JsonContentValidator()
-        {
-            _jsonValidator = new JsonValidator();
-        }
-
-        public bool CanValidate(string mediaType)
-        {
-            return mediaType.Contains("json");
-        }
+        public bool CanValidate(string mediaType) => mediaType.Contains("json");
 
         public void Validate(OpenApiMediaType mediaTypeSpec, OpenApiDocument openApiDocument, HttpContent content)
         {
-            if (mediaTypeSpec?.Schema == null) return;
+            if (mediaTypeSpec?.Schema == null)
+            {
+                return;
+            }
 
             var instance = JToken.Parse(content.ReadAsStringAsync().Result);
             if (!_jsonValidator.Validate(mediaTypeSpec.Schema, openApiDocument, instance, out IEnumerable<string> errorMessages))
+            {
                 throw new ContentDoesNotMatchSpecException(string.Join(Environment.NewLine, errorMessages));
+            }
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonAllOfValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonAllOfValidator.cs
@@ -5,14 +5,9 @@ using Newtonsoft.Json.Linq;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
-    public class JsonAllOfValidator : IJsonValidator
+    public class JsonAllOfValidator(JsonValidator jsonValidator) : IJsonValidator
     {
-        private JsonValidator _jsonValidator;
-
-        public JsonAllOfValidator(JsonValidator jsonValidator)
-        {
-            _jsonValidator = jsonValidator;
-        }
+        private JsonValidator _jsonValidator = jsonValidator;
 
         public bool CanValidate(OpenApiSchema schema) => schema.AllOf != null && schema.AllOf.Any();
 
@@ -26,10 +21,12 @@ namespace Swashbuckle.AspNetCore.ApiTesting
 
             var allOfArray = schema.AllOf.ToArray();
 
-            for (int i=0;i<allOfArray.Length;i++)
+            for (int i = 0; i < allOfArray.Length; i++)
             {
                 if (!_jsonValidator.Validate(allOfArray[i], openApiDocument, instance, out IEnumerable<string> subErrorMessages))
+                {
                     errorMessagesList.AddRange(subErrorMessages.Select(msg => $"{msg} (allOf[{i}])"));
+                }
             }
 
             errorMessages = errorMessagesList;

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonAllOfValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonAllOfValidator.cs
@@ -5,9 +5,9 @@ using Newtonsoft.Json.Linq;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
-    public class JsonAllOfValidator(JsonValidator jsonValidator) : IJsonValidator
+    public sealed class JsonAllOfValidator(JsonValidator jsonValidator) : IJsonValidator
     {
-        private JsonValidator _jsonValidator = jsonValidator;
+        private readonly JsonValidator _jsonValidator = jsonValidator;
 
         public bool CanValidate(OpenApiSchema schema) => schema.AllOf != null && schema.AllOf.Any();
 

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonAnyOfValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonAnyOfValidator.cs
@@ -1,18 +1,13 @@
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json.Linq;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
-    public class JsonAnyOfValidator : IJsonValidator
+    public class JsonAnyOfValidator(JsonValidator jsonValidator) : IJsonValidator
     {
-        private JsonValidator _jsonValidator;
-
-        public JsonAnyOfValidator(JsonValidator jsonValidator)
-        {
-            _jsonValidator = jsonValidator;
-        }
+        private JsonValidator _jsonValidator = jsonValidator;
 
         public bool CanValidate(OpenApiSchema schema) => schema.AnyOf != null && schema.AnyOf.Any();
 
@@ -26,11 +21,11 @@ namespace Swashbuckle.AspNetCore.ApiTesting
 
             var anyOfArray = schema.AnyOf.ToArray();
 
-            for (int i=0;i<anyOfArray.Length;i++)
+            for (int i = 0; i < anyOfArray.Length; i++)
             {
                 if (_jsonValidator.Validate(anyOfArray[i], openApiDocument, instance, out IEnumerable<string> subErrorMessages))
                 {
-                    errorMessages = Enumerable.Empty<string>();
+                    errorMessages = [];
                     return true;
                 }
 

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonAnyOfValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonAnyOfValidator.cs
@@ -5,9 +5,9 @@ using Newtonsoft.Json.Linq;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
-    public class JsonAnyOfValidator(JsonValidator jsonValidator) : IJsonValidator
+    public sealed class JsonAnyOfValidator(JsonValidator jsonValidator) : IJsonValidator
     {
-        private JsonValidator _jsonValidator = jsonValidator;
+        private readonly JsonValidator _jsonValidator = jsonValidator;
 
         public bool CanValidate(OpenApiSchema schema) => schema.AnyOf != null && schema.AnyOf.Any();
 

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonArrayValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonArrayValidator.cs
@@ -9,7 +9,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting
     {
         private readonly IJsonValidator _jsonValidator = jsonValidator;
 
-        public bool CanValidate(OpenApiSchema schema) => schema.Type == "array";
+        public bool CanValidate(OpenApiSchema schema) => schema.Type is JsonSchemaType.Array;
 
         public bool Validate(
             OpenApiSchema schema,

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonArrayValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonArrayValidator.cs
@@ -1,19 +1,13 @@
-using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json.Linq;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
-    public class JsonArrayValidator : IJsonValidator
+    public class JsonArrayValidator(IJsonValidator jsonValidator) : IJsonValidator
     {
-        private readonly IJsonValidator _jsonValidator;
-
-        public JsonArrayValidator(IJsonValidator jsonValidator)
-        {
-            _jsonValidator = jsonValidator;
-        }
+        private readonly IJsonValidator _jsonValidator = jsonValidator;
 
         public bool CanValidate(OpenApiSchema schema) => schema.Type == "array";
 
@@ -25,7 +19,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting
         {
             if (instance.Type != JTokenType.Array)
             {
-                errorMessages = new[] { $"Path: {instance.Path}. Instance is not of type 'array'" };
+                errorMessages = [$"Path: {instance.Path}. Instance is not of type 'array'"];
                 return false;
             }
 
@@ -38,21 +32,29 @@ namespace Swashbuckle.AspNetCore.ApiTesting
                 foreach (var itemInstance in arrayInstance)
                 {
                     if (!_jsonValidator.Validate(schema.Items, openApiDocument, itemInstance, out IEnumerable<string> itemErrorMessages))
+                    {
                         errorMessagesList.AddRange(itemErrorMessages);
+                    }
                 }
             }
 
             // maxItems
-            if (schema.MaxItems.HasValue && (arrayInstance.Count() > schema.MaxItems.Value))
+            if (schema.MaxItems.HasValue && (arrayInstance.Count > schema.MaxItems.Value))
+            {
                 errorMessagesList.Add($"Path: {instance.Path}. Array size is greater than maxItems");
+            }
 
             // minItems
-            if (schema.MinItems.HasValue && (arrayInstance.Count() < schema.MinItems.Value))
+            if (schema.MinItems.HasValue && (arrayInstance.Count < schema.MinItems.Value))
+            {
                 errorMessagesList.Add($"Path: {instance.Path}. Array size is less than minItems");
+            }
 
             // uniqueItems
-            if (schema.UniqueItems.HasValue && (arrayInstance.Count() != arrayInstance.Distinct().Count()))
+            if (schema.UniqueItems.HasValue && (arrayInstance.Count != arrayInstance.Distinct().Count()))
+            {
                 errorMessagesList.Add($"Path: {instance.Path}. Array does not contain uniqueItems");
+            }
 
             errorMessages = errorMessagesList;
             return !errorMessages.Any();

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonBooleanValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonBooleanValidator.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json.Linq;
 
@@ -17,11 +16,11 @@ namespace Swashbuckle.AspNetCore.ApiTesting
         {
             if (instance.Type != JTokenType.Boolean)
             {
-                errorMessages = new[] { $"Path: {instance.Path}. Instance is not of type 'boolean'" };
+                errorMessages = [$"Path: {instance.Path}. Instance is not of type 'boolean'"];
                 return false;
             }
 
-            errorMessages = Enumerable.Empty<string>();
+            errorMessages = [];
             return true;
         }
     }

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonBooleanValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonBooleanValidator.cs
@@ -4,9 +4,9 @@ using Newtonsoft.Json.Linq;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
-    public class JsonBooleanValidator : IJsonValidator
+    public sealed class JsonBooleanValidator : IJsonValidator
     {
-        public bool CanValidate(OpenApiSchema schema) => schema.Type == "boolean";
+        public bool CanValidate(OpenApiSchema schema) => schema.Type is JsonSchemaType.Boolean;
 
         public bool Validate(
             OpenApiSchema schema,

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonNullValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonNullValidator.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json.Linq;
 
@@ -17,11 +16,11 @@ namespace Swashbuckle.AspNetCore.ApiTesting
         {
             if (instance.Type != JTokenType.Null)
             {
-                errorMessages = new[] { $"Path: {instance.Path}. Instance is not of type 'null'" };
+                errorMessages = [$"Path: {instance.Path}. Instance is not of type 'null'"];
                 return false;
             }
 
-            errorMessages = Enumerable.Empty<string>();
+            errorMessages = [];
             return true;
         }
     }

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonNullValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonNullValidator.cs
@@ -4,9 +4,9 @@ using Newtonsoft.Json.Linq;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
-    public class JsonNullValidator : IJsonValidator
+    public sealed class JsonNullValidator : IJsonValidator
     {
-        public bool CanValidate(OpenApiSchema schema) => schema.Type == "null";
+        public bool CanValidate(OpenApiSchema schema) => schema.Type is JsonSchemaType.Null;
 
         public bool Validate(
             OpenApiSchema schema,

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonNumberValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonNumberValidator.cs
@@ -1,5 +1,5 @@
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json.Linq;
 
@@ -15,9 +15,9 @@ namespace Swashbuckle.AspNetCore.ApiTesting
             JToken instance,
             out IEnumerable<string> errorMessages)
         {
-            if (!new[] { JTokenType.Float, JTokenType.Integer }.Contains(instance.Type))
+            if (instance.Type is not JTokenType.Float and not JTokenType.Integer)
             {
-                errorMessages = new[] { $"Path: {instance.Path}. Instance is not of type 'number'" };
+                errorMessages = [$"Path: {instance.Path}. Instance is not of type 'number'"];
                 return false;
             }
 
@@ -26,28 +26,38 @@ namespace Swashbuckle.AspNetCore.ApiTesting
 
             // multipleOf
             if (schema.MultipleOf.HasValue && ((numberValue % schema.MultipleOf.Value) != 0))
+            {
                 errorMessagesList.Add($"Path: {instance.Path}. Number is not evenly divisible by multipleOf");
+            }
 
             // maximum & exclusiveMaximum
             if (schema.Maximum.HasValue)
             {
-                var exclusiveMaximum = schema.ExclusiveMaximum.HasValue ? schema.ExclusiveMaximum.Value : false;
+                var exclusiveMaximum = schema.ExclusiveMaximum ?? false;
 
                 if (exclusiveMaximum && (numberValue >= schema.Maximum.Value))
+                {
                     errorMessagesList.Add($"Path: {instance.Path}. Number is greater than, or equal to, maximum");
+                }
                 else if (numberValue > schema.Maximum.Value)
+                {
                     errorMessagesList.Add($"Path: {instance.Path}. Number is greater than maximum");
+                }
             }
 
             // minimum & exclusiveMinimum
             if (schema.Minimum.HasValue)
             {
-                var exclusiveMinimum = schema.ExclusiveMinimum.HasValue ? schema.ExclusiveMinimum.Value : false;
+                var exclusiveMinimum = schema.ExclusiveMinimum ?? false;
 
                 if (exclusiveMinimum && (numberValue <= schema.Minimum.Value))
+                {
                     errorMessagesList.Add($"Path: {instance.Path}. Number is less than, or equal to, minimum");
+                }
                 else if (numberValue < schema.Minimum.Value)
+                {
                     errorMessagesList.Add($"Path: {instance.Path}. Number is less than minimum");
+                }
             }
 
             errorMessages = errorMessagesList;

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonNumberValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonNumberValidator.cs
@@ -5,9 +5,9 @@ using Newtonsoft.Json.Linq;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
-    public class JsonNumberValidator : IJsonValidator
+    public sealed class JsonNumberValidator : IJsonValidator
     {
-        public bool CanValidate(OpenApiSchema schema) => schema.Type == "number";
+        public bool CanValidate(OpenApiSchema schema) => schema.Type is JsonSchemaType.Number;
 
         public bool Validate(
             OpenApiSchema schema,

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonObjectValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonObjectValidator.cs
@@ -5,11 +5,11 @@ using Newtonsoft.Json.Linq;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
-    public class JsonObjectValidator(IJsonValidator jsonValidator) : IJsonValidator
+    public sealed class JsonObjectValidator(IJsonValidator jsonValidator) : IJsonValidator
     {
         private readonly IJsonValidator _jsonValidator = jsonValidator;
 
-        public bool CanValidate(OpenApiSchema schema) => schema.Type == "object";
+        public bool CanValidate(OpenApiSchema schema) => schema.Type is JsonSchemaType.Object;
 
         public bool Validate(
             OpenApiSchema schema,

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonOneOfValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonOneOfValidator.cs
@@ -5,7 +5,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
-    public class JsonOneOfValidator(JsonValidator jsonValidator) : IJsonValidator
+    public sealed class JsonOneOfValidator(JsonValidator jsonValidator) : IJsonValidator
     {
         private readonly JsonValidator _jsonValidator = jsonValidator;
 

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonOneOfValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonOneOfValidator.cs
@@ -1,18 +1,13 @@
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json.Linq;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
-    public class JsonOneOfValidator : IJsonValidator
+    public class JsonOneOfValidator(JsonValidator jsonValidator) : IJsonValidator
     {
-        private JsonValidator _jsonValidator;
-
-        public JsonOneOfValidator(JsonValidator jsonValidator)
-        {
-            _jsonValidator = jsonValidator;
-        }
+        private readonly JsonValidator _jsonValidator = jsonValidator;
 
         public bool CanValidate(OpenApiSchema schema) => schema.OneOf != null && schema.OneOf.Any();
 
@@ -27,12 +22,16 @@ namespace Swashbuckle.AspNetCore.ApiTesting
             var oneOfArray = schema.OneOf.ToArray();
 
             int matched = 0;
-            for (int i=0;i<oneOfArray.Length;i++)
+            for (int i = 0; i < oneOfArray.Length; i++)
             {
                 if (_jsonValidator.Validate(oneOfArray[i], openApiDocument, instance, out IEnumerable<string> subErrorMessages))
+                {
                     matched++;
+                }
                 else
+                {
                     errorMessagesList.AddRange(subErrorMessages.Select(msg => $"{msg} (oneOf[{i}])"));
+                }
             }
 
             if (matched == 0)
@@ -43,11 +42,11 @@ namespace Swashbuckle.AspNetCore.ApiTesting
 
             if (matched > 1)
             {
-                errorMessages = new[] { $"Path: {instance.Path}. Instance matches multiple schemas in oneOf array" };
+                errorMessages = [$"Path: {instance.Path}. Instance matches multiple schemas in oneOf array"];
                 return false;
             }
 
-            errorMessages = Enumerable.Empty<string>();
+            errorMessages = [];
             return true;
         }
     }

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonStringValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonStringValidator.cs
@@ -16,9 +16,9 @@ namespace Swashbuckle.AspNetCore.ApiTesting
             JToken instance,
             out IEnumerable<string> errorMessages)
         {
-            if (!new JTokenType[] { JTokenType.Date, JTokenType.Guid, JTokenType.String }.Contains(instance.Type))
+            if (instance.Type is not JTokenType.Date and not JTokenType.Guid and not JTokenType.String)
             {
-                errorMessages = new[] { $"Path: {instance.Path}. Instance is not of type 'string'" };
+                errorMessages = [$"Path: {instance.Path}. Instance is not of type 'string'"];
                 return false;
             }
 
@@ -27,15 +27,21 @@ namespace Swashbuckle.AspNetCore.ApiTesting
 
             // maxLength
             if (schema.MaxLength.HasValue && (stringValue.Length > schema.MaxLength.Value))
+            {
                 errorMessagesList.Add($"Path: {instance.Path}. String length is greater than maxLength");
+            }
 
             // minLength
             if (schema.MinLength.HasValue && (stringValue.Length < schema.MinLength.Value))
+            {
                 errorMessagesList.Add($"Path: {instance.Path}. String length is less than minLength");
+            }
 
             // pattern
             if ((schema.Pattern != null) && !Regex.IsMatch(stringValue, schema.Pattern))
+            {
                 errorMessagesList.Add($"Path: {instance.Path}. String does not match pattern");
+            }
 
             errorMessages = errorMessagesList;
             return !errorMessages.Any();

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonStringValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonStringValidator.cs
@@ -6,9 +6,9 @@ using Newtonsoft.Json.Linq;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
-    public class JsonStringValidator : IJsonValidator
+    public sealed class JsonStringValidator : IJsonValidator
     {
-        public bool CanValidate(OpenApiSchema schema) => schema.Type == "string";
+        public bool CanValidate(OpenApiSchema schema) => schema.Type is JsonSchemaType.String;
 
         public bool Validate(
             OpenApiSchema schema,

--- a/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/JsonValidation/JsonValidator.cs
@@ -1,5 +1,5 @@
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json.Linq;
 
@@ -11,8 +11,8 @@ namespace Swashbuckle.AspNetCore.ApiTesting
 
         public JsonValidator()
         {
-            _subValidators = new IJsonValidator[]
-            {
+            _subValidators =
+            [
                 new JsonNullValidator(),
                 new JsonBooleanValidator(),
                 new JsonObjectValidator(this),
@@ -22,7 +22,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting
                 new JsonAllOfValidator(this),
                 new JsonAnyOfValidator(this),
                 new JsonOneOfValidator(this),
-            };
+            ];
         }
 
         public bool CanValidate(OpenApiSchema schema) => true;
@@ -33,7 +33,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting
             JToken instance,
             out IEnumerable<string> errorMessages)
         {
-            schema = (schema.Reference != null)
+            schema = schema.Reference != null
                 ? (OpenApiSchema)openApiDocument.ResolveReference(schema.Reference)
                 : schema;
 
@@ -41,10 +41,15 @@ namespace Swashbuckle.AspNetCore.ApiTesting
 
             foreach (var subValidator in _subValidators)
             {
-                if (!subValidator.CanValidate(schema)) continue;
+                if (!subValidator.CanValidate(schema))
+                {
+                    continue;
+                }
 
                 if (!subValidator.Validate(schema, openApiDocument, instance, out IEnumerable<string> subErrorMessages))
+                {
                     errorMessagesList.AddRange(subErrorMessages);
+                }
             }
 
             errorMessages = errorMessagesList;

--- a/src/Swashbuckle.AspNetCore.ApiTesting/OpenApiSchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/OpenApiSchemaExtensions.cs
@@ -5,45 +5,55 @@ using Microsoft.OpenApi.Models;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
-    public static class OpenApiSchemaExtensions
+    internal static class OpenApiSchemaExtensions
     {
         internal static bool TryParse(this OpenApiSchema schema, string stringValue, out object typedValue)
         {
             typedValue = null;
 
-            if (schema.Type == "integer" && schema.Format == "int64" && long.TryParse(stringValue, out long longValue))
-                typedValue = longValue;
-
-            else if (schema.Type == "integer" && int.TryParse(stringValue, out int intValue))
-                typedValue = intValue;
-
-            else if (schema.Type == "number" && schema.Format == "double" && double.TryParse(stringValue, out double doubleValue))
-                typedValue = doubleValue;
-
-            else if (schema.Type == "number" && float.TryParse(stringValue, out float floatValue))
-                typedValue = floatValue;
-
-            else if (schema.Type == "string" && schema.Format == "byte" && byte.TryParse(stringValue, out byte byteValue))
-                typedValue = byteValue;
-
-            else if (schema.Type == "boolean" && bool.TryParse(stringValue, out bool boolValue))
-                typedValue = boolValue;
-
-            else if (schema.Type == "string" && schema.Format == "date" && DateTime.TryParse(stringValue, out DateTime dateValue))
-                typedValue = dateValue;
-
-            else if (schema.Type == "string" && schema.Format == "date-time" && DateTime.TryParse(stringValue, out DateTime dateTimeValue))
-                typedValue = dateTimeValue;
-
-            else if (schema.Type == "string" && schema.Format == "uuid" && Guid.TryParse(stringValue, out Guid uuidValue))
-                typedValue = uuidValue;
-
-            else if (schema.Type == "string")
-                typedValue = stringValue;
-
-            else if (schema.Type == "array")
+            if (schema.Type is JsonSchemaType.Integer && schema.Format == "int64" && long.TryParse(stringValue, out long longValue))
             {
-                var arrayValue = (schema.Items == null)
+                typedValue = longValue;
+            }
+            else if (schema.Type is JsonSchemaType.Integer && int.TryParse(stringValue, out int intValue))
+            {
+                typedValue = intValue;
+            }
+            else if (schema.Type is JsonSchemaType.Number && schema.Format == "double" && double.TryParse(stringValue, out double doubleValue))
+            {
+                typedValue = doubleValue;
+            }
+            else if (schema.Type is JsonSchemaType.Number && float.TryParse(stringValue, out float floatValue))
+            {
+                typedValue = floatValue;
+            }
+            else if (schema.Type is JsonSchemaType.String && schema.Format == "byte" && byte.TryParse(stringValue, out byte byteValue))
+            {
+                typedValue = byteValue;
+            }
+            else if (schema.Type is JsonSchemaType.Boolean && bool.TryParse(stringValue, out bool boolValue))
+            {
+                typedValue = boolValue;
+            }
+            else if (schema.Type is JsonSchemaType.String && schema.Format == "date" && DateTime.TryParse(stringValue, out DateTime dateValue))
+            {
+                typedValue = dateValue;
+            }
+            else if (schema.Type is JsonSchemaType.String && schema.Format == "date-time" && DateTime.TryParse(stringValue, out DateTime dateTimeValue))
+            {
+                typedValue = dateTimeValue;
+            }
+            else if (schema.Type is JsonSchemaType.String && schema.Format == "uuid" && Guid.TryParse(stringValue, out Guid uuidValue))
+            {
+                typedValue = uuidValue;
+            }
+            else if (schema.Type is JsonSchemaType.String)
+            {
+                typedValue = stringValue;
+            }
+            else if (schema.Type is JsonSchemaType.Array)
+            {
+                var arrayValue = schema.Items == null
                     ? stringValue.Split(',')
                     : stringValue.Split(',').Select(itemStringValue =>
                     {
@@ -59,9 +69,9 @@ namespace Swashbuckle.AspNetCore.ApiTesting
 
         internal static string TypeIdentifier(this OpenApiSchema schema)
         {
-            var idBuilder = new StringBuilder(schema.Type);
+            var idBuilder = new StringBuilder(schema.Type.ToString().ToLowerInvariant());
 
-            if (schema.Type == "array" && schema.Items != null)
+            if (schema.Type is JsonSchemaType.Array && schema.Items != null)
                 idBuilder.Append($"[{schema.Items.Type}]");
 
             return idBuilder.ToString();

--- a/src/Swashbuckle.AspNetCore.ApiTesting/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/PublicAPI/PublicAPI.Shipped.txt
@@ -69,7 +69,6 @@ Swashbuckle.AspNetCore.ApiTesting.JsonValidator.CanValidate(Microsoft.OpenApi.Mo
 Swashbuckle.AspNetCore.ApiTesting.JsonValidator.JsonValidator() -> void
 Swashbuckle.AspNetCore.ApiTesting.JsonValidator.Validate(Microsoft.OpenApi.Models.OpenApiSchema schema, Microsoft.OpenApi.Models.OpenApiDocument openApiDocument, Newtonsoft.Json.Linq.JToken instance, out System.Collections.Generic.IEnumerable<string> errorMessages) -> bool
 Swashbuckle.AspNetCore.ApiTesting.OpenApiDocumentExtensions
-Swashbuckle.AspNetCore.ApiTesting.OpenApiSchemaExtensions
 Swashbuckle.AspNetCore.ApiTesting.RequestDoesNotMatchSpecException
 Swashbuckle.AspNetCore.ApiTesting.RequestDoesNotMatchSpecException.RequestDoesNotMatchSpecException(string message) -> void
 Swashbuckle.AspNetCore.ApiTesting.RequestValidator

--- a/src/Swashbuckle.AspNetCore.ApiTesting/RequestValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/RequestValidator.cs
@@ -8,10 +8,11 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Template;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.References;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
-    public class RequestValidator(IEnumerable<IContentValidator> contentValidators)
+    public sealed class RequestValidator(IEnumerable<IContentValidator> contentValidators)
     {
         private readonly IEnumerable<IContentValidator> _contentValidators = contentValidators;
 
@@ -60,7 +61,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting
                 .Select(p =>
                 {
                     return p.Reference != null
-                        ? (OpenApiParameter)openApiDocument.ResolveReference(p.Reference)
+                        ? new OpenApiParameterReference(p.Reference.Id, openApiDocument)
                         : p;
                 });
         }
@@ -113,7 +114,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting
                 }
 
                 var schema = (parameterSpec.Schema.Reference != null)
-                    ? (OpenApiSchema)openApiDocument.ResolveReference(parameterSpec.Schema.Reference)
+                    ? new OpenApiSchemaReference(parameterSpec.Schema.Reference.Id, openApiDocument)
                     : parameterSpec.Schema;
 
                 if (!schema.TryParse(value, out object typedValue))
@@ -126,7 +127,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting
         private void ValidateContent(OpenApiRequestBody requestBodySpec, OpenApiDocument openApiDocument, HttpContent content)
         {
             requestBodySpec = requestBodySpec.Reference != null
-                ? (OpenApiRequestBody)openApiDocument.ResolveReference(requestBodySpec.Reference)
+                ? new OpenApiRequestBodyReference(requestBodySpec.Reference.Id, openApiDocument)
                 : requestBodySpec;
 
             if (requestBodySpec.Required && content == null)

--- a/src/Swashbuckle.AspNetCore.ApiTesting/RequestValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/RequestValidator.cs
@@ -11,14 +11,9 @@ using Microsoft.OpenApi.Models;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
-    public class RequestValidator
+    public class RequestValidator(IEnumerable<IContentValidator> contentValidators)
     {
-        private readonly IEnumerable<IContentValidator> _contentValidators;
-
-        public RequestValidator(IEnumerable<IContentValidator> contentValidators)
-        {
-            _contentValidators = contentValidators;
-        }
+        private readonly IEnumerable<IContentValidator> _contentValidators = contentValidators;
 
         public void Validate(
             HttpRequestMessage request,
@@ -33,17 +28,23 @@ namespace Swashbuckle.AspNetCore.ApiTesting
             var requestUri = new Uri(new Uri("http://tempuri.org"), request.RequestUri);
 
             if (!TryParsePathNameValues(pathTemplate, requestUri.AbsolutePath, out NameValueCollection pathNameValues))
+            {
                 throw new RequestDoesNotMatchSpecException($"Request URI '{requestUri.AbsolutePath}' does not match specified template '{pathTemplate}'");
+            }
 
             if (request.Method != new HttpMethod(operationType.ToString()))
+            {
                 throw new RequestDoesNotMatchSpecException($"Request method '{request.Method}' does not match specified operation type '{operationType}'");
+            }
 
             ValidateParameters(parameterSpecs.Where(p => p.In == ParameterLocation.Path), openApiDocument, pathNameValues);
             ValidateParameters(parameterSpecs.Where(p => p.In == ParameterLocation.Query), openApiDocument, HttpUtility.ParseQueryString(requestUri.Query));
             ValidateParameters(parameterSpecs.Where(p => p.In == ParameterLocation.Header), openApiDocument, request.Headers.ToNameValueCollection());
 
             if (operationSpec.RequestBody != null)
+            {
                 ValidateContent(operationSpec.RequestBody, openApiDocument, request.Content);
+            }
         }
 
         private static IEnumerable<OpenApiParameter> ExpandParameterSpecs(
@@ -58,7 +59,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting
                 .Concat(operationSpec.Parameters)
                 .Select(p =>
                 {
-                    return (p.Reference != null)
+                    return p.Reference != null
                         ? (OpenApiParameter)openApiDocument.ResolveReference(p.Reference)
                         : p;
                 });
@@ -69,27 +70,30 @@ namespace Swashbuckle.AspNetCore.ApiTesting
             OpenApiDocument openApiDocument)
         {
             // TODO
-            return new OpenApiParameter[] { };
+            return [];
         }
 
-        private bool TryParsePathNameValues(string pathTemplate, string requestUri, out NameValueCollection pathNameValues)
+        private static bool TryParsePathNameValues(string pathTemplate, string requestUri, out NameValueCollection pathNameValues)
         {
-            pathNameValues = new NameValueCollection();
+            pathNameValues = [];
 
             var templateMatcher = new TemplateMatcher(TemplateParser.Parse(pathTemplate), null);
             var routeValues = new RouteValueDictionary();
             if (!templateMatcher.TryMatch(new PathString(requestUri), routeValues))
+            {
                 return false;
+            }
 
             foreach (var entry in routeValues)
             {
                 pathNameValues.Add(entry.Key, entry.Value.ToString());
             }
+
             return true;
         }
 
 
-        private void ValidateParameters(
+        private static void ValidateParameters(
             IEnumerable<OpenApiParameter> parameterSpecs,
             OpenApiDocument openApiDocument,
             NameValueCollection parameterNameValues)
@@ -99,39 +103,55 @@ namespace Swashbuckle.AspNetCore.ApiTesting
                 var value = parameterNameValues[parameterSpec.Name];
 
                 if ((parameterSpec.In == ParameterLocation.Path || parameterSpec.Required) && value == null)
+                {
                     throw new RequestDoesNotMatchSpecException($"Required parameter '{parameterSpec.Name}' is not present");
+                }
 
-                if (value == null || parameterSpec.Schema == null) continue;
+                if (value == null || parameterSpec.Schema == null)
+                {
+                    continue;
+                }
 
                 var schema = (parameterSpec.Schema.Reference != null)
                     ? (OpenApiSchema)openApiDocument.ResolveReference(parameterSpec.Schema.Reference)
                     : parameterSpec.Schema;
 
                 if (!schema.TryParse(value, out object typedValue))
+                {
                     throw new RequestDoesNotMatchSpecException($"Parameter '{parameterSpec.Name}' is not of type '{parameterSpec.Schema.TypeIdentifier()}'");
+                }
             }
         }
 
         private void ValidateContent(OpenApiRequestBody requestBodySpec, OpenApiDocument openApiDocument, HttpContent content)
         {
-            requestBodySpec = (requestBodySpec.Reference != null)
+            requestBodySpec = requestBodySpec.Reference != null
                 ? (OpenApiRequestBody)openApiDocument.ResolveReference(requestBodySpec.Reference)
                 : requestBodySpec;
 
             if (requestBodySpec.Required && content == null)
+            {
                 throw new RequestDoesNotMatchSpecException("Required content is not present");
+            }
 
-            if (content == null) return;
+            if (content == null)
+            {
+                return;
+            }
 
             if (!requestBodySpec.Content.TryGetValue(content.Headers.ContentType.MediaType, out OpenApiMediaType mediaTypeSpec))
+            {
                 throw new RequestDoesNotMatchSpecException($"Content media type '{content.Headers.ContentType.MediaType}' is not specified");
+            }
 
             try
             {
                 foreach (var contentValidator in _contentValidators)
                 {
                     if (contentValidator.CanValidate(content.Headers.ContentType.MediaType))
+                    {
                         contentValidator.Validate(mediaTypeSpec, openApiDocument, content);
+                    }
                 }
             }
             catch (ContentDoesNotMatchSpecException contentException)
@@ -141,10 +161,5 @@ namespace Swashbuckle.AspNetCore.ApiTesting
         }
     }
 
-    public class RequestDoesNotMatchSpecException : Exception
-    {
-        public RequestDoesNotMatchSpecException(string message)
-            : base(message)
-        { }
-    }
+    public class RequestDoesNotMatchSpecException(string message) : Exception(message);
 }

--- a/src/Swashbuckle.AspNetCore.ApiTesting/ResponseValidator.cs
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/ResponseValidator.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Net.Http;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.References;
 
 namespace Swashbuckle.AspNetCore.ApiTesting
 {
-    public class ResponseValidator(IEnumerable<IContentValidator> contentValidators)
+    public sealed class ResponseValidator(IEnumerable<IContentValidator> contentValidators)
     {
         private readonly IEnumerable<IContentValidator> _contentValidators = contentValidators;
 
@@ -58,7 +59,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting
                 }
 
                 var schema = (headerSpec.Schema.Reference != null)
-                    ? (OpenApiSchema)openApiDocument.ResolveReference(headerSpec.Schema.Reference)
+                    ? new OpenApiSchemaReference(headerSpec.Schema.Reference.Id, openApiDocument)
                     : headerSpec.Schema;
 
                 if (value == null)

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
@@ -49,11 +49,7 @@ namespace Swashbuckle.AspNetCore.ReDoc
             {
                 _jsonSerializerOptions = new JsonSerializerOptions()
                 {
-#if NET5_0_OR_GREATER
                     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-#else
-                    IgnoreNullValues = true,
-#endif
                     PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                     Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, false) }
                 };

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Shipped.txt
@@ -68,10 +68,10 @@ static Swashbuckle.AspNetCore.SwaggerGen.MemberInfoExtensions.GetInlineAndMetada
 static Swashbuckle.AspNetCore.SwaggerGen.MemberInfoExtensions.IsDictionaryValueNonNullable(this System.Reflection.MemberInfo memberInfo) -> bool
 static Swashbuckle.AspNetCore.SwaggerGen.MemberInfoExtensions.IsNonNullableReferenceType(this System.Reflection.MemberInfo memberInfo) -> bool
 static Swashbuckle.AspNetCore.SwaggerGen.MethodInfoExtensions.GetUnderlyingGenericTypeMethod(this System.Reflection.MethodInfo constructedTypeMethod) -> System.Reflection.MethodInfo
-static Swashbuckle.AspNetCore.SwaggerGen.OpenApiAnyFactory.CreateFromJson(string json) -> Microsoft.OpenApi.Any.IOpenApiAny
+static Swashbuckle.AspNetCore.SwaggerGen.OpenApiAnyFactory.CreateFromJson(string json) -> System.Text.Json.Nodes.JsonNode
 static Swashbuckle.AspNetCore.SwaggerGen.OpenApiSchemaExtensions.ApplyRouteConstraints(this Microsoft.OpenApi.Models.OpenApiSchema schema, Microsoft.AspNetCore.Mvc.ApiExplorer.ApiParameterRouteInfo routeInfo) -> void
 static Swashbuckle.AspNetCore.SwaggerGen.OpenApiSchemaExtensions.ApplyValidationAttributes(this Microsoft.OpenApi.Models.OpenApiSchema schema, System.Collections.Generic.IEnumerable<object> customAttributes) -> void
-static Swashbuckle.AspNetCore.SwaggerGen.OpenApiSchemaExtensions.ResolveType(this Microsoft.OpenApi.Models.OpenApiSchema schema, Swashbuckle.AspNetCore.SwaggerGen.SchemaRepository schemaRepository) -> string
+static Swashbuckle.AspNetCore.SwaggerGen.OpenApiSchemaExtensions.ResolveType(this Microsoft.OpenApi.Models.OpenApiSchema schema, Swashbuckle.AspNetCore.SwaggerGen.SchemaRepository schemaRepository) -> Microsoft.OpenApi.Models.JsonSchemaType?
 static Swashbuckle.AspNetCore.SwaggerGen.PropertyInfoExtensions.HasAttribute<TAttribute>(this System.Reflection.PropertyInfo property) -> bool
 static Swashbuckle.AspNetCore.SwaggerGen.PropertyInfoExtensions.IsPubliclyReadable(this System.Reflection.PropertyInfo property) -> bool
 static Swashbuckle.AspNetCore.SwaggerGen.PropertyInfoExtensions.IsPubliclyWritable(this System.Reflection.PropertyInfo property) -> bool

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-static Swashbuckle.AspNetCore.SwaggerGen.OpenApiAnyFactory.CreateFromJson(string json, System.Text.Json.JsonSerializerOptions options) -> Microsoft.OpenApi.Any.IOpenApiAny
+static Swashbuckle.AspNetCore.SwaggerGen.OpenApiAnyFactory.CreateFromJson(string json, System.Text.Json.JsonSerializerOptions options) -> System.Text.Json.Nodes.JsonNode
 static Swashbuckle.AspNetCore.SwaggerGen.XmlCommentsTextHelper.Humanize(string text, string xmlCommentEndOfLine) -> string
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenerator.GetDocumentNames() -> System.Collections.Generic.IList<string>
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.XmlCommentEndOfLine.get -> string

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
@@ -113,12 +113,17 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         public static string ResolveType(this OpenApiSchema schema, SchemaRepository schemaRepository)
         {
             if (schema.Reference != null && schemaRepository.Schemas.TryGetValue(schema.Reference.Id, out OpenApiSchema definitionSchema))
+            {
                 return definitionSchema.ResolveType(schemaRepository);
+            }
 
             foreach (var subSchema in schema.AllOf)
             {
                 var type = subSchema.ResolveType(schemaRepository);
-                if (type != null) return type;
+                if (type != null)
+                {
+                    return type;
+                }
             }
 
             return schema.Type;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
@@ -97,20 +97,20 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     ApplyLengthRouteConstraint(schema, lengthRouteConstraint);
 
                 else if (constraint is FloatRouteConstraint or DecimalRouteConstraint)
-                    schema.Type = "number";
+                    schema.Type = JsonSchemaType.Null;
 
                 else if (constraint is LongRouteConstraint or IntRouteConstraint)
-                    schema.Type = "integer";
+                    schema.Type = JsonSchemaType.Integer;
 
                 else if (constraint is GuidRouteConstraint or StringRouteConstraint)
-                    schema.Type = "string";
+                    schema.Type = JsonSchemaType.String;
 
                 else if (constraint is BoolRouteConstraint)
-                    schema.Type = "boolean";
+                    schema.Type = JsonSchemaType.Boolean;
             }
         }
 
-        public static string ResolveType(this OpenApiSchema schema, SchemaRepository schemaRepository)
+        public static JsonSchemaType? ResolveType(this OpenApiSchema schema, SchemaRepository schemaRepository)
         {
             if (schema.Reference != null && schemaRepository.Schemas.TryGetValue(schema.Reference.Id, out OpenApiSchema definitionSchema))
             {
@@ -139,7 +139,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private static void ApplyMinLengthAttribute(OpenApiSchema schema, MinLengthAttribute minLengthAttribute)
         {
-            if (schema.Type == "array")
+            if (schema.Type == JsonSchemaType.Array)
                 schema.MinItems = minLengthAttribute.Length;
             else
                 schema.MinLength = minLengthAttribute.Length;
@@ -147,7 +147,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private static void ApplyMinLengthRouteConstraint(OpenApiSchema schema, MinLengthRouteConstraint minLengthRouteConstraint)
         {
-            if (schema.Type == "array")
+            if (schema.Type == JsonSchemaType.Array)
                 schema.MinItems = minLengthRouteConstraint.MinLength;
             else
                 schema.MinLength = minLengthRouteConstraint.MinLength;
@@ -155,7 +155,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private static void ApplyMaxLengthAttribute(OpenApiSchema schema, MaxLengthAttribute maxLengthAttribute)
         {
-            if (schema.Type == "array")
+            if (schema.Type == JsonSchemaType.Array)
                 schema.MaxItems = maxLengthAttribute.Length;
             else
                 schema.MaxLength = maxLengthAttribute.Length;
@@ -163,7 +163,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private static void ApplyMaxLengthRouteConstraint(OpenApiSchema schema, MaxLengthRouteConstraint maxLengthRouteConstraint)
         {
-            if (schema.Type == "array")
+            if (schema.Type == JsonSchemaType.Array)
                 schema.MaxItems = maxLengthRouteConstraint.MaxLength;
             else
                 schema.MaxLength = maxLengthRouteConstraint.MaxLength;
@@ -173,7 +173,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private static void ApplyLengthAttribute(OpenApiSchema schema, LengthAttribute lengthAttribute)
         {
-            if (schema.Type == "array")
+            if (schema.Type == JsonSchemaType.Array)
             {
                 schema.MinItems = lengthAttribute.MinimumLength;
                 schema.MaxItems = lengthAttribute.MaximumLength;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/OpenApiAnyFactory.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/OpenApiAnyFactory.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 using System.Text.Json;
-using Microsoft.OpenApi.Any;
+using System.Text.Json.Nodes;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     public static class OpenApiAnyFactory
     {
-        public static IOpenApiAny CreateFromJson(string json)
+        public static JsonNode CreateFromJson(string json)
             => CreateFromJson(json, null);
 
-        public static IOpenApiAny CreateFromJson(string json, JsonSerializerOptions options)
+        public static JsonNode CreateFromJson(string json, JsonSerializerOptions options)
         {
             try
             {
@@ -22,9 +22,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             }
         }
 
-        private static OpenApiArray CreateOpenApiArray(JsonElement jsonElement)
+        private static JsonArray CreateOpenApiArray(JsonElement jsonElement)
         {
-            var openApiArray = new OpenApiArray();
+            var openApiArray = new JsonArray();
 
             foreach (var item in jsonElement.EnumerateArray())
             {
@@ -34,9 +34,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             return openApiArray;
         }
 
-        private static OpenApiObject CreateOpenApiObject(JsonElement jsonElement)
+        private static JsonObject CreateOpenApiObject(JsonElement jsonElement)
         {
-            var openApiObject = new OpenApiObject();
+            var openApiObject = new JsonObject();
 
             foreach (var property in jsonElement.EnumerateObject())
             {
@@ -46,39 +46,18 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             return openApiObject;
         }
 
-        private static IOpenApiAny CreateFromJsonElement(JsonElement jsonElement)
+        private static JsonNode CreateFromJsonElement(JsonElement jsonElement)
         {
-            if (jsonElement.ValueKind == JsonValueKind.Null)
-                return new OpenApiNull();
-
-            if (jsonElement.ValueKind == JsonValueKind.True || jsonElement.ValueKind == JsonValueKind.False)
-                return new OpenApiBoolean(jsonElement.GetBoolean());
-
-            if (jsonElement.ValueKind == JsonValueKind.Number)
+            if (jsonElement.ValueKind == JsonValueKind.Array)
             {
-                if (jsonElement.TryGetInt32(out int intValue))
-                    return new OpenApiInteger(intValue);
-
-                if (jsonElement.TryGetInt64(out long longValue))
-                    return new OpenApiLong(longValue);
-
-                if (jsonElement.TryGetSingle(out float floatValue) && !float.IsInfinity(floatValue))
-                    return new OpenApiFloat(floatValue);
-
-                if (jsonElement.TryGetDouble(out double doubleValue))
-                    return new OpenApiDouble(doubleValue);
+                return CreateOpenApiArray(jsonElement);
+            }
+            else if (jsonElement.ValueKind == JsonValueKind.Object)
+            {
+                return CreateOpenApiObject(jsonElement);
             }
 
-            if (jsonElement.ValueKind == JsonValueKind.String)
-                return new OpenApiString(jsonElement.ToString());
-
-            if (jsonElement.ValueKind == JsonValueKind.Array)
-                return CreateOpenApiArray(jsonElement);
-
-            if (jsonElement.ValueKind == JsonValueKind.Object)
-                return CreateOpenApiObject(jsonElement);
-
-            throw new System.ArgumentException($"Unsupported value kind {jsonElement.ValueKind}");
+            return JsonValue.Create(jsonElement);
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -20,22 +20,15 @@ using Microsoft.AspNetCore.Http.Metadata;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
-    public class SwaggerGenerator : ISwaggerProvider, IAsyncSwaggerProvider, ISwaggerDocumentMetadataProvider
+    public class SwaggerGenerator(
+        SwaggerGeneratorOptions options,
+        IApiDescriptionGroupCollectionProvider apiDescriptionsProvider,
+        ISchemaGenerator schemaGenerator) : ISwaggerProvider, IAsyncSwaggerProvider, ISwaggerDocumentMetadataProvider
     {
-        private readonly IApiDescriptionGroupCollectionProvider _apiDescriptionsProvider;
-        private readonly ISchemaGenerator _schemaGenerator;
-        private readonly SwaggerGeneratorOptions _options;
+        private readonly IApiDescriptionGroupCollectionProvider _apiDescriptionsProvider = apiDescriptionsProvider;
+        private readonly ISchemaGenerator _schemaGenerator = schemaGenerator;
+        private readonly SwaggerGeneratorOptions _options = options ?? new();
         private readonly IAuthenticationSchemeProvider _authenticationSchemeProvider;
-
-        public SwaggerGenerator(
-            SwaggerGeneratorOptions options,
-            IApiDescriptionGroupCollectionProvider apiDescriptionsProvider,
-            ISchemaGenerator schemaGenerator)
-        {
-            _options = options ?? new SwaggerGeneratorOptions();
-            _apiDescriptionsProvider = apiDescriptionsProvider;
-            _schemaGenerator = schemaGenerator;
-        }
 
         public SwaggerGenerator(
             SwaggerGeneratorOptions options,

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
@@ -1,18 +1,18 @@
 ﻿using System.Text.Json;
-using Microsoft.OpenApi.Any;
+using System.Text.Json.Nodes;
 using Microsoft.OpenApi.Models;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
 {
     internal static class XmlCommentsExampleHelper
     {
-        public static IOpenApiAny Create(
+        public static JsonNode Create(
             SchemaRepository schemaRepository,
             OpenApiSchema schema,
             string exampleString)
         {
             var isStringType =
-                schema?.ResolveType(schemaRepository) == "string" &&
+                schema?.ResolveType(schemaRepository) == JsonSchemaType.String &&
                 !string.Equals(exampleString, "null");
 
             var exampleAsJson = isStringType

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsExampleHelper.cs
@@ -12,7 +12,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             string exampleString)
         {
             var isStringType =
-                (schema?.ResolveType(schemaRepository) == "string") &&
+                schema?.ResolveType(schemaRepository) == "string" &&
                 !string.Equals(exampleString, "null");
 
             var exampleAsJson = isStringType

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -51,11 +51,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI
             {
                 _jsonSerializerOptions = new JsonSerializerOptions()
                 {
-#if NET5_0_OR_GREATER
                     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-#else
-                    IgnoreNullValues = true,
-#endif
                     PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
                     Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase, false) }
                 };

--- a/test/Swashbuckle.AspNetCore.Annotations.Test/AnnotationsOperationFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.Annotations.Test/AnnotationsOperationFilterTests.cs
@@ -4,8 +4,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi.Models;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Xunit;
 
@@ -30,7 +28,7 @@ namespace Swashbuckle.AspNetCore.Annotations.Test
             Assert.Equal("Summary for ActionWithSwaggerOperationAttribute", operation.Summary);
             Assert.Equal("Description for ActionWithSwaggerOperationAttribute", operation.Description);
             Assert.Equal("actionWithSwaggerOperationAttribute", operation.OperationId);
-            Assert.Equal(new[] { "foobar" }, operation.Tags.Cast<OpenApiTag>().Select(t => t.Name));
+            Assert.Equal(["foobar"], [.. operation.Tags.Select(t => t.Name)]);
         }
 
         [Fact]
@@ -54,7 +52,7 @@ namespace Swashbuckle.AspNetCore.Annotations.Test
 
             Subject().Apply(operation, filterContext);
 
-            Assert.Equal(new[] { "204", "400", "500" }, operation.Responses.Keys.ToArray());
+            Assert.Equal(["204", "400", "500"], [.. operation.Responses.Keys]);
             var response1 = operation.Responses["204"];
             Assert.Equal("Description for 204 response", response1.Description);
             var response2 = operation.Responses["400"];
@@ -83,7 +81,7 @@ namespace Swashbuckle.AspNetCore.Annotations.Test
 
             Subject().Apply(operation, filterContext);
 
-            Assert.Equal(new[] { "200", "500" }, operation.Responses.Keys.ToArray());
+            Assert.Equal(["200", "500"], [.. operation.Responses.Keys]);
             var response1 = operation.Responses["200"];
             Assert.Equal("Description for 200 response", response1.Description);
             Assert.NotNull(response1.Content);
@@ -135,7 +133,7 @@ namespace Swashbuckle.AspNetCore.Annotations.Test
             {
                 Description = "Description for ActionWithSwaggerOperationAttribute",
                 OperationId = "actionWithSwaggerOperationAttribute",
-                Tags = new[] { "foobar" }
+                Tags = ["foobar"]
             };
 
             var action = RequestDelegateFactory.Create((string parameter) => "{}");
@@ -147,7 +145,7 @@ namespace Swashbuckle.AspNetCore.Annotations.Test
             {
                 ActionDescriptor = new ActionDescriptor()
                 {
-                    EndpointMetadata = new[] { operationAttribute }
+                    EndpointMetadata = [operationAttribute]
                 }
             };
 
@@ -162,12 +160,12 @@ namespace Swashbuckle.AspNetCore.Annotations.Test
             Assert.Equal("Summary for ActionWithSwaggerOperationAttribute", operation.Summary);
             Assert.Equal("Description for ActionWithSwaggerOperationAttribute", operation.Description);
             Assert.Equal("actionWithSwaggerOperationAttribute", operation.OperationId);
-            Assert.Equal(new[] { "foobar" }, operation.Tags.Cast<OpenApiTag>().Select(t => t.Name));
+            Assert.Equal(["foobar"], [.. operation.Tags.Select(t => t.Name)]);
         }
 
-        private AnnotationsOperationFilter Subject()
+        private static AnnotationsOperationFilter Subject()
         {
-            return new AnnotationsOperationFilter();
+            return new();
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.Annotations.Test/AnnotationsOperationFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.Annotations.Test/AnnotationsOperationFilterTests.cs
@@ -89,9 +89,9 @@ namespace Swashbuckle.AspNetCore.Annotations.Test
             var jsonContent = response1.Content.First();
             var xmlContent = response1.Content.Last();
             Assert.Equal("application/json", jsonContent.Key);
-            Assert.Equal("string", jsonContent.Value.Schema.Type);
+            Assert.Equal(JsonSchemaType.String, jsonContent.Value.Schema.Type);
             Assert.Equal("application/xml", xmlContent.Key);
-            Assert.Equal("string", xmlContent.Value.Schema.Type);
+            Assert.Equal(JsonSchemaType.String, xmlContent.Value.Schema.Type);
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.Annotations.Test/Fixtures/VendorExtensionsOperationFilter.cs
+++ b/test/Swashbuckle.AspNetCore.Annotations.Test/Fixtures/VendorExtensionsOperationFilter.cs
@@ -8,7 +8,7 @@ namespace Swashbuckle.AspNetCore.Annotations.Test
     {
         public void Apply(OpenApiOperation operation, OperationFilterContext contex)
         {
-            operation.Extensions.Add("X-property1", new OpenApiString("value"));
+            operation.Extensions.Add("X-property1", new OpenApiAny("value"));
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.Annotations.Test/Fixtures/VendorExtensionsSchemaFilter.cs
+++ b/test/Swashbuckle.AspNetCore.Annotations.Test/Fixtures/VendorExtensionsSchemaFilter.cs
@@ -8,7 +8,7 @@ namespace Swashbuckle.AspNetCore.Annotations.Test
     {
         public void Apply(OpenApiSchema schema, SchemaFilterContext context)
         {
-            schema.Extensions.Add("X-property1", new OpenApiString("value"));
+            schema.Extensions.Add("X-property1", new OpenApiAny("value"));
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.ApiTesting.Test/JsonValidatorTests.cs
+++ b/test/Swashbuckle.AspNetCore.ApiTesting.Test/JsonValidatorTests.cs
@@ -9,20 +9,20 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
     public class JsonValidatorTests
     {
         [Theory]
-        [InlineData("null", "{}", false, "Path: . Instance is not of type 'null'")]
-        [InlineData("null", "null", true, null)]
-        [InlineData("boolean", "'foobar'", false, "Path: . Instance is not of type 'boolean'")]
-        [InlineData("boolean", "true", true, null)]
-        [InlineData("object", "'foobar'", false, "Path: . Instance is not of type 'object'")]
-        [InlineData("object", "{}", true, null)]
-        [InlineData("array", "'foobar'", false, "Path: . Instance is not of type 'array'")]
-        [InlineData("array", "[]", true, null)]
-        [InlineData("number", "'foobar'", false, "Path: . Instance is not of type 'number'")]
-        [InlineData("number", "1", true, null)]
-        [InlineData("string", "{}", false, "Path: . Instance is not of type 'string'")]
-        [InlineData("string", "'foobar'", true, null)]
+        [InlineData(JsonSchemaType.Null, "{}", false, "Path: . Instance is not of type 'null'")]
+        [InlineData(JsonSchemaType.Null, "null", true, null)]
+        [InlineData(JsonSchemaType.Boolean, "'foobar'", false, "Path: . Instance is not of type 'boolean'")]
+        [InlineData(JsonSchemaType.Boolean, "true", true, null)]
+        [InlineData(JsonSchemaType.Object, "'foobar'", false, "Path: . Instance is not of type 'object'")]
+        [InlineData(JsonSchemaType.Object, "{}", true, null)]
+        [InlineData(JsonSchemaType.Array, "'foobar'", false, "Path: . Instance is not of type 'array'")]
+        [InlineData(JsonSchemaType.Array, "[]", true, null)]
+        [InlineData(JsonSchemaType.Number, "'foobar'", false, "Path: . Instance is not of type 'number'")]
+        [InlineData(JsonSchemaType.Number, "1", true, null)]
+        [InlineData(JsonSchemaType.String, "{}", false, "Path: . Instance is not of type 'string'")]
+        [InlineData(JsonSchemaType.String, "'foobar'", true, null)]
         public void Validate_ReturnsError_IfInstanceNotOfExpectedType(
-            string schemaType,
+            JsonSchemaType schemaType,
             string instanceText,
             bool expectedReturnValue,
             string expectedErrorMessage)
@@ -49,7 +49,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
             bool expectedReturnValue,
             string expectedErrorMessage)
         {
-            var openApiSchema = new OpenApiSchema { Type = "number", MultipleOf = schemaMultipleOf };
+            var openApiSchema = new OpenApiSchema { Type = JsonSchemaType.Number, MultipleOf = schemaMultipleOf };
             var instance = JToken.Parse(instanceText);
 
             var returnValue = Subject().Validate(
@@ -71,7 +71,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
             bool expectedReturnValue,
             string expectedErrorMessage)
         {
-            var openApiSchema = new OpenApiSchema { Type = "number", Maximum = schemaMaximum };
+            var openApiSchema = new OpenApiSchema { Type = JsonSchemaType.Number, Maximum = schemaMaximum };
             var instance = JToken.Parse(instanceText);
 
             var returnValue = Subject().Validate(
@@ -95,7 +95,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema
             {
-                Type = "number",
+                Type = JsonSchemaType.Number,
                 Maximum = schemaMaximum,
                 ExclusiveMaximum = true
             };
@@ -120,7 +120,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
             bool expectedReturnValue,
             string expectedErrorMessage)
         {
-            var openApiSchema = new OpenApiSchema { Type = "number", Minimum = schemaMinimum };
+            var openApiSchema = new OpenApiSchema { Type = JsonSchemaType.Number, Minimum = schemaMinimum };
             var instance = JToken.Parse(instanceText);
 
             var returnValue = Subject().Validate(
@@ -144,7 +144,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema
             {
-                Type = "number",
+                Type = JsonSchemaType.Number,
                 Minimum = schemaMinimum,
                 ExclusiveMinimum = true
             };
@@ -171,7 +171,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema
             {
-                Type = "string",
+                Type = JsonSchemaType.String,
                 MaxLength = schemaMaxLength
             };
             var instance = JToken.Parse(instanceText);
@@ -197,7 +197,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema
             {
-                Type = "string",
+                Type = JsonSchemaType.String,
                 MinLength = schemaMinLength
             };
             var instance = JToken.Parse(instanceText);
@@ -223,7 +223,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema
             {
-                Type = "string",
+                Type = JsonSchemaType.String,
                 Pattern = schemaPattern
             };
             var instance = JToken.Parse(instanceText);
@@ -239,18 +239,18 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         }
 
         [Theory]
-        [InlineData("boolean", "[ true, 'foo' ]", false, "Path: [1]. Instance is not of type 'boolean'")]
-        [InlineData("number", "[ 123, 'foo' ]", false, "Path: [1]. Instance is not of type 'number'")]
-        [InlineData("boolean", "[ true, false ]", true, null)]
+        [InlineData(JsonSchemaType.Boolean, "[ true, 'foo' ]", false, "Path: [1]. Instance is not of type 'boolean'")]
+        [InlineData(JsonSchemaType.Number, "[ 123, 'foo' ]", false, "Path: [1]. Instance is not of type 'number'")]
+        [InlineData(JsonSchemaType.Boolean, "[ true, false ]", true, null)]
         public void Validate_ReturnsError_IfArrayItemDoesNotMatchItemsSchema(
-            string itemsSchemaType,
+            JsonSchemaType itemsSchemaType,
             string instanceText,
             bool expectedReturnValue,
             string expectedErrorMessage)
         {
             var openApiSchema = new OpenApiSchema
             {
-                Type = "array",
+                Type = JsonSchemaType.Array,
                 Items = new OpenApiSchema { Type = itemsSchemaType }
             };
             var instance = JToken.Parse(instanceText);
@@ -276,7 +276,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema
             {
-                Type = "array",
+                Type = JsonSchemaType.Array,
                 MaxItems = schemaMaxItems
             };
             var instance = JToken.Parse(instanceText);
@@ -302,7 +302,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema
             {
-                Type = "array",
+                Type = JsonSchemaType.Array,
                 MinItems = schemaMinItems
             };
             var instance = JToken.Parse(instanceText);
@@ -327,7 +327,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema
             {
-                Type = "array",
+                Type = JsonSchemaType.Array,
                 UniqueItems = true
             };
             var instance = JToken.Parse(instanceText);
@@ -353,7 +353,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema
             {
-                Type = "object",
+                Type = JsonSchemaType.Object,
                 MaxProperties = schemaMaxProperties
             };
             var instance = JToken.Parse(instanceText);
@@ -379,7 +379,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema
             {
-                Type = "object",
+                Type = JsonSchemaType.Object,
                 MinProperties = schemaMinProperties
             };
             var instance = JToken.Parse(instanceText);
@@ -405,7 +405,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema
             {
-                Type = "object",
+                Type = JsonSchemaType.Object,
                 Required = new SortedSet<string>(schemaRequired)
             };
             var instance = JToken.Parse(instanceText);
@@ -421,18 +421,18 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         }
 
         [Theory]
-        [InlineData("number", "{ \"id\": \"foo\" }", false, "Path: id. Instance is not of type 'number'")]
-        [InlineData("string", "{ \"id\": 123 }", false, "Path: id. Instance is not of type 'string'")]
-        [InlineData("number", "{ \"id\": 123 }", true, null)]
+        [InlineData(JsonSchemaType.Number, "{ \"id\": \"foo\" }", false, "Path: id. Instance is not of type 'number'")]
+        [InlineData(JsonSchemaType.String, "{ \"id\": 123 }", false, "Path: id. Instance is not of type 'string'")]
+        [InlineData(JsonSchemaType.Number, "{ \"id\": 123 }", true, null)]
         public void Validate_ReturnsError_IfKnownPropertyDoesNotMatchPropertySchema(
-            string propertySchemaType,
+            JsonSchemaType propertySchemaType,
             string instanceText,
             bool expectedReturnValue,
             string expectedErrorMessage)
         {
             var openApiSchema = new OpenApiSchema
             {
-                Type = "object",
+                Type = JsonSchemaType.Object,
                 Properties = new Dictionary<string, OpenApiSchema>
                 {
                     [ "id" ] = new OpenApiSchema { Type = propertySchemaType }
@@ -451,18 +451,18 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         }
 
         [Theory]
-        [InlineData("number", "{ \"id\": \"foo\" }", false, "Path: id. Instance is not of type 'number'")]
-        [InlineData("string", "{ \"name\": 123 }", false, "Path: name. Instance is not of type 'string'")]
-        [InlineData("number", "{ \"description\": 123 }", true, null)]
+        [InlineData(JsonSchemaType.Number, "{ \"id\": \"foo\" }", false, "Path: id. Instance is not of type 'number'")]
+        [InlineData(JsonSchemaType.String, "{ \"name\": 123 }", false, "Path: name. Instance is not of type 'string'")]
+        [InlineData(JsonSchemaType.Number, "{ \"description\": 123 }", true, null)]
         public void Validate_ReturnsError_IfAdditionalPropertyDoesNotMatchAdditionalPropertiesSchema(
-            string additionalPropertiesType,
+            JsonSchemaType additionalPropertiesType,
             string instanceText,
             bool expectedReturnValue,
             string expectedErrorMessage)
         {
             var openApiSchema = new OpenApiSchema
             {
-                Type = "object",
+                Type = JsonSchemaType.Object,
                 AdditionalProperties = new OpenApiSchema { Type = additionalPropertiesType }
             };
             var instance = JToken.Parse(instanceText);
@@ -488,7 +488,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema
             {
-                Type = "object",
+                Type = JsonSchemaType.Object,
                 AdditionalPropertiesAllowed = additionalPropertiesAllowed
             };
             var instance = JToken.Parse(instanceText);
@@ -515,9 +515,9 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
             {
                 AllOf =
                 [
-                    new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p1" } },
-                    new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p2" } },
-                    new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p3" } }
+                    new OpenApiSchema { Type = JsonSchemaType.Object, Required = new SortedSet<string> { "p1" } },
+                    new OpenApiSchema { Type = JsonSchemaType.Object, Required = new SortedSet<string> { "p2" } },
+                    new OpenApiSchema { Type = JsonSchemaType.Object, Required = new SortedSet<string> { "p3" } }
                 ]
             };
             var instance = JToken.Parse(instanceText);
@@ -544,9 +544,9 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
             {
                 AnyOf =
                 [
-                    new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p1" } },
-                    new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p2" } },
-                    new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p3" } }
+                    new OpenApiSchema { Type = JsonSchemaType.Object, Required = new SortedSet<string> { "p1" } },
+                    new OpenApiSchema { Type = JsonSchemaType.Object, Required = new SortedSet<string> { "p2" } },
+                    new OpenApiSchema { Type = JsonSchemaType.Object, Required = new SortedSet<string> { "p3" } }
                 ]
             };
             var instance = JToken.Parse(instanceText);
@@ -574,9 +574,9 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
             {
                 OneOf =
                 [
-                    new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p1" } },
-                    new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p2" } },
-                    new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p3" } }
+                    new OpenApiSchema { Type = JsonSchemaType.Object, Required = new SortedSet<string> { "p1" } },
+                    new OpenApiSchema { Type = JsonSchemaType.Object, Required = new SortedSet<string> { "p2" } },
+                    new OpenApiSchema { Type = JsonSchemaType.Object, Required = new SortedSet<string> { "p3" } }
                 ]
             };
             var instance = JToken.Parse(instanceText);
@@ -608,7 +608,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                 {
                     Schemas = new Dictionary<string, OpenApiSchema>
                     {
-                        ["ref"] = new OpenApiSchema { Type = "number" }
+                        ["ref"] = new OpenApiSchema { Type = JsonSchemaType.Number }
                     }
                 }
             };

--- a/test/Swashbuckle.AspNetCore.ApiTesting.Test/JsonValidatorTests.cs
+++ b/test/Swashbuckle.AspNetCore.ApiTesting.Test/JsonValidatorTests.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
-using Xunit;
+using System.Linq;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json.Linq;
-using System.Linq;
+using Xunit;
 
 namespace Swashbuckle.AspNetCore.ApiTesting.Test
 {
@@ -51,7 +51,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema { Type = "number", MultipleOf = schemaMultipleOf };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -73,7 +73,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema { Type = "number", Maximum = schemaMaximum };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -100,7 +100,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                 ExclusiveMaximum = true
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -122,7 +122,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema { Type = "number", Minimum = schemaMinimum };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -149,7 +149,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                 ExclusiveMinimum = true
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -175,7 +175,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                 MaxLength = schemaMaxLength
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -201,7 +201,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                 MinLength = schemaMinLength
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -227,7 +227,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                 Pattern = schemaPattern
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -254,7 +254,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                 Items = new OpenApiSchema { Type = itemsSchemaType }
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -280,7 +280,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                 MaxItems = schemaMaxItems
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -306,7 +306,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                 MinItems = schemaMinItems
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -331,7 +331,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                 UniqueItems = true
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -357,7 +357,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                 MaxProperties = schemaMaxProperties
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -383,7 +383,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                 MinProperties = schemaMinProperties
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -409,7 +409,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                 Required = new SortedSet<string>(schemaRequired)
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -439,7 +439,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                 }
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -466,7 +466,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                 AdditionalProperties = new OpenApiSchema { Type = additionalPropertiesType }
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -492,7 +492,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                 AdditionalPropertiesAllowed = additionalPropertiesAllowed
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -513,15 +513,15 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema
             {
-                AllOf = new List<OpenApiSchema>
-                {
+                AllOf =
+                [
                     new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p1" } },
                     new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p2" } },
                     new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p3" } }
-                }
+                ]
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -542,15 +542,15 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema
             {
-                AnyOf = new List<OpenApiSchema>
-                {
+                AnyOf =
+                [
                     new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p1" } },
                     new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p2" } },
                     new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p3" } }
-                }
+                ]
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -572,15 +572,15 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         {
             var openApiSchema = new OpenApiSchema
             {
-                OneOf = new List<OpenApiSchema>
-                {
+                OneOf =
+                [
                     new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p1" } },
                     new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p2" } },
                     new OpenApiSchema { Type = "object", Required = new SortedSet<string> { "p3" } }
-                }
+                ]
             };
             var instance = JToken.Parse(instanceText);
-            
+
             var returnValue = Subject().Validate(
                 openApiSchema,
                 new OpenApiDocument(),
@@ -628,9 +628,6 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
             Assert.Equal(expectedExceptionMessage, exception?.Message);
         }
 
-        private JsonValidator Subject()
-        {
-            return new JsonValidator();
-        }
+        private static JsonValidator Subject() => new();
     }
 }

--- a/test/Swashbuckle.AspNetCore.ApiTesting.Test/RequestValidatorTests.cs
+++ b/test/Swashbuckle.AspNetCore.ApiTesting.Test/RequestValidatorTests.cs
@@ -69,7 +69,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                     {
                         Name = "param",
                         In = ParameterLocation.Query,
-                        Schema = new OpenApiSchema { Type = "string" },
+                        Schema = new OpenApiSchema { Type = JsonSchemaType.String },
                         Required = true
                     }
                 }
@@ -103,7 +103,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                     {
                         Name = "test-header",
                         In = ParameterLocation.Header,
-                        Schema = new OpenApiSchema { Type = "string" },
+                        Schema = new OpenApiSchema { Type = JsonSchemaType.String },
                         Required = true
                     }
                 }
@@ -125,14 +125,14 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
 
 
         [Theory]
-        [InlineData("/api/products/foo", "boolean", "Parameter 'param' is not of type 'boolean'")]
-        [InlineData("/api/products/foo", "number", "Parameter 'param' is not of type 'number'")]
-        [InlineData("/api/products/true", "boolean", null)]
-        [InlineData("/api/products/1", "number", null)]
-        [InlineData("/api/products/foo", "string", null)]
+        [InlineData("/api/products/foo", JsonSchemaType.Boolean, "Parameter 'param' is not of type 'boolean'")]
+        [InlineData("/api/products/foo", JsonSchemaType.Number, "Parameter 'param' is not of type 'number'")]
+        [InlineData("/api/products/true", JsonSchemaType.Boolean, null)]
+        [InlineData("/api/products/1", JsonSchemaType.Number, null)]
+        [InlineData("/api/products/foo", JsonSchemaType.String, null)]
         public void Validate_ThrowsException_IfPathParameterIsNotOfSpecifiedType(
             string uriString,
-            string specifiedType,
+            JsonSchemaType specifiedType,
             string expectedErrorMessage)
         {
             var openApiDocument = DocumentWithOperation("/api/products/{param}", OperationType.Get, new OpenApiOperation
@@ -162,17 +162,17 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         }
 
         [Theory]
-        [InlineData("/api/products?param=foo", "boolean", null, "Parameter 'param' is not of type 'boolean'")]
-        [InlineData("/api/products?param=foo", "number", null, "Parameter 'param' is not of type 'number'")]
-        [InlineData("/api/products?param=1&param=foo", "array", "number", "Parameter 'param' is not of type 'array[number]'")]
-        [InlineData("/api/products?param=true", "boolean", null, null)]
-        [InlineData("/api/products?param=1", "number", null, null)]
-        [InlineData("/api/products?param=foo", "string", null, null)]
-        [InlineData("/api/products?param=1&param=2", "array", "number", null)]
+        [InlineData("/api/products?param=foo", JsonSchemaType.Boolean, null, "Parameter 'param' is not of type 'boolean'")]
+        [InlineData("/api/products?param=foo", JsonSchemaType.Number, null, "Parameter 'param' is not of type 'number'")]
+        [InlineData("/api/products?param=1&param=foo", JsonSchemaType.Array, JsonSchemaType.Number, "Parameter 'param' is not of type 'array[Number]'")]
+        [InlineData("/api/products?param=true", JsonSchemaType.Boolean, null, null)]
+        [InlineData("/api/products?param=1", JsonSchemaType.Number, null, null)]
+        [InlineData("/api/products?param=foo", JsonSchemaType.String, null, null)]
+        [InlineData("/api/products?param=1&param=2", JsonSchemaType.Array, JsonSchemaType.Number, null)]
         public void Validate_ThrowsException_IfQueryParameterIsNotOfSpecifiedType(
             string path,
-            string specifiedType,
-            string specifiedItemsType,
+            JsonSchemaType specifiedType,
+            JsonSchemaType? specifiedItemsType,
             string expectedErrorMessage)
         {
             var openApiDocument = DocumentWithOperation("/api/products", OperationType.Get, new OpenApiOperation
@@ -206,17 +206,17 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         }
 
         [Theory]
-        [InlineData("foo", "boolean", null, "Parameter 'test-header' is not of type 'boolean'")]
-        [InlineData("foo", "number", null, "Parameter 'test-header' is not of type 'number'")]
-        [InlineData("1,foo", "array", "number", "Parameter 'test-header' is not of type 'array[number]'")]
-        [InlineData("true", "boolean", null, null)]
-        [InlineData("1", "number", null, null)]
-        [InlineData("foo", "string", null, null)]
-        [InlineData("1,2", "array", "number", null)]
+        [InlineData("foo", JsonSchemaType.Boolean, null, "Parameter 'test-header' is not of type 'boolean'")]
+        [InlineData("foo", JsonSchemaType.Number, null, "Parameter 'test-header' is not of type 'number'")]
+        [InlineData("1,foo", JsonSchemaType.Array, JsonSchemaType.Number, "Parameter 'test-header' is not of type 'array[Number]'")]
+        [InlineData("true", JsonSchemaType.Boolean, null, null)]
+        [InlineData("1", JsonSchemaType.Number, null, null)]
+        [InlineData("foo", JsonSchemaType.String, null, null)]
+        [InlineData("1,2", JsonSchemaType.Array, JsonSchemaType.Number, null)]
         public void Validate_ThrowsException_IfHeaderParameterIsNotOfSpecifiedType(
             string parameterValue,
-            string specifiedType,
-            string specifiedItemsType,
+            JsonSchemaType specifiedType,
+            JsonSchemaType? specifiedItemsType,
             string expectedErrorMessage)
         {
             var openApiDocument = DocumentWithOperation("/api/products", OperationType.Get, new OpenApiOperation
@@ -332,7 +332,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                         {
                             Schema = new OpenApiSchema
                             {
-                                Type = "object",
+                                Type = JsonSchemaType.Object,
                                 Required = new SortedSet<string> { "prop1", "prop2" }
                             }
                         }

--- a/test/Swashbuckle.AspNetCore.ApiTesting.Test/RequestValidatorTests.cs
+++ b/test/Swashbuckle.AspNetCore.ApiTesting.Test/RequestValidatorTests.cs
@@ -186,7 +186,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                         Schema = new OpenApiSchema
                         {
                             Type = specifiedType,
-                            Items = (specifiedItemsType != null) ? new OpenApiSchema { Type = specifiedItemsType } : null
+                            Items = specifiedItemsType != null ? new OpenApiSchema { Type = specifiedItemsType } : null
                         }
                     }
                 }
@@ -348,13 +348,13 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
 
             var exception = Record.Exception(() =>
             {
-                Subject(new[] { new JsonContentValidator() }).Validate(request, openApiDocument, "/api/products", OperationType.Post);
+                Subject([new JsonContentValidator()]).Validate(request, openApiDocument, "/api/products", OperationType.Post);
             });
 
             Assert.Equal(expectedErrorMessage, exception?.Message);
         }
 
-        private OpenApiDocument DocumentWithOperation(string pathTemplate, OperationType operationType, OpenApiOperation operationSpec)
+        private static OpenApiDocument DocumentWithOperation(string pathTemplate, OperationType operationType, OpenApiOperation operationSpec)
         {
             return new OpenApiDocument
             {
@@ -375,9 +375,9 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
             };
         }
 
-        private RequestValidator Subject(IEnumerable<IContentValidator> contentValidators = null)
+        private static RequestValidator Subject(IEnumerable<IContentValidator> contentValidators = null)
         {
-            return new RequestValidator(contentValidators ?? new IContentValidator[] { });
+            return new RequestValidator(contentValidators ?? []);
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.ApiTesting.Test/ResponseValidatorTests.cs
+++ b/test/Swashbuckle.AspNetCore.ApiTesting.Test/ResponseValidatorTests.cs
@@ -222,14 +222,14 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
 
             var exception = Record.Exception(() =>
             {
-                Subject(new[] { new JsonContentValidator() }).Validate(response, openApiDocument, "/api/products/1", OperationType.Get, "200");
+                Subject([new JsonContentValidator()]).Validate(response, openApiDocument, "/api/products/1", OperationType.Get, "200");
             });
 
             Assert.Equal(expectedErrorMessage, exception?.Message);
         }
 
 
-        private OpenApiDocument DocumentWithOperation(string pathTemplate, OperationType operationType, OpenApiOperation operationSpec)
+        private static OpenApiDocument DocumentWithOperation(string pathTemplate, OperationType operationType, OpenApiOperation operationSpec)
         {
             return new OpenApiDocument
             {
@@ -250,9 +250,9 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
             };
         }
 
-        private ResponseValidator Subject(IEnumerable<IContentValidator> contentValidators = null)
+        private static ResponseValidator Subject(IEnumerable<IContentValidator> contentValidators = null)
         {
-            return new ResponseValidator(contentValidators ?? new IContentValidator[] { });
+            return new ResponseValidator(contentValidators ?? []);
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.ApiTesting.Test/ResponseValidatorTests.cs
+++ b/test/Swashbuckle.AspNetCore.ApiTesting.Test/ResponseValidatorTests.cs
@@ -75,17 +75,17 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
         }
 
         [Theory]
-        [InlineData("foo", "boolean", null, "Header 'test-header' is not of type 'boolean'")]
-        [InlineData("foo", "number", null, "Header 'test-header' is not of type 'number'")]
-        [InlineData("1,foo", "array", "number", "Header 'test-header' is not of type 'array[number]'")]
-        [InlineData("true", "boolean", null, null)]
-        [InlineData("1", "number", null, null)]
-        [InlineData("foo", "string", null, null)]
-        [InlineData("1,2", "array", "number", null)]
+        [InlineData("foo", JsonSchemaType.Boolean, null, "Header 'test-header' is not of type 'boolean'")]
+        [InlineData("foo", JsonSchemaType.Number, null, "Header 'test-header' is not of type 'number'")]
+        [InlineData("1,foo", JsonSchemaType.Array, JsonSchemaType.Number, "Header 'test-header' is not of type 'array[Number]'")]
+        [InlineData("true", JsonSchemaType.Boolean, null, null)]
+        [InlineData("1", JsonSchemaType.Number, null, null)]
+        [InlineData("foo", JsonSchemaType.String, null, null)]
+        [InlineData("1,2", JsonSchemaType.Array, JsonSchemaType.Number, null)]
         public void Validate_ThrowsException_IfHeaderIsNotOfSpecifiedType(
             string headerValue,
-            string specifiedType,
-            string specifiedItemsType,
+            JsonSchemaType specifiedType,
+            JsonSchemaType? specifiedItemsType,
             string expectedErrorMessage)
         {
             var openApiDocument = DocumentWithOperation("/api/products", OperationType.Post, new OpenApiOperation
@@ -207,7 +207,7 @@ namespace Swashbuckle.AspNetCore.ApiTesting.Test
                             {
                                 Schema = new OpenApiSchema
                                 {
-                                    Type = "object",
+                                    Type = JsonSchemaType.Object,
                                     Required = new SortedSet<string> { "prop1", "prop2" }
                                 }
                             }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/DocumentProviderTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/DocumentProviderTests.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.ApiDescriptions;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Reader;
 using Microsoft.OpenApi.Readers;
 using Swashbuckle.AspNetCore.Swagger;
 using Xunit;
@@ -12,6 +14,12 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
     [Collection("TestSite")]
     public class DocumentProviderTests
     {
+        static DocumentProviderTests()
+        {
+            // TODO Make an assembly fixture
+            OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
+        }
+
         [Theory]
         [InlineData(typeof(Basic.Startup), new[] { "v1" })]
         [InlineData(typeof(CustomUIConfig.Startup), new[] { "v1" })]
@@ -53,9 +61,9 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
             }
 
             stream.Position = 0L;
-            new OpenApiStreamReader().Read(stream, out var diagnostic);
-            Assert.NotNull(diagnostic);
-            Assert.Empty(diagnostic.Errors);
+            var result = await OpenApiDocument.LoadAsync(stream);
+            Assert.NotNull(result.Diagnostic);
+            Assert.Empty(result.Diagnostic.Errors);
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API V1",
     "description": "A sample API for testing Swashbuckle",

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=ConfigFromFile.Startup_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=ConfigFromFile.Startup_swaggerRequestUri=v1.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "ConfigFromFile",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=CustomUIConfig.Startup_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=CustomUIConfig.Startup_swaggerRequestUri=v1.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "CustomUIConfig",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=GenericControllers.Startup_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=GenericControllers.Startup_swaggerRequestUri=v1.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "1"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=MultipleVersions.Startup_swaggerRequestUri=1.0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=MultipleVersions.Startup_swaggerRequestUri=1.0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Sample API 1.0",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/RecursiveCallSchemaFilter.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/RecursiveCallSchemaFilter.cs
@@ -7,7 +7,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
     {
         public void Apply(OpenApiSchema model, SchemaFilterContext context)
         {
-            if (model.Type == "object")
+            if (model.Type == JsonSchemaType.Object)
             {
                 model.Properties.Add("Self", context.SchemaGenerator.GenerateSchema(context.Type, context.SchemaRepository));
             }

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/VendorExtensionsSchemaFilter.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/VendorExtensionsSchemaFilter.cs
@@ -8,7 +8,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
     {
         public void Apply(OpenApiSchema schema, SchemaFilterContext context)
         {
-            schema.Extensions.Add("X-foo", new OpenApiString("bar"));
+            schema.Extensions.Add("X-foo", new OpenApiAny("bar"));
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -29,49 +29,49 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         {
             var schema = Subject().GenerateSchema(type, new SchemaRepository());
 
-            Assert.Equal("string", schema.Type);
+            Assert.Equal(JsonSchemaType.String, schema.Type);
             Assert.Equal("binary", schema.Format);
         }
 
         [Theory]
-        [InlineData(typeof(bool), "boolean", null)]
-        [InlineData(typeof(byte), "integer", "int32")]
-        [InlineData(typeof(sbyte), "integer", "int32")]
-        [InlineData(typeof(short), "integer", "int32")]
-        [InlineData(typeof(ushort), "integer", "int32")]
-        [InlineData(typeof(int), "integer", "int32")]
-        [InlineData(typeof(uint), "integer", "int32")]
-        [InlineData(typeof(long), "integer", "int64")]
-        [InlineData(typeof(ulong), "integer", "int64")]
-        [InlineData(typeof(float), "number", "float")]
-        [InlineData(typeof(double), "number", "double")]
-        [InlineData(typeof(decimal), "number", "double")]
-        [InlineData(typeof(string), "string", null)]
-        [InlineData(typeof(char), "string", null)]
-        [InlineData(typeof(byte[]), "string", "byte")]
-        [InlineData(typeof(DateTime), "string", "date-time")]
-        [InlineData(typeof(DateTimeOffset), "string", "date-time")]
-        [InlineData(typeof(TimeSpan), "string", "date-span")]
-        [InlineData(typeof(Guid), "string", "uuid")]
-        [InlineData(typeof(Uri), "string", "uri")]
-        [InlineData(typeof(Version), "string", null)]
-        [InlineData(typeof(DateOnly), "string", "date")]
-        [InlineData(typeof(TimeOnly), "string", "time")]
-        [InlineData(typeof(bool?), "boolean", null)]
-        [InlineData(typeof(int?), "integer", "int32")]
-        [InlineData(typeof(DateTime?), "string", "date-time")]
-        [InlineData(typeof(Guid?), "string", "uuid")]
-        [InlineData(typeof(DateOnly?), "string", "date")]
-        [InlineData(typeof(TimeOnly?), "string", "time")]
+        [InlineData(typeof(bool), JsonSchemaType.Boolean, null)]
+        [InlineData(typeof(byte), JsonSchemaType.Integer, "int32")]
+        [InlineData(typeof(sbyte), JsonSchemaType.Integer, "int32")]
+        [InlineData(typeof(short), JsonSchemaType.Integer, "int32")]
+        [InlineData(typeof(ushort), JsonSchemaType.Integer, "int32")]
+        [InlineData(typeof(int), JsonSchemaType.Integer, "int32")]
+        [InlineData(typeof(uint), JsonSchemaType.Integer, "int32")]
+        [InlineData(typeof(long), JsonSchemaType.Integer, "int64")]
+        [InlineData(typeof(ulong), JsonSchemaType.Integer, "int64")]
+        [InlineData(typeof(float), JsonSchemaType.Number, "float")]
+        [InlineData(typeof(double), JsonSchemaType.Number, "double")]
+        [InlineData(typeof(decimal), JsonSchemaType.Number, "double")]
+        [InlineData(typeof(string), JsonSchemaType.String, null)]
+        [InlineData(typeof(char), JsonSchemaType.String, null)]
+        [InlineData(typeof(byte[]), JsonSchemaType.String, "byte")]
+        [InlineData(typeof(DateTime), JsonSchemaType.String, "date-time")]
+        [InlineData(typeof(DateTimeOffset), JsonSchemaType.String, "date-time")]
+        [InlineData(typeof(TimeSpan), JsonSchemaType.String, "date-span")]
+        [InlineData(typeof(Guid), JsonSchemaType.String, "uuid")]
+        [InlineData(typeof(Uri), JsonSchemaType.String, "uri")]
+        [InlineData(typeof(Version), JsonSchemaType.String, null)]
+        [InlineData(typeof(DateOnly), JsonSchemaType.String, "date")]
+        [InlineData(typeof(TimeOnly), JsonSchemaType.String, "time")]
+        [InlineData(typeof(bool?), JsonSchemaType.Boolean, null)]
+        [InlineData(typeof(int?), JsonSchemaType.Integer, "int32")]
+        [InlineData(typeof(DateTime?), JsonSchemaType.String, "date-time")]
+        [InlineData(typeof(Guid?), JsonSchemaType.String, "uuid")]
+        [InlineData(typeof(DateOnly?), JsonSchemaType.String, "date")]
+        [InlineData(typeof(TimeOnly?), JsonSchemaType.String, "time")]
 #if NET7_0_OR_GREATER
-        [InlineData(typeof(Int128), "integer", "int128")]
-        [InlineData(typeof(Int128?), "integer", "int128")]
-        [InlineData(typeof(UInt128), "integer", "int128")]
-        [InlineData(typeof(UInt128?), "integer", "int128")]
+        [InlineData(typeof(Int128), JsonSchemaType.Integer, "int128")]
+        [InlineData(typeof(Int128?), JsonSchemaType.Integer, "int128")]
+        [InlineData(typeof(UInt128), JsonSchemaType.Integer, "int128")]
+        [InlineData(typeof(UInt128?), JsonSchemaType.Integer, "int128")]
 #endif
         public void GenerateSchema_GeneratesPrimitiveSchema_IfPrimitiveOrNullablePrimitiveType(
             Type type,
-            string expectedSchemaType,
+            JsonSchemaType expectedSchemaType,
             string expectedFormat)
         {
             var schema = Subject().GenerateSchema(type, new SchemaRepository());
@@ -81,13 +81,13 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         }
 
         [Theory]
-        [InlineData(typeof(IntEnum), "integer", "int32", 3)]
-        [InlineData(typeof(LongEnum), "integer", "int64", 3)]
-        [InlineData(typeof(IntEnum?), "integer", "int32", 3)]
-        [InlineData(typeof(LongEnum?), "integer", "int64", 3)]
+        [InlineData(typeof(IntEnum), JsonSchemaType.Integer, "int32", 3)]
+        [InlineData(typeof(LongEnum), JsonSchemaType.Integer, "int64", 3)]
+        [InlineData(typeof(IntEnum?), JsonSchemaType.Integer, "int32", 3)]
+        [InlineData(typeof(LongEnum?), JsonSchemaType.Integer, "int64", 3)]
         public void GenerateSchema_GeneratesReferencedEnumSchema_IfEnumOrNullableEnumType(
             Type type,
-            string expectedSchemaType,
+            JsonSchemaType expectedSchemaType,
             string expectedFormat,
             int expectedEnumCount)
         {
@@ -117,17 +117,17 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         }
 
         [Theory]
-        [InlineData(typeof(IDictionary<string, int>), "integer")]
-        [InlineData(typeof(IReadOnlyDictionary<string, bool>), "boolean")]
+        [InlineData(typeof(IDictionary<string, int>), JsonSchemaType.Integer)]
+        [InlineData(typeof(IReadOnlyDictionary<string, bool>), JsonSchemaType.Boolean)]
         [InlineData(typeof(IDictionary), null)]
         [InlineData(typeof(ExpandoObject), null)]
         public void GenerateSchema_GeneratesDictionarySchema_IfDictionaryType(
             Type type,
-            string expectedAdditionalPropertiesType)
+            JsonSchemaType? expectedAdditionalPropertiesType)
         {
             var schema = Subject().GenerateSchema(type, new SchemaRepository());
 
-            Assert.Equal("object", schema.Type);
+            Assert.Equal(JsonSchemaType.Object, schema.Type);
             Assert.True(schema.AdditionalPropertiesAllowed);
             Assert.NotNull(schema.AdditionalProperties);
             Assert.Equal(expectedAdditionalPropertiesType, schema.AdditionalProperties.Type);
@@ -138,7 +138,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         {
             var schema = Subject().GenerateSchema(typeof(IDictionary<IntEnum, int>), new SchemaRepository());
 
-            Assert.Equal("object", schema.Type);
+            Assert.Equal(JsonSchemaType.Object, schema.Type);
             Assert.Equal(["Value2", "Value4", "Value8"], schema.Properties.Keys);
         }
 
@@ -151,26 +151,26 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 
             Assert.NotNull(referenceSchema.Reference);
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal("object", schema.Type);
+            Assert.Equal(JsonSchemaType.Object, schema.Type);
             Assert.True(schema.AdditionalPropertiesAllowed);
             Assert.NotNull(schema.AdditionalProperties);
             Assert.Equal(schema.AdditionalProperties.Reference.Id, referenceSchema.Reference.Id); // ref to self
         }
 
         [Theory]
-        [InlineData(typeof(int[]), "integer", "int32")]
-        [InlineData(typeof(IEnumerable<string>), "string", null)]
-        [InlineData(typeof(DateTime?[]), "string", "date-time")]
-        [InlineData(typeof(int[][]), "array", null)]
+        [InlineData(typeof(int[]), JsonSchemaType.Integer, "int32")]
+        [InlineData(typeof(IEnumerable<string>), JsonSchemaType.String, null)]
+        [InlineData(typeof(DateTime?[]), JsonSchemaType.String, "date-time")]
+        [InlineData(typeof(int[][]), JsonSchemaType.Array, null)]
         [InlineData(typeof(IList), null, null)]
         public void GenerateSchema_GeneratesArraySchema_IfEnumerableType(
             Type type,
-            string expectedItemsType,
+            JsonSchemaType? expectedItemsType,
             string expectedItemsFormat)
         {
             var schema = Subject().GenerateSchema(type, new SchemaRepository());
 
-            Assert.Equal("array", schema.Type);
+            Assert.Equal(JsonSchemaType.Array, schema.Type);
             Assert.NotNull(schema.Items);
             Assert.Equal(expectedItemsType, schema.Items.Type);
             Assert.Equal(expectedItemsFormat, schema.Items.Format);
@@ -184,7 +184,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         {
             var schema = Subject().GenerateSchema(type, new SchemaRepository());
 
-            Assert.Equal("array", schema.Type);
+            Assert.Equal(JsonSchemaType.Array, schema.Type);
             Assert.True(schema.UniqueItems);
         }
 
@@ -197,7 +197,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 
             Assert.NotNull(referenceSchema.Reference);
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal("array", schema.Type);
+            Assert.Equal(JsonSchemaType.Array, schema.Type);
             Assert.Equal(schema.Items.Reference.Id, referenceSchema.Reference.Id); // ref to self
         }
 
@@ -218,7 +218,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Assert.NotNull(referenceSchema.Reference);
             Assert.Equal(expectedSchemaId, referenceSchema.Reference.Id);
             var schema = schemaRepository.Schemas[expectedSchemaId];
-            Assert.Equal("object", schema.Type);
+            Assert.Equal(JsonSchemaType.Object, schema.Type);
             Assert.Equal(expectedProperties, schema.Properties.Keys);
             Assert.False(schema.AdditionalPropertiesAllowed);
         }
@@ -231,7 +231,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             var referenceSchema = Subject().GenerateSchema(typeof(SubType1), schemaRepository);
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal("object", schema.Type);
+            Assert.Equal(JsonSchemaType.Object, schema.Type);
             Assert.Equal(["Property1", "BaseProperty"], schema.Properties.Keys);
         }
 
@@ -243,7 +243,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             var referenceSchema = Subject().GenerateSchema(typeof(IndexedType), schemaRepository);
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal("object", schema.Type);
+            Assert.Equal(JsonSchemaType.Object, schema.Type);
             Assert.Equal(["Property1"], schema.Properties.Keys);
         }
 
@@ -272,8 +272,8 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.DoubleWithDefault), "1.7976931348623157E+308")]
         [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.DoubleWithDefaultOfDifferentType), "1")]
         [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.StringWithDefault), "\"foobar\"")]
-        [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.IntArrayWithDefault), "[\n  1,\n  2,\n  3\n]")]
-        [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.StringArrayWithDefault), "[\n  \"foo\",\n  \"bar\"\n]")]
+        [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.IntArrayWithDefault), "[1,2,3]")]
+        [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.StringArrayWithDefault), "[\"foo\",\"bar\"]")]
         [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.NullableIntWithDefaultNullValue), "null")]
         [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.NullableIntWithDefaultValue), "2147483647")]
         [UseInvariantCulture]
@@ -289,7 +289,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
             var propertySchema = schema.Properties[propertyName];
             Assert.NotNull(propertySchema.Default);
-            Assert.Equal(expectedDefaultAsJson, propertySchema.Default.ToJson());
+            Assert.Equal(expectedDefaultAsJson, propertySchema.Default.ToJsonString());
         }
 
         [Fact]
@@ -326,7 +326,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Assert.Equal(true, schema.Properties["IntWithExclusiveRange"].ExclusiveMinimum);
             Assert.Equal(true, schema.Properties["IntWithExclusiveRange"].ExclusiveMaximum);
             Assert.Equal("byte", schema.Properties["StringWithBase64"].Format);
-            Assert.Equal("string", schema.Properties["StringWithBase64"].Type);
+            Assert.Equal(JsonSchemaType.String, schema.Properties["StringWithBase64"].Type);
 #endif
             Assert.Null(schema.Properties["IntWithRange"].ExclusiveMinimum);
             Assert.Null(schema.Properties["IntWithRange"].ExclusiveMaximum);
@@ -381,11 +381,11 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Type type)
         {
             var subject = Subject(
-                configureGenerator: c => c.CustomTypeMappings.Add(mappingType, () => new OpenApiSchema { Type = "string" })
+                configureGenerator: c => c.CustomTypeMappings.Add(mappingType, () => new OpenApiSchema { Type = JsonSchemaType.String })
             );
             var schema = subject.GenerateSchema(type, new SchemaRepository());
 
-            Assert.Equal("string", schema.Type);
+            Assert.Equal(JsonSchemaType.String, schema.Type);
             Assert.Empty(schema.Properties);
         }
 
@@ -457,7 +457,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Assert.Equal(["Property1"], subSchema.Properties.Keys);
             // The base type schema
             var baseTypeSchema = schemaRepository.Schemas[baseSchema.Reference.Id];
-            Assert.Equal("object", baseTypeSchema.Type);
+            Assert.Equal(JsonSchemaType.Object, baseTypeSchema.Type);
             Assert.Equal(["BaseProperty"], baseTypeSchema.Properties.Keys);
         }
 
@@ -514,12 +514,12 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             // The base type schema
             Assert.NotNull(schema.OneOf[0].Reference);
             var baseSchema = schemaRepository.Schemas[schema.OneOf[0].Reference.Id];
-            Assert.Equal("object", baseSchema.Type);
+            Assert.Equal(JsonSchemaType.Object, baseSchema.Type);
             Assert.Equal(["BaseProperty"], baseSchema.Properties.Keys);
             // The first sub type schema
             Assert.NotNull(schema.OneOf[1].Reference);
             var subType1Schema = schemaRepository.Schemas[schema.OneOf[1].Reference.Id];
-            Assert.Equal("object", subType1Schema.Type);
+            Assert.Equal(JsonSchemaType.Object, subType1Schema.Type);
             Assert.NotNull(subType1Schema.AllOf);
             var allOf = Assert.Single(subType1Schema.AllOf);
             Assert.NotNull(allOf.Reference);
@@ -528,7 +528,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             // The second sub type schema
             Assert.NotNull(schema.OneOf[2].Reference);
             var subType2Schema = schemaRepository.Schemas[schema.OneOf[2].Reference.Id];
-            Assert.Equal("object", subType2Schema.Type);
+            Assert.Equal(JsonSchemaType.Object, subType2Schema.Type);
             Assert.NotNull(subType2Schema.AllOf);
             allOf = Assert.Single(subType2Schema.AllOf);
             Assert.NotNull(allOf.Reference);
@@ -560,7 +560,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 
             var schema = subject.GenerateSchema(typeof(IntEnum), new SchemaRepository());
 
-            Assert.Equal("integer", schema.Type);
+            Assert.Equal(JsonSchemaType.Integer, schema.Type);
             Assert.NotNull(schema.Enum);
         }
 
@@ -572,7 +572,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             var referenceSchema = Subject().GenerateSchema(typeof(ContainingType), schemaRepository);
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal("object", schema.Type);
+            Assert.Equal(JsonSchemaType.Object, schema.Type);
             Assert.Equal("NestedType", schema.Properties["Property1"].Reference.Id);
         }
 
@@ -585,7 +585,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 
             Assert.NotNull(referenceSchema.Items);
             Assert.NotNull(referenceSchema.Items.Type);
-            Assert.Equal("string", referenceSchema.Items.Type);
+            Assert.Equal(JsonSchemaType.String, referenceSchema.Items.Type);
         }
 
         [Fact]
@@ -596,8 +596,8 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             var referenceSchema = Subject().GenerateSchema(typeof(TypeWithOverriddenProperty), schemaRepository);
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal("object", schema.Type);
-            Assert.Equal("string", schema.Properties["Property1"].Type);
+            Assert.Equal(JsonSchemaType.Object, schema.Type);
+            Assert.Equal(JsonSchemaType.String, schema.Properties["Property1"].Type);
         }
 
         [Fact]
@@ -649,9 +649,9 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
             var propertySchema = schema.Properties[nameof(TypeWithDefaultAttributeOnEnum.EnumWithDefault)];
-            Assert.Equal("string", propertySchema.Type);
-            Assert.Equal(expectedEnumAsJson, propertySchema.Enum.Select(openApiAny => openApiAny.ToJson()));
-            Assert.Equal(expectedDefaultAsJson, propertySchema.Default.ToJson());
+            Assert.Equal(JsonSchemaType.String, propertySchema.Type);
+            Assert.Equal(expectedEnumAsJson, propertySchema.Enum.Select(openApiAny => openApiAny.ToJsonString()));
+            Assert.Equal(expectedDefaultAsJson, propertySchema.Default.ToJsonString());
         }
 
         [Theory]
@@ -736,8 +736,8 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             var referenceSchema = Subject().GenerateSchema(typeof(JsonConverterAnnotatedEnum), schemaRepository);
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal("string", schema.Type);
-            Assert.Equal(["\"Value1\"", "\"Value2\"", "\"X-foo\""], schema.Enum.Select(openApiAny => openApiAny.ToJson()));
+            Assert.Equal(JsonSchemaType.String, schema.Type);
+            Assert.Equal(["\"Value1\"", "\"Value2\"", "\"X-foo\""], schema.Enum.Select(openApiAny => openApiAny.ToJsonString()));
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -7,7 +7,6 @@ using System.Net;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.NewtonsoftJson;
-using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -140,7 +139,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             var schema = Subject().GenerateSchema(typeof(IDictionary<IntEnum, int>), new SchemaRepository());
 
             Assert.Equal("object", schema.Type);
-            Assert.Equal(new[] { "Value2", "Value4", "Value8" }, schema.Properties.Keys);
+            Assert.Equal(["Value2", "Value4", "Value8"], schema.Properties.Keys);
         }
 
         [Fact]
@@ -233,7 +232,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
             Assert.Equal("object", schema.Type);
-            Assert.Equal(new[] { "Property1", "BaseProperty" }, schema.Properties.Keys);
+            Assert.Equal(["Property1", "BaseProperty"], schema.Properties.Keys);
         }
 
         [Fact]
@@ -245,7 +244,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
             Assert.Equal("object", schema.Type);
-            Assert.Equal(new[] { "Property1" }, schema.Properties.Keys);
+            Assert.Equal(["Property1"], schema.Properties.Keys);
         }
 
         [Theory]
@@ -374,20 +373,19 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
         }
 
         [Theory]
-        [InlineData(typeof(ComplexType), typeof(ComplexType), "string")]
-        [InlineData(typeof(GenericType<int, string>), typeof(GenericType<int, string>), "string")]
-        [InlineData(typeof(GenericType<,>), typeof(GenericType<int, int>), "string")]
+        [InlineData(typeof(ComplexType), typeof(ComplexType))]
+        [InlineData(typeof(GenericType<int, string>), typeof(GenericType<int, string>))]
+        [InlineData(typeof(GenericType<,>), typeof(GenericType<int, int>))]
         public void GenerateSchema_SupportsOption_CustomTypeMappings(
             Type mappingType,
-            Type type,
-            string expectedSchemaType)
+            Type type)
         {
             var subject = Subject(
                 configureGenerator: c => c.CustomTypeMappings.Add(mappingType, () => new OpenApiSchema { Type = "string" })
             );
             var schema = subject.GenerateSchema(type, new SchemaRepository());
 
-            Assert.Equal(expectedSchemaType, schema.Type);
+            Assert.Equal("string", schema.Type);
             Assert.Empty(schema.Properties);
         }
 
@@ -456,11 +454,11 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Assert.Equal("BaseType", baseSchema.Reference.Id);
             Assert.NotNull(baseSchema.Reference);
             var subSchema = schema.AllOf[1];
-            Assert.Equal(new[] { "Property1" }, subSchema.Properties.Keys);
+            Assert.Equal(["Property1"], subSchema.Properties.Keys);
             // The base type schema
             var baseTypeSchema = schemaRepository.Schemas[baseSchema.Reference.Id];
             Assert.Equal("object", baseTypeSchema.Type);
-            Assert.Equal(new[] { "BaseProperty" }, baseTypeSchema.Properties.Keys);
+            Assert.Equal(["BaseProperty"], baseTypeSchema.Properties.Keys);
         }
 
         [Fact]
@@ -469,13 +467,13 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             var subject = Subject(configureGenerator: c =>
             {
                 c.UseAllOfForInheritance = true;
-                c.SubTypesSelector = (type) => new[] { typeof(SubType1) };
+                c.SubTypesSelector = (type) => [typeof(SubType1)];
             });
             var schemaRepository = new SchemaRepository();
 
             var schema = subject.GenerateSchema(typeof(BaseType), schemaRepository);
 
-            Assert.Equal(new[] { "SubType1", "BaseType" }, schemaRepository.Schemas.Keys);
+            Assert.Equal(["SubType1", "BaseType"], schemaRepository.Schemas.Keys);
         }
 
         [Fact]
@@ -517,7 +515,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             Assert.NotNull(schema.OneOf[0].Reference);
             var baseSchema = schemaRepository.Schemas[schema.OneOf[0].Reference.Id];
             Assert.Equal("object", baseSchema.Type);
-            Assert.Equal(new[] { "BaseProperty" }, baseSchema.Properties.Keys);
+            Assert.Equal(["BaseProperty"], baseSchema.Properties.Keys);
             // The first sub type schema
             Assert.NotNull(schema.OneOf[1].Reference);
             var subType1Schema = schemaRepository.Schemas[schema.OneOf[1].Reference.Id];
@@ -526,7 +524,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             var allOf = Assert.Single(subType1Schema.AllOf);
             Assert.NotNull(allOf.Reference);
             Assert.Equal("BaseType", allOf.Reference.Id);
-            Assert.Equal(new[] { "Property1" }, subType1Schema.Properties.Keys);
+            Assert.Equal(["Property1"], subType1Schema.Properties.Keys);
             // The second sub type schema
             Assert.NotNull(schema.OneOf[2].Reference);
             var subType2Schema = schemaRepository.Schemas[schema.OneOf[2].Reference.Id];
@@ -535,7 +533,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
             allOf = Assert.Single(subType2Schema.AllOf);
             Assert.NotNull(allOf.Reference);
             Assert.Equal("BaseType", allOf.Reference.Id);
-            Assert.Equal(new[] { "Property2" }, subType2Schema.Properties.Keys);
+            Assert.Equal(["Property2"], subType2Schema.Properties.Keys);
         }
 
         [Fact]
@@ -739,7 +737,7 @@ namespace Swashbuckle.AspNetCore.Newtonsoft.Test
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
             Assert.Equal("string", schema.Type);
-            Assert.Equal(new[] { "\"Value1\"", "\"Value2\"", "\"X-foo\"" }, schema.Enum.Select(openApiAny => openApiAny.ToJson()));
+            Assert.Equal(["\"Value1\"", "\"Value2\"", "\"X-foo\""], schema.Enum.Select(openApiAny => openApiAny.ToJson()));
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/RecursiveCallSchemaFilter.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/RecursiveCallSchemaFilter.cs
@@ -6,7 +6,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
     {
         public void Apply(OpenApiSchema model, SchemaFilterContext context)
         {
-            if (model.Type == "object")
+            if (model.Type == JsonSchemaType.Object)
             {
                 model.Properties.Add("Self", context.SchemaGenerator.GenerateSchema(context.Type, context.SchemaRepository));
             }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TestDocumentFilter.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TestDocumentFilter.cs
@@ -10,8 +10,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
     {
         public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
         {
-            swaggerDoc.Extensions.Add("X-foo", new OpenApiString("bar"));
-            swaggerDoc.Extensions.Add("X-docName", new OpenApiString(context.DocumentName));
+            swaggerDoc.Extensions.Add("X-foo", new OpenApiAny("bar"));
+            swaggerDoc.Extensions.Add("X-docName", new OpenApiAny(context.DocumentName));
             context.SchemaGenerator.GenerateSchema(typeof(ComplexType), context.SchemaRepository);
         }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TestOperationFilter.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TestOperationFilter.cs
@@ -9,8 +9,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
     {
         public void Apply(OpenApiOperation operation, OperationFilterContext context)
         {
-            operation.Extensions.Add("X-foo", new OpenApiString("bar"));
-            operation.Extensions.Add("X-docName", new OpenApiString(context.DocumentName));
+            operation.Extensions.Add("X-foo", new OpenApiAny("bar"));
+            operation.Extensions.Add("X-docName", new OpenApiAny(context.DocumentName));
         }
 
         public Task ApplyAsync(OpenApiOperation operation, OperationFilterContext context, CancellationToken cancellationToken)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TestParameterFilter.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TestParameterFilter.cs
@@ -9,8 +9,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
     {
         public void Apply(OpenApiParameter parameter, ParameterFilterContext context)
         {
-            parameter.Extensions.Add("X-foo", new OpenApiString("bar"));
-            parameter.Extensions.Add("X-docName", new OpenApiString(context.DocumentName));
+            parameter.Extensions.Add("X-foo", new OpenApiAny("bar"));
+            parameter.Extensions.Add("X-docName", new OpenApiAny(context.DocumentName));
         }
 
         public Task ApplyAsync(OpenApiParameter parameter, ParameterFilterContext context, CancellationToken cancellationToken)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TestRequestBodyFilter.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TestRequestBodyFilter.cs
@@ -9,8 +9,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
     {
         public void Apply(OpenApiRequestBody requestBody, RequestBodyFilterContext context)
         {
-            requestBody.Extensions.Add("X-foo", new OpenApiString("bar"));
-            requestBody.Extensions.Add("X-docName", new OpenApiString(context.DocumentName));
+            requestBody.Extensions.Add("X-foo", new OpenApiAny("bar"));
+            requestBody.Extensions.Add("X-docName", new OpenApiAny(context.DocumentName));
         }
 
         public Task ApplyAsync(OpenApiRequestBody requestBody, RequestBodyFilterContext context, CancellationToken cancellationToken)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TestSchemaFilter.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TestSchemaFilter.cs
@@ -7,8 +7,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
     {
         public void Apply(OpenApiSchema schema, SchemaFilterContext context)
         {
-            schema.Extensions.Add("X-foo", new OpenApiString("bar"));
-            schema.Extensions.Add("X-docName", new OpenApiString(context.DocumentName));
+            schema.Extensions.Add("X-foo", new OpenApiAny("bar"));
+            schema.Extensions.Add("X-docName", new OpenApiAny(context.DocumentName));
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -85,13 +85,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
-        [InlineData(typeof(IntEnum), "integer", "int32", "2", "4", "8")]
-        [InlineData(typeof(LongEnum), "integer", "int64", "2", "4", "8")]
-        [InlineData(typeof(IntEnum?), "integer", "int32", "2", "4", "8")]
-        [InlineData(typeof(LongEnum?), "integer", "int64", "2", "4", "8")]
+        [InlineData(typeof(IntEnum), "int32", "2", "4", "8")]
+        [InlineData(typeof(LongEnum), "int64", "2", "4", "8")]
+        [InlineData(typeof(IntEnum?), "int32", "2", "4", "8")]
+        [InlineData(typeof(LongEnum?), "int64", "2", "4", "8")]
         public void GenerateSchema_GeneratesReferencedEnumSchema_IfEnumOrNullableEnumType(
             Type type,
-            string expectedSchemaType,
             string expectedFormat,
             params string[] expectedEnumAsJson)
         {
@@ -101,7 +100,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.NotNull(referenceSchema.Reference);
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal(expectedSchemaType, schema.Type);
+            Assert.Equal("integer", schema.Type);
             Assert.Equal(expectedFormat, schema.Format);
             Assert.NotNull(schema.Enum);
             Assert.Equal(expectedEnumAsJson, schema.Enum.Select(openApiAny => openApiAny.ToJson()));
@@ -228,7 +227,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
             Assert.Equal("object", schema.Type);
-            Assert.Equal(new[] { "BaseProperty", "Property1" }, schema.Properties.Keys);
+            Assert.Equal(["BaseProperty", "Property1"], schema.Properties.Keys);
         }
 
         [Theory]
@@ -269,7 +268,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
             Assert.Equal("object", schema.Type);
-            Assert.Equal(new[] { "Property1" }, schema.Properties.Keys);
+            Assert.Equal(["Property1"], schema.Properties.Keys);
         }
 
         [Theory]
@@ -483,20 +482,19 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
-        [InlineData(typeof(ComplexType), typeof(ComplexType), "string")]
-        [InlineData(typeof(GenericType<int, string>), typeof(GenericType<int, string>), "string")]
-        [InlineData(typeof(GenericType<,>), typeof(GenericType<int, int>), "string")]
+        [InlineData(typeof(ComplexType), typeof(ComplexType))]
+        [InlineData(typeof(GenericType<int, string>), typeof(GenericType<int, string>))]
+        [InlineData(typeof(GenericType<,>), typeof(GenericType<int, int>))]
         public void GenerateSchema_SupportsOption_CustomTypeMappings(
             Type mappingType,
-            Type type,
-            string expectedSchemaType)
+            Type type)
         {
             var subject = Subject(
                 configureGenerator: c => c.CustomTypeMappings.Add(mappingType, () => new OpenApiSchema { Type = "string" })
             );
             var schema = subject.GenerateSchema(type, new SchemaRepository());
 
-            Assert.Equal(expectedSchemaType, schema.Type);
+            Assert.Equal("string", schema.Type);
             Assert.Empty(schema.Properties);
         }
 
@@ -564,11 +562,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal("BaseType", baseSchema.Reference.Id);
             Assert.NotNull(baseSchema.Reference);
             var subSchema = schema.AllOf[1];
-            Assert.Equal(new[] { "Property1" }, subSchema.Properties.Keys);
+            Assert.Equal(["Property1"], subSchema.Properties.Keys);
             // The base type schema
             var baseTypeSchema = schemaRepository.Schemas[baseSchema.Reference.Id];
             Assert.Equal("object", baseTypeSchema.Type);
-            Assert.Equal(new[] { "BaseProperty" }, baseTypeSchema.Properties.Keys);
+            Assert.Equal(["BaseProperty"], baseTypeSchema.Properties.Keys);
         }
 
         [Fact]
@@ -577,13 +575,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var subject = Subject(configureGenerator: c =>
             {
                 c.UseAllOfForInheritance = true;
-                c.SubTypesSelector = (type) => new[] { typeof(SubType1) };
+                c.SubTypesSelector = (type) => [typeof(SubType1)];
             });
             var schemaRepository = new SchemaRepository();
 
             var schema = subject.GenerateSchema(typeof(BaseType), schemaRepository);
 
-            Assert.Equal(new[] { "SubType1", "BaseType" }, schemaRepository.Schemas.Keys);
+            Assert.Equal(["SubType1", "BaseType"], schemaRepository.Schemas.Keys);
 
             var subSchema = schemaRepository.Schemas["SubType1"];
             Assert.NotNull(subSchema.AllOf);
@@ -596,13 +594,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var subject = Subject(configureGenerator: c =>
             {
                 c.UseAllOfForInheritance = true;
-                c.SubTypesSelector = (type) => type == typeof(BaseSecondLevelType) ? new[] { typeof(SubSubSecondLevelType) } : Array.Empty<Type>();
+                c.SubTypesSelector = (type) => type == typeof(BaseSecondLevelType) ? [typeof(SubSubSecondLevelType)] : Array.Empty<Type>();
             });
             var schemaRepository = new SchemaRepository();
 
             var schema = subject.GenerateSchema(typeof(BaseSecondLevelType), schemaRepository);
 
-            Assert.Equal(new[] { "SubSubSecondLevelType", "BaseSecondLevelType" }, schemaRepository.Schemas.Keys);
+            Assert.Equal(["SubSubSecondLevelType", "BaseSecondLevelType"], schemaRepository.Schemas.Keys);
 
             var subSchema = schemaRepository.Schemas["SubSubSecondLevelType"];
             Assert.NotNull(subSchema.AllOf);
@@ -648,7 +646,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.NotNull(schema.OneOf[0].Reference);
             var baseSchema = schemaRepository.Schemas[schema.OneOf[0].Reference.Id];
             Assert.Equal("object", baseSchema.Type);
-            Assert.Equal(new[] { "BaseProperty" }, baseSchema.Properties.Keys);
+            Assert.Equal(["BaseProperty"], baseSchema.Properties.Keys);
             // The first sub type schema
             Assert.NotNull(schema.OneOf[1].Reference);
             var subType1Schema = schemaRepository.Schemas[schema.OneOf[1].Reference.Id];
@@ -657,7 +655,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var allOf = Assert.Single(subType1Schema.AllOf);
             Assert.NotNull(allOf.Reference);
             Assert.Equal("BaseType", allOf.Reference.Id);
-            Assert.Equal(new[] { "Property1" }, subType1Schema.Properties.Keys);
+            Assert.Equal(["Property1"], subType1Schema.Properties.Keys);
             // The second sub type schema
             Assert.NotNull(schema.OneOf[2].Reference);
             var subType2Schema = schemaRepository.Schemas[schema.OneOf[2].Reference.Id];
@@ -666,7 +664,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             allOf = Assert.Single(subType2Schema.AllOf);
             Assert.NotNull(allOf.Reference);
             Assert.Equal("BaseType", allOf.Reference.Id);
-            Assert.Equal(new[] { "Property2" }, subType2Schema.Properties.Keys);
+            Assert.Equal(["Property2"], subType2Schema.Properties.Keys);
         }
 
         [Fact]
@@ -1132,7 +1130,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.NotNull(referenceSchema.Reference);
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal(new[] { "property1", "property2" }, schema.Properties.Keys);
+            Assert.Equal(["property1", "property2"], schema.Properties.Keys);
         }
 
         [Theory]
@@ -1178,7 +1176,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
             Assert.Equal("string", schema.Type);
-            Assert.Equal(new[] { "\"Value1\"", "\"Value2\"", "\"X\"" }, schema.Enum.Select(openApiAny => openApiAny.ToJson()));
+            Assert.Equal(["\"Value1\"", "\"Value2\"", "\"X\""], schema.Enum.Select(openApiAny => openApiAny.ToJson()));
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -33,49 +33,49 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         {
             var schema = Subject().GenerateSchema(type, new SchemaRepository());
 
-            Assert.Equal("string", schema.Type);
+            Assert.Equal(JsonSchemaType.String, schema.Type);
             Assert.Equal("binary", schema.Format);
         }
 
         [Theory]
-        [InlineData(typeof(bool), "boolean", null)]
-        [InlineData(typeof(byte), "integer", "int32")]
-        [InlineData(typeof(sbyte), "integer", "int32")]
-        [InlineData(typeof(short), "integer", "int32")]
-        [InlineData(typeof(ushort), "integer", "int32")]
-        [InlineData(typeof(int), "integer", "int32")]
-        [InlineData(typeof(uint), "integer", "int32")]
-        [InlineData(typeof(long), "integer", "int64")]
-        [InlineData(typeof(ulong), "integer", "int64")]
-        [InlineData(typeof(float), "number", "float")]
-        [InlineData(typeof(double), "number", "double")]
-        [InlineData(typeof(decimal), "number", "double")]
-        [InlineData(typeof(string), "string", null)]
-        [InlineData(typeof(char), "string", null)]
-        [InlineData(typeof(byte[]), "string", "byte")]
-        [InlineData(typeof(DateTime), "string", "date-time")]
-        [InlineData(typeof(DateTimeOffset), "string", "date-time")]
-        [InlineData(typeof(TimeSpan), "string", "date-span")]
-        [InlineData(typeof(Guid), "string", "uuid")]
-        [InlineData(typeof(Uri), "string", "uri")]
-        [InlineData(typeof(Version), "string", null)]
-        [InlineData(typeof(DateOnly), "string", "date")]
-        [InlineData(typeof(TimeOnly), "string", "time")]
-        [InlineData(typeof(bool?), "boolean", null)]
-        [InlineData(typeof(int?), "integer", "int32")]
-        [InlineData(typeof(DateTime?), "string", "date-time")]
-        [InlineData(typeof(Guid?), "string", "uuid")]
-        [InlineData(typeof(DateOnly?), "string", "date")]
-        [InlineData(typeof(TimeOnly?), "string", "time")]
+        [InlineData(typeof(bool), JsonSchemaType.Boolean, null)]
+        [InlineData(typeof(byte), JsonSchemaType.Integer, "int32")]
+        [InlineData(typeof(sbyte), JsonSchemaType.Integer, "int32")]
+        [InlineData(typeof(short), JsonSchemaType.Integer, "int32")]
+        [InlineData(typeof(ushort), JsonSchemaType.Integer, "int32")]
+        [InlineData(typeof(int), JsonSchemaType.Integer, "int32")]
+        [InlineData(typeof(uint), JsonSchemaType.Integer, "int32")]
+        [InlineData(typeof(long), JsonSchemaType.Integer, "int64")]
+        [InlineData(typeof(ulong), JsonSchemaType.Integer, "int64")]
+        [InlineData(typeof(float), JsonSchemaType.Number, "float")]
+        [InlineData(typeof(double), JsonSchemaType.Number, "double")]
+        [InlineData(typeof(decimal), JsonSchemaType.Number, "double")]
+        [InlineData(typeof(string), JsonSchemaType.String, null)]
+        [InlineData(typeof(char), JsonSchemaType.String, null)]
+        [InlineData(typeof(byte[]), JsonSchemaType.String, "byte")]
+        [InlineData(typeof(DateTime), JsonSchemaType.String, "date-time")]
+        [InlineData(typeof(DateTimeOffset), JsonSchemaType.String, "date-time")]
+        [InlineData(typeof(TimeSpan), JsonSchemaType.String, "date-span")]
+        [InlineData(typeof(Guid), JsonSchemaType.String, "uuid")]
+        [InlineData(typeof(Uri), JsonSchemaType.String, "uri")]
+        [InlineData(typeof(Version), JsonSchemaType.String, null)]
+        [InlineData(typeof(DateOnly), JsonSchemaType.String, "date")]
+        [InlineData(typeof(TimeOnly), JsonSchemaType.String, "time")]
+        [InlineData(typeof(bool?), JsonSchemaType.Boolean, null)]
+        [InlineData(typeof(int?), JsonSchemaType.Integer, "int32")]
+        [InlineData(typeof(DateTime?), JsonSchemaType.String, "date-time")]
+        [InlineData(typeof(Guid?), JsonSchemaType.String, "uuid")]
+        [InlineData(typeof(DateOnly?), JsonSchemaType.String, "date")]
+        [InlineData(typeof(TimeOnly?), JsonSchemaType.String, "time")]
 #if NET7_0_OR_GREATER
-        [InlineData(typeof(Int128), "integer", "int128")]
-        [InlineData(typeof(Int128?), "integer", "int128")]
-        [InlineData(typeof(UInt128), "integer", "int128")]
-        [InlineData(typeof(UInt128?), "integer", "int128")]
+        [InlineData(typeof(Int128), JsonSchemaType.Integer, "int128")]
+        [InlineData(typeof(Int128?), JsonSchemaType.Integer, "int128")]
+        [InlineData(typeof(UInt128), JsonSchemaType.Integer, "int128")]
+        [InlineData(typeof(UInt128?), JsonSchemaType.Integer, "int128")]
 #endif
         public void GenerateSchema_GeneratesPrimitiveSchema_IfPrimitiveOrNullablePrimitiveType(
             Type type,
-            string expectedSchemaType,
+            JsonSchemaType expectedSchemaType,
             string expectedFormat)
         {
             var schema = Subject().GenerateSchema(type, new SchemaRepository());
@@ -100,10 +100,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.NotNull(referenceSchema.Reference);
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal("integer", schema.Type);
+            Assert.Equal(JsonSchemaType.Integer, schema.Type);
             Assert.Equal(expectedFormat, schema.Format);
             Assert.NotNull(schema.Enum);
-            Assert.Equal(expectedEnumAsJson, schema.Enum.Select(openApiAny => openApiAny.ToJson()));
+            Assert.Equal(expectedEnumAsJson, schema.Enum.Select(openApiAny => openApiAny.ToJsonString()));
         }
 
         [Fact]
@@ -120,18 +120,18 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
-        [InlineData(typeof(IDictionary<string, int>), "integer")]
-        [InlineData(typeof(IDictionary<EmptyIntEnum, int>), "integer")]
-        [InlineData(typeof(IReadOnlyDictionary<string, bool>), "boolean")]
-        [InlineData(typeof(IDictionary), null)]
-        [InlineData(typeof(ExpandoObject), null)]
+        [InlineData(typeof(IDictionary<string, int>), JsonSchemaType.Integer)]
+        [InlineData(typeof(IDictionary<EmptyIntEnum, int>), JsonSchemaType.Integer)]
+        [InlineData(typeof(IReadOnlyDictionary<string, bool>), JsonSchemaType.Boolean)]
+        [InlineData(typeof(IDictionary), JsonSchemaType.Null)]
+        [InlineData(typeof(ExpandoObject), JsonSchemaType.Null)]
         public void GenerateSchema_GeneratesDictionarySchema_IfDictionaryType(
             Type type,
-            string expectedAdditionalPropertiesType)
+            JsonSchemaType expectedAdditionalPropertiesType)
         {
             var schema = Subject().GenerateSchema(type, new SchemaRepository());
 
-            Assert.Equal("object", schema.Type);
+            Assert.Equal(JsonSchemaType.Object, schema.Type);
             Assert.True(schema.AdditionalPropertiesAllowed);
             Assert.NotNull(schema.AdditionalProperties);
             Assert.Equal(expectedAdditionalPropertiesType, schema.AdditionalProperties.Type);
@@ -146,26 +146,26 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.NotNull(referenceSchema.Reference);
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal("object", schema.Type);
+            Assert.Equal(JsonSchemaType.Object, schema.Type);
             Assert.True(schema.AdditionalPropertiesAllowed);
             Assert.NotNull(schema.AdditionalProperties);
             Assert.Equal(schema.AdditionalProperties.Reference.Id, referenceSchema.Reference.Id); // ref to self
         }
 
         [Theory]
-        [InlineData(typeof(int[]), "integer", "int32")]
-        [InlineData(typeof(IEnumerable<string>), "string", null)]
-        [InlineData(typeof(DateTime?[]), "string", "date-time")]
-        [InlineData(typeof(int[][]), "array", null)]
-        [InlineData(typeof(IList), null, null)]
+        [InlineData(typeof(int[]), JsonSchemaType.Integer, "int32")]
+        [InlineData(typeof(IEnumerable<string>), JsonSchemaType.String, null)]
+        [InlineData(typeof(DateTime?[]), JsonSchemaType.String, "date-time")]
+        [InlineData(typeof(int[][]), JsonSchemaType.Array, null)]
+        [InlineData(typeof(IList), JsonSchemaType.Null, null)]
         public void GenerateSchema_GeneratesArraySchema_IfEnumerableType(
             Type type,
-            string expectedItemsType,
+            JsonSchemaType expectedItemsType,
             string expectedItemsFormat)
         {
             var schema = Subject().GenerateSchema(type, new SchemaRepository());
 
-            Assert.Equal("array", schema.Type);
+            Assert.Equal(JsonSchemaType.Array, schema.Type);
             Assert.NotNull(schema.Items);
             Assert.Equal(expectedItemsType, schema.Items.Type);
             Assert.Equal(expectedItemsFormat, schema.Items.Format);
@@ -179,7 +179,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         {
             var schema = Subject().GenerateSchema(type, new SchemaRepository());
 
-            Assert.Equal("array", schema.Type);
+            Assert.Equal(JsonSchemaType.Array, schema.Type);
             Assert.True(schema.UniqueItems);
         }
 
@@ -192,7 +192,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.NotNull(referenceSchema.Reference);
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal("array", schema.Type);
+            Assert.Equal(JsonSchemaType.Array, schema.Type);
             Assert.Equal(schema.Items.Reference.Id, referenceSchema.Reference.Id); // ref to self
         }
 
@@ -213,7 +213,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.NotNull(referenceSchema.Reference);
             Assert.Equal(expectedSchemaId, referenceSchema.Reference.Id);
             var schema = schemaRepository.Schemas[expectedSchemaId];
-            Assert.Equal("object", schema.Type);
+            Assert.Equal(JsonSchemaType.Object, schema.Type);
             Assert.Equal(expectedProperties, schema.Properties.Keys);
             Assert.False(schema.AdditionalPropertiesAllowed);
         }
@@ -226,7 +226,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var referenceSchema = Subject().GenerateSchema(typeof(SubType1), schemaRepository);
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal("object", schema.Type);
+            Assert.Equal(JsonSchemaType.Object, schema.Type);
             Assert.Equal(["BaseProperty", "Property1"], schema.Properties.Keys);
         }
 
@@ -244,7 +244,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var referenceSchema = Subject().GenerateSchema(type, schemaRepository);
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal("object", schema.Type);
+            Assert.Equal(JsonSchemaType.Object, schema.Type);
             Assert.Equal(expectedPropertyNames.OrderBy(n => n), schema.Properties.Keys.OrderBy(k => k));
         }
 
@@ -256,7 +256,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var referenceSchema = Subject().GenerateSchema(typeof(INewBaseInterface), schemaRepository);
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal("integer", schema.Properties["BaseProperty"].Type);
+            Assert.Equal(JsonSchemaType.Integer, schema.Properties["BaseProperty"].Type);
         }
 
         [Fact]
@@ -267,7 +267,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var referenceSchema = Subject().GenerateSchema(typeof(IndexedType), schemaRepository);
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal("object", schema.Type);
+            Assert.Equal(JsonSchemaType.Object, schema.Type);
             Assert.Equal(["Property1"], schema.Properties.Keys);
         }
 
@@ -296,8 +296,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.DoubleWithDefault), "1.7976931348623157E+308")]
         [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.DoubleWithDefaultOfDifferentType), "1")]
         [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.StringWithDefault), "\"foobar\"")]
-        [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.IntArrayWithDefault), "[\n  1,\n  2,\n  3\n]")]
-        [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.StringArrayWithDefault), "[\n  \"foo\",\n  \"bar\"\n]")]
+        [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.IntArrayWithDefault), "[1,2,3]")]
+        [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.StringArrayWithDefault), "[\"foo\",\"bar\"]")]
         [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.NullableIntWithDefaultNullValue), "null")]
         [InlineData(typeof(TypeWithDefaultAttributes), nameof(TypeWithDefaultAttributes.NullableIntWithDefaultValue), "2147483647")]
         [UseInvariantCulture]
@@ -313,7 +313,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
             var propertySchema = schema.Properties[propertyName];
             Assert.NotNull(propertySchema.Default);
-            Assert.Equal(expectedDefaultAsJson, propertySchema.Default.ToJson());
+            Assert.Equal(expectedDefaultAsJson, propertySchema.Default.ToJsonString());
         }
 
         [Fact]
@@ -350,7 +350,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal(true, schema.Properties["IntWithExclusiveRange"].ExclusiveMinimum);
             Assert.Equal(true, schema.Properties["IntWithExclusiveRange"].ExclusiveMaximum);
             Assert.Equal("byte", schema.Properties["StringWithBase64"].Format);
-            Assert.Equal("string", schema.Properties["StringWithBase64"].Type);
+            Assert.Equal(JsonSchemaType.String, schema.Properties["StringWithBase64"].Type);
 #endif
             Assert.Null(schema.Properties["IntWithRange"].ExclusiveMinimum);
             Assert.Null(schema.Properties["IntWithRange"].ExclusiveMaximum);
@@ -478,7 +478,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var schema = Subject().GenerateSchema(parameterInfo.ParameterType, schemaRepository, parameterInfo: parameterInfo);
 
             Assert.NotNull(schema.Default);
-            Assert.Equal("3", schema.Default.ToJson());
+            Assert.Equal("3", schema.Default.ToJsonString());
         }
 
         [Theory]
@@ -490,11 +490,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Type type)
         {
             var subject = Subject(
-                configureGenerator: c => c.CustomTypeMappings.Add(mappingType, () => new OpenApiSchema { Type = "string" })
+                configureGenerator: c => c.CustomTypeMappings.Add(mappingType, () => new OpenApiSchema { Type = JsonSchemaType.String })
             );
             var schema = subject.GenerateSchema(type, new SchemaRepository());
 
-            Assert.Equal("string", schema.Type);
+            Assert.Equal(JsonSchemaType.String, schema.Type);
             Assert.Empty(schema.Properties);
         }
 
@@ -514,7 +514,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var definitionSchema = schema.Reference == null ? schema : schemaRepository.Schemas[schema.Reference.Id];
             Assert.Contains("X-foo", definitionSchema.Extensions.Keys);
-            Assert.Equal("v1", ((OpenApiString)definitionSchema.Extensions["X-docName"]).Value);
+            Assert.Equal("v1", ((OpenApiAny)definitionSchema.Extensions["X-docName"]).Node.GetValue<string>());
         }
 
         [Fact]
@@ -565,7 +565,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal(["Property1"], subSchema.Properties.Keys);
             // The base type schema
             var baseTypeSchema = schemaRepository.Schemas[baseSchema.Reference.Id];
-            Assert.Equal("object", baseTypeSchema.Type);
+            Assert.Equal(JsonSchemaType.Object, baseTypeSchema.Type);
             Assert.Equal(["BaseProperty"], baseTypeSchema.Properties.Keys);
         }
 
@@ -645,12 +645,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             // The base type schema
             Assert.NotNull(schema.OneOf[0].Reference);
             var baseSchema = schemaRepository.Schemas[schema.OneOf[0].Reference.Id];
-            Assert.Equal("object", baseSchema.Type);
+            Assert.Equal(JsonSchemaType.Object, baseSchema.Type);
             Assert.Equal(["BaseProperty"], baseSchema.Properties.Keys);
             // The first sub type schema
             Assert.NotNull(schema.OneOf[1].Reference);
             var subType1Schema = schemaRepository.Schemas[schema.OneOf[1].Reference.Id];
-            Assert.Equal("object", subType1Schema.Type);
+            Assert.Equal(JsonSchemaType.Object, subType1Schema.Type);
             Assert.NotNull(subType1Schema.AllOf);
             var allOf = Assert.Single(subType1Schema.AllOf);
             Assert.NotNull(allOf.Reference);
@@ -659,7 +659,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             // The second sub type schema
             Assert.NotNull(schema.OneOf[2].Reference);
             var subType2Schema = schemaRepository.Schemas[schema.OneOf[2].Reference.Id];
-            Assert.Equal("object", subType2Schema.Type);
+            Assert.Equal(JsonSchemaType.Object, subType2Schema.Type);
             Assert.NotNull(subType2Schema.AllOf);
             allOf = Assert.Single(subType2Schema.AllOf);
             Assert.NotNull(allOf.Reference);
@@ -691,7 +691,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var schema = subject.GenerateSchema(typeof(IntEnum), new SchemaRepository());
 
-            Assert.Equal("integer", schema.Type);
+            Assert.Equal(JsonSchemaType.Integer, schema.Type);
             Assert.NotNull(schema.Enum);
         }
 
@@ -1059,7 +1059,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var referenceSchema = Subject().GenerateSchema(typeof(ContainingType), schemaRepository);
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal("object", schema.Type);
+            Assert.Equal(JsonSchemaType.Object, schema.Type);
             Assert.Equal("NestedType", schema.Properties["Property1"].Reference.Id);
         }
 
@@ -1072,7 +1072,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.NotNull(referenceSchema.Items);
             Assert.NotNull(referenceSchema.Items.Type);
-            Assert.Equal("string", referenceSchema.Items.Type);
+            Assert.Equal(JsonSchemaType.String, referenceSchema.Items.Type);
         }
 
         [Fact]
@@ -1151,9 +1151,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
             var propertySchema = schema.Properties[nameof(TypeWithDefaultAttributeOnEnum.EnumWithDefault)];
-            Assert.Equal("string", propertySchema.Type);
-            Assert.Equal(expectedEnumAsJson, propertySchema.Enum.Select(openApiAny => openApiAny.ToJson()));
-            Assert.Equal(expectedDefaultAsJson, propertySchema.Default.ToJson());
+            Assert.Equal(JsonSchemaType.String, propertySchema.Type);
+            Assert.Equal(expectedEnumAsJson, propertySchema.Enum.Select(openApiAny => openApiAny.ToJsonString()));
+            Assert.Equal(expectedDefaultAsJson, propertySchema.Default.ToJsonString());
         }
 
         [Fact]
@@ -1175,8 +1175,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var referenceSchema = Subject().GenerateSchema(typeof(JsonConverterAnnotatedEnum), schemaRepository);
 
             var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-            Assert.Equal("string", schema.Type);
-            Assert.Equal(["\"Value1\"", "\"Value2\"", "\"X\""], schema.Enum.Select(openApiAny => openApiAny.ToJson()));
+            Assert.Equal(JsonSchemaType.String, schema.Type);
+            Assert.Equal(["\"Value1\"", "\"Value2\"", "\"X\""], schema.Enum.Select(openApiAny => openApiAny.ToJsonString()));
         }
 
         [Fact]
@@ -1324,7 +1324,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 .GetParameters()
                 .First();
             var schema = Subject().GenerateSchema(typeof(string), new SchemaRepository(), parameterInfo: parameterInfo, routeInfo: routeInfo);
-            Assert.Equal("integer", schema.Type);
+            Assert.Equal(JsonSchemaType.Integer, schema.Type);
         }
 
         private static SchemaGenerator Subject(

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/OpenApiAnyFactoryTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/OpenApiAnyFactoryTests.cs
@@ -1,69 +1,135 @@
-﻿namespace Swashbuckle.AspNetCore.SwaggerGen.Test
-{
-    using System;
-    using System.Text.Json;
-    using Microsoft.OpenApi.Any;
-    using Xunit;
+﻿using System.Text.Json;
+using Xunit;
 
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test
+{
     public class OpenApiAnyFactoryTests
     {
+        [Fact]
+        public void CreateFromJson_Int32()
+        {
+            var openApiAnyObject = OpenApiAnyFactory.CreateFromJson("1");
+            Assert.NotNull(openApiAnyObject);
+            Assert.Equal(JsonValueKind.Number, openApiAnyObject.GetValueKind());
+            Assert.Equal(1, openApiAnyObject.GetValue<int>());
+        }
+
+        [Fact]
+        public void CreateFromJson_Int64()
+        {
+            var openApiAnyObject = OpenApiAnyFactory.CreateFromJson("4294877294");
+            Assert.NotNull(openApiAnyObject);
+            Assert.Equal(JsonValueKind.Number, openApiAnyObject.GetValueKind());
+            Assert.Equal(4294877294L, openApiAnyObject.GetValue<long>());
+        }
+
+        [Fact]
+        public void CreateFromJson_Float()
+        {
+            var openApiAnyObject = OpenApiAnyFactory.CreateFromJson("1.5");
+            Assert.NotNull(openApiAnyObject);
+            Assert.Equal(JsonValueKind.Number, openApiAnyObject.GetValueKind());
+            Assert.Equal(1.5f, openApiAnyObject.GetValue<float>());
+        }
+
+        [Fact]
+        public void CreateFromJson_Double()
+        {
+            var openApiAnyObject = OpenApiAnyFactory.CreateFromJson("1.5e308");
+            Assert.NotNull(openApiAnyObject);
+            Assert.Equal(JsonValueKind.Number, openApiAnyObject.GetValueKind());
+            Assert.Equal(1.5e308, openApiAnyObject.GetValue<double>());
+        }
+
+        [Fact]
+        public void CreateFromJson_String()
+        {
+            var openApiAnyObject = OpenApiAnyFactory.CreateFromJson("\"abc\"");
+            Assert.NotNull(openApiAnyObject);
+            Assert.Equal(JsonValueKind.String, openApiAnyObject.GetValueKind());
+            Assert.Equal("abc", openApiAnyObject.GetValue<string>());
+        }
+
         [Theory]
-        [InlineData("1", typeof(OpenApiInteger), 1)]
-        [InlineData("4294877294", typeof(OpenApiLong), 4294877294L)]
-        [InlineData("1.5", typeof(OpenApiFloat), 1.5f)]
-        [InlineData("1.5e308", typeof(OpenApiDouble), 1.5e308)]
-        [InlineData("\"abc\"", typeof(OpenApiString), "abc")]
-        [InlineData("true", typeof(OpenApiBoolean), true)]
-        [InlineData("false", typeof(OpenApiBoolean), false)]
-        public void CreateFromJson_SimpleType(string json, Type expectedType, object expectedValue)
+        [InlineData("true", JsonValueKind.True, true)]
+        [InlineData("false", JsonValueKind.False, false)]
+        public void CreateFromJson_Boolean(string json, JsonValueKind expectedKind, object expectedValue)
         {
             var openApiAnyObject = OpenApiAnyFactory.CreateFromJson(json);
             Assert.NotNull(openApiAnyObject);
-            Assert.Equal(expectedType, openApiAnyObject.GetType());
-            Assert.Equal(AnyType.Primitive, openApiAnyObject.AnyType);
-            var valueProperty = expectedType.GetProperty("Value");
-            var actualValue = valueProperty.GetValue(openApiAnyObject);
-            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedKind, openApiAnyObject.GetValueKind());
+            Assert.Equal(expectedValue, openApiAnyObject.GetValue<bool>());
         }
 
         [Fact]
         public void CreateFromJson_NullType()
         {
-            var expectedType = typeof(OpenApiNull);
-
             var openApiAnyObject = OpenApiAnyFactory.CreateFromJson("null");
-            Assert.NotNull(openApiAnyObject);
-            Assert.Equal(expectedType, openApiAnyObject.GetType());
-            Assert.Equal(AnyType.Null, openApiAnyObject.AnyType);
-            var valueProperty = expectedType.GetProperty("Value");
-            Assert.Null(valueProperty);
+            Assert.Null(openApiAnyObject);
         }
 
-        [Theory]
-        [InlineData("[1,2]", typeof(OpenApiInteger), 1, 2)]
-        [InlineData("[4294877294,4294877295]", typeof(OpenApiLong), 4294877294L, 4294877295L)]
-        [InlineData("[1.5,-1.5]", typeof(OpenApiFloat), 1.5f, -1.5f)]
-        [InlineData("[1.5e308,-1.5e308]", typeof(OpenApiDouble), 1.5e308, -1.5e308)]
-        [InlineData("[\"abc\",\"def\"]", typeof(OpenApiString), "abc", "def")]
-        [InlineData("[true,false]", typeof(OpenApiBoolean), true, false)]
-        [InlineData("[{\"a\":1,\"b\":2},{\"a\":3,\"b\":4}]", typeof(OpenApiObject))]
-        [InlineData("[[1,2],[3,4]]", typeof(OpenApiArray))]
-        public void CreateFromJson_Array(string json, Type expectedType, params object[] expectedValues)
+        [Fact]
+        public void CreateFromJson_Array_Int32()
+        {
+            CreateFromJsonArray("[1,2]", JsonValueKind.Number, [1, 2]);
+        }
+
+        [Fact]
+        public void CreateFromJson_Array_Int64()
+        {
+            CreateFromJsonArray("[4294877294,4294877295]", JsonValueKind.Number, [4294877294L, 4294877295L]);
+        }
+
+        [Fact]
+        public void CreateFromJson_Array_Float()
+        {
+            CreateFromJsonArray("[1.5,-1.5]", JsonValueKind.Number, [1.5f, -1.5f]);
+        }
+
+        [Fact]
+        public void CreateFromJson_Array_Double()
+        {
+            CreateFromJsonArray("[1.5e308,-1.5e308]", JsonValueKind.Number, [1.5e308, -1.5e308]);
+        }
+
+        [Fact]
+        public void CreateFromJson_Array_String()
+        {
+            CreateFromJsonArray("[\"abc\",\"def\"]", JsonValueKind.String, ["abc", "def"]);
+        }
+
+        [Fact]
+        public void CreateFromJson_Array_Boolean()
+        {
+            CreateFromJsonArray("[true,true]", JsonValueKind.True, [true, true]);
+        }
+
+        [Fact]
+        public void CreateFromJson_Array_Object()
+        {
+            CreateFromJsonArray<object>("[{\"a\":1,\"b\":2},{\"a\":3,\"b\":4}]", JsonValueKind.Object, []);
+        }
+
+        [Fact]
+        public void CreateFromJson_Array_Array()
+        {
+            CreateFromJsonArray<int[]>("[[1,2],[3,4]]", JsonValueKind.Array, []);
+        }
+
+        private static void CreateFromJsonArray<T>(string json, JsonValueKind expectedType, params T[] expectedValues)
         {
             var openApiAnyObject = OpenApiAnyFactory.CreateFromJson(json);
             Assert.NotNull(openApiAnyObject);
-            Assert.Equal(typeof(OpenApiArray), openApiAnyObject.GetType());
-            Assert.Equal(AnyType.Array, openApiAnyObject.AnyType);
-            var array = (OpenApiArray)openApiAnyObject;
+            Assert.Equal(JsonValueKind.Array, openApiAnyObject.GetValueKind());
+            var array = openApiAnyObject.AsArray();
             for (var i = 0; i < array.Count; i++)
             {
                 Assert.NotNull(array[i]);
-                Assert.Equal(expectedType, array[i].GetType());
+                Assert.Equal(expectedType, array[i].GetValueKind());
                 if (expectedValues.Length > 0)
                 {
-                    var valueProperty = expectedType.GetProperty("Value");
                     var expectedValue = expectedValues[i];
-                    var actualValue = valueProperty.GetValue(array[i]);
+                    var actualValue = array[i].GetValue<T>();
                     Assert.Equal(expectedValue, actualValue);
                 }
             }
@@ -81,7 +147,7 @@
                 string_value = "abc",
                 true_value = true,
                 false_value = false,
-                array_value = new[] {1,2},
+                array_value = new int[] { 1, 2 },
                 object_value = new
                 {
                     a = 1,
@@ -91,52 +157,43 @@
 
             var openApiAnyObject = OpenApiAnyFactory.CreateFromJson(json);
             Assert.NotNull(openApiAnyObject);
-            Assert.Equal(typeof(OpenApiObject), openApiAnyObject.GetType());
-            Assert.Equal(AnyType.Object, openApiAnyObject.AnyType);
-            var obj = (OpenApiObject)openApiAnyObject;
+            Assert.Equal(JsonValueKind.Object, openApiAnyObject.GetValueKind());
+            var obj = openApiAnyObject.AsObject();
 
             Assert.NotNull(obj["int_value"]);
-            Assert.Equal(typeof(OpenApiInteger), obj["int_value"].GetType());
-            Assert.Equal(AnyType.Primitive, obj["int_value"].AnyType);
-            Assert.Equal(1, ((OpenApiInteger) obj["int_value"]).Value);
+            Assert.Equal(JsonValueKind.Number, obj["int_value"].GetValueKind());
+            Assert.Equal(1, obj["int_value"].GetValue<int>());
 
             Assert.NotNull(obj["long_value"]);
-            Assert.Equal(typeof(OpenApiLong), obj["long_value"].GetType());
-            Assert.Equal(AnyType.Primitive, obj["long_value"].AnyType);
-            Assert.Equal(4294877294L, ((OpenApiLong)obj["long_value"]).Value);
+            Assert.Equal(JsonValueKind.Number, obj["long_value"].GetValueKind());
+            Assert.Equal(4294877294L, obj["long_value"].GetValue<long>());
 
             Assert.NotNull(obj["float_value"]);
-            Assert.Equal(typeof(OpenApiFloat), obj["float_value"].GetType());
-            Assert.Equal(AnyType.Primitive, obj["float_value"].AnyType);
-            Assert.Equal(1.5f, ((OpenApiFloat)obj["float_value"]).Value);
+            Assert.Equal(JsonValueKind.Number, obj["float_value"].GetValueKind());
+            Assert.Equal(1.5f, obj["float_value"].GetValue<float>());
 
             Assert.NotNull(obj["double_value"]);
-            Assert.Equal(typeof(OpenApiDouble), obj["double_value"].GetType());
-            Assert.Equal(AnyType.Primitive, obj["double_value"].AnyType);
-            Assert.Equal(1.5e308, ((OpenApiDouble)obj["double_value"]).Value);
+            Assert.Equal(JsonValueKind.Number, obj["double_value"].GetValueKind());
+            Assert.Equal(1.5e308, obj["double_value"].GetValue<double>());
 
             Assert.NotNull(obj["string_value"]);
-            Assert.Equal(typeof(OpenApiString), obj["string_value"].GetType());
-            Assert.Equal(AnyType.Primitive, obj["string_value"].AnyType);
-            Assert.Equal("abc", ((OpenApiString)obj["string_value"]).Value);
+            Assert.Equal(JsonValueKind.String, obj["string_value"].GetValueKind());
+            Assert.Equal("abc", obj["string_value"].GetValue<string>());
 
             Assert.NotNull(obj["true_value"]);
-            Assert.Equal(typeof(OpenApiBoolean), obj["true_value"].GetType());
-            Assert.Equal(AnyType.Primitive, obj["true_value"].AnyType);
-            Assert.True(((OpenApiBoolean)obj["true_value"]).Value);
+            Assert.Equal(JsonValueKind.True, obj["true_value"].GetValueKind());
+            Assert.True(obj["true_value"].GetValue<bool>());
 
             Assert.NotNull(obj["false_value"]);
-            Assert.Equal(typeof(OpenApiBoolean), obj["false_value"].GetType());
-            Assert.Equal(AnyType.Primitive, obj["false_value"].AnyType);
-            Assert.False(((OpenApiBoolean)obj["false_value"]).Value);
+            Assert.Equal(JsonValueKind.False, obj["false_value"].GetValueKind());
+            Assert.False(obj["false_value"].GetValue<bool>());
 
             Assert.NotNull(obj["array_value"]);
-            Assert.Equal(typeof(OpenApiArray), obj["array_value"].GetType());
-            Assert.Equal(AnyType.Array, obj["array_value"].AnyType);
+            Assert.Equal(JsonValueKind.Array, obj["array_value"].GetValueKind());
+            Assert.Equal([1, 2], obj["array_value"].AsArray().GetValues<int>());
 
             Assert.NotNull(obj["object_value"]);
-            Assert.Equal(typeof(OpenApiObject), obj["object_value"].GetType());
-            Assert.Equal(AnyType.Object, obj["object_value"].AnyType);
+            Assert.Equal(JsonValueKind.Object, obj["object_value"].GetValueKind());
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Swagger;
@@ -29,8 +28,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_GeneratesSwaggerDocument_ForApiDescriptionsWithMatchingGroupName()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource"),
 
@@ -38,8 +37,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "GET", relativePath: "resource"),
 
                     ApiDescriptionFactory.Create<FakeController>(
-                        c => nameof(c.ActionWithNoParameters), groupName: "v2", httpMethod: "POST", relativePath: "resource")
-                },
+                        c => nameof(c.ActionWithNoParameters), groupName: "v2", httpMethod: "POST", relativePath: "resource"),
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
@@ -58,15 +57,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal("V1", document.Info.Version);
             Assert.Equal("Test API", document.Info.Title);
-            Assert.Equal(new[] { "/resource" }, document.Paths.Keys.ToArray());
-            Assert.Equal(new[] { OperationType.Post, OperationType.Get }, document.Paths["/resource"].Operations.Keys);
+            Assert.Equal(["/resource"], [.. document.Paths.Keys]);
+            Assert.Equal([OperationType.Post, OperationType.Get], document.Paths["/resource"].Operations.Keys);
             Assert.Equal(2, document.Paths["/resource"].Operations.Count);
 
             var documentV2 = subject.GetSwagger("v2");
             Assert.Equal("V2", documentV2.Info.Version);
             Assert.Equal("Test API 2", documentV2.Info.Title);
-            Assert.Equal(new[] { "/resource" }, documentV2.Paths.Keys.ToArray());
-            Assert.Equal(new[] { OperationType.Post }, documentV2.Paths["/resource"].Operations.Keys);
+            Assert.Equal(["/resource"], [.. documentV2.Paths.Keys]);
+            Assert.Equal([OperationType.Post], documentV2.Paths["/resource"].Operations.Keys);
             Assert.Single(documentV2.Paths["/resource"].Operations);
         }
 
@@ -83,12 +82,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_GeneratesSwaggerDocument_ForApiDescriptionsWithConstrainedRelativePaths(string path, string expectedPath)
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: path),
 
-                },
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
@@ -110,11 +109,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SetsOperationIdToNull_ByDefault()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource"),
-                }
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -126,11 +125,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SetsOperationIdToRouteName_IfActionHasRouteNameMetadata()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithRouteNameMetadata), groupName: "v1", httpMethod: "POST", relativePath: "resource"),
-                }
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -144,17 +143,17 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));
             var actionDescriptor = new ActionDescriptor
             {
-                EndpointMetadata = new List<object>() { new EndpointNameMetadata("SomeEndpointName") },
+                EndpointMetadata = [new EndpointNameMetadata("SomeEndpointName")],
                 RouteValues = new Dictionary<string, string>
                 {
                     ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
                 }
             };
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create(actionDescriptor, methodInfo, groupName: "v1", httpMethod: "POST", relativePath: "resource"),
-                }
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -168,30 +167,30 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));
             var actionDescriptor = new ActionDescriptor
             {
-                EndpointMetadata = new List<object>()
-                {
+                EndpointMetadata =
+                [
                     new OpenApiOperation
                     {
                         OperationId = "OperationIdSetInMetadata",
-                        Parameters = new List<OpenApiParameter>()
-                        {
+                        Parameters =
+                        [
                             new OpenApiParameter
                             {
                                 Name = "ParameterInMetadata"
                             }
-                        }
+                        ]
                     }
-                },
+                ],
                 RouteValues = new Dictionary<string, string>
                 {
                     ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
                 }
             };
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create(actionDescriptor, methodInfo, groupName: "v1", httpMethod: "POST", relativePath: "resource"),
-                }
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -206,8 +205,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithProducesAttribute));
             var actionDescriptor = new ActionDescriptor
             {
-                EndpointMetadata = new List<object>()
-                {
+                EndpointMetadata =
+                [
                     new OpenApiOperation
                     {
                         OperationId = "OperationIdSetInMetadata",
@@ -222,30 +221,30 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                             }
                         }
                     }
-                },
+                ],
                 RouteValues = new Dictionary<string, string>
                 {
                     ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
                 }
             };
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create(
                         actionDescriptor,
                         methodInfo,
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        supportedResponseTypes: new[]
-                        {
+                        supportedResponseTypes:
+                        [
                             new ApiResponseType()
                             {
                                 StatusCode = 200,
                                 Type = typeof(TestDto)
                             }
-                        }),
-                }
+                        ]),
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -353,44 +352,44 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));
             var actionDescriptor = new ActionDescriptor
             {
-                EndpointMetadata = new List<object>()
-                {
+                EndpointMetadata =
+                [
                     new OpenApiOperation
                     {
                         OperationId = "OperationIdSetInMetadata",
-                        Parameters = new List<OpenApiParameter>()
-                        {
+                        Parameters =
+                        [
                             new OpenApiParameter
                             {
                                 Name = "ParameterInMetadata"
                             }
-                        }
+                        ]
                     }
-                },
+                ],
                 RouteValues = new Dictionary<string, string>
                 {
                     ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
                 }
             };
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create(
                         actionDescriptor,
                         methodInfo,
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new[]
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = "ParameterInMetadata",
                                 ModelMetadata = ModelMetadataFactory.CreateForType(typeof(string)),
                                 Type = typeof(string)
                             }
-                        }),
-                }
+                        ]),
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -414,10 +413,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 }
             };
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create(actionDescriptor, methodInfo, groupName: "v1", httpMethod: "POST", relativePath: "resource"),
-                }
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -429,11 +428,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SetsDeprecated_IfActionHasObsoleteAttribute()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithObsoleteAttribute), groupName: "v1", httpMethod: "POST", relativePath: "resource"),
-                }
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -451,22 +450,22 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             ParameterLocation expectedParameterLocation)
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithParameter),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = "param",
                                 Source = (bindingSourceId != null) ? new BindingSource(bindingSourceId, null, false, true) : null
                             }
-                        })
-                }
+                        ])
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -480,16 +479,16 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_IgnoresOperations_IfOperationHasSwaggerIgnoreAttribute()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithSwaggerIgnoreAttribute),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "ignored",
-                        parameterDescriptions: Array.Empty<ApiParameterDescription>()
+                        parameterDescriptions: []
                     )
-                }
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -501,22 +500,22 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_IgnoresParameters_IfActionParameterHasBindNeverAttribute()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithParameterWithBindNeverAttribute),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = "param",
                                 Source = BindingSource.Query
                             }
-                        })
-                }
+                        ])
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -529,23 +528,22 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_IgnoresParameters_IfActionParameterHasSwaggerIgnoreAttribute()
         {
             var subject = Subject(
-                new[]
-                {
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithIntParameterWithSwaggerIgnoreAttribute),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new[]
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = "param",
                                 Source = BindingSource.Query
                             }
-                        }
+                        ]
                     )
-                }
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -564,15 +562,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var fromHeaderAttribute = illegalParameter.GetCustomAttribute<FromHeaderAttribute>();
 
             var subject = Subject(
-                new[]
-                {
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => action,
                         groupName: "v1",
                         httpMethod: "GET",
                         relativePath: "resource",
-                        parameterDescriptions: new[]
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = fromHeaderAttribute?.Name ?? illegalParameter.Name,
@@ -584,9 +581,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                                 Name = "param",
                                 Source = BindingSource.Header
                             }
-                        }
+                        ]
                     )
-                }
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -608,13 +605,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var methodInfo = typeof(FakeController).GetMethod(action);
             var actionDescriptor = new ActionDescriptor
             {
-                EndpointMetadata = new List<object>()
-                {
+                EndpointMetadata =
+                [
                     new OpenApiOperation
                     {
                         OperationId = "OperationIdSetInMetadata",
-                        Parameters = new List<OpenApiParameter>()
-                        {
+                        Parameters =
+                        [
                             new OpenApiParameter
                             {
                                 Name = illegalParameterName,
@@ -623,25 +620,25 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                             {
                                 Name = "param",
                             }
-                        }
+                        ]
                     }
-                },
+                ],
                 RouteValues = new Dictionary<string, string>
                 {
                     ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
                 }
             };
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create(
                         actionDescriptor,
                         methodInfo,
                         groupName: "v1",
                         httpMethod: "GET",
                         relativePath: "resource",
-                        parameterDescriptions: new[]
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = illegalParameterName,
@@ -655,8 +652,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                                 ModelMetadata = ModelMetadataFactory.CreateForType(typeof(string)),
                                 Type = typeof(string)
                             }
-                        }),
-                }
+                        ]),
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -670,22 +667,22 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SetsParameterRequired_IfApiParameterIsBoundToPath()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithParameter),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = "param",
                                 Source = BindingSource.Path
                             }
-                        })
-                }
+                        ])
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -703,22 +700,22 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             bool expectedRequired)
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create(
                         methodInfo: typeof(FakeController).GetMethod(actionName),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = "param",
                                 Source = BindingSource.Query
                             }
-                        })
-                }
+                        ])
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -733,23 +730,23 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SetsParameterRequired_IfActionParameterHasRequiredMember()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create(
                         methodInfo: typeof(FakeController).GetMethod(nameof(FakeController.ActionWithRequiredMember)),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = "param",
                                 Source = BindingSource.Query,
                                 ModelMetadata = ModelMetadataFactory.CreateForProperty(typeof(FakeController.TypeWithRequiredProperty), "RequiredProperty")
                             }
-                        })
-                }
+                        ])
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -787,10 +784,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             };
 
             var subject = Subject(
-                apiDescriptions: new[]
-                {
-                    ApiDescriptionFactory.Create(actionDescriptor, action.Method, groupName: "v1", httpMethod: "POST", relativePath: "resource", parameterDescriptions: new[]{ parameter }),
-                }
+                apiDescriptions:
+                [
+                    ApiDescriptionFactory.Create(actionDescriptor, action.Method, groupName: "v1", httpMethod: "POST", relativePath: "resource", parameterDescriptions: [parameter]),
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -802,22 +799,22 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SetsParameterTypeToString_IfApiParameterHasNoCorrespondingActionParameter()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = "param",
                                 Source = BindingSource.Path
                             }
-                        })
-                }
+                        ])
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -831,33 +828,33 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_GeneratesRequestBody_ForFirstApiParameterThatIsBoundToBody()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithParameter),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = "param",
                                 Source = BindingSource.Body,
                             }
-                        },
-                        supportedRequestFormats: new[]
-                        {
+                        ],
+                        supportedRequestFormats:
+                        [
                             new ApiRequestFormat { MediaType = "application/json" }
-                        })
-                }
+                        ])
+                ]
             );
 
             var document = subject.GetSwagger("v1");
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.NotNull(operation.RequestBody);
-            Assert.Equal(new[] { "application/json" }, operation.RequestBody.Content.Keys);
+            Assert.Equal(["application/json"], operation.RequestBody.Content.Keys);
             var mediaType = operation.RequestBody.Content["application/json"];
             Assert.NotNull(mediaType.Schema);
         }
@@ -871,26 +868,26 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             bool expectedRequired)
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create(
                         methodInfo: typeof(FakeController).GetMethod(actionName),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = "param",
                                 Source = BindingSource.Body,
                             }
-                        },
-                        supportedRequestFormats: new[]
-                        {
+                        ],
+                        supportedRequestFormats:
+                        [
                             new ApiRequestFormat { MediaType = "application/json" }
-                        })
-                }
+                        ])
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -903,15 +900,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_GeneratesRequestBody_ForApiParametersThatAreBoundToForm()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithMultipleParameters),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = "param1",
@@ -923,19 +920,19 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                                 Source = BindingSource.Form,
                             }
 
-                        }
+                        ]
                     )
-                }
+                ]
             );
 
             var document = subject.GetSwagger("v1");
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.NotNull(operation.RequestBody);
-            Assert.Equal(new[] { "multipart/form-data" }, operation.RequestBody.Content.Keys);
+            Assert.Equal(["multipart/form-data"], operation.RequestBody.Content.Keys);
             var mediaType = operation.RequestBody.Content["multipart/form-data"];
             Assert.NotNull(mediaType.Schema);
-            Assert.Equal(new[] { "param1", "param2" }, mediaType.Schema.Properties.Keys);
+            Assert.Equal(["param1", "param2"], mediaType.Schema.Properties.Keys);
             Assert.NotNull(mediaType.Encoding);
         }
 
@@ -946,76 +943,76 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             string bindingSourceId)
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithConsumesAttribute),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = "param",
                                 Source = new BindingSource(bindingSourceId, null, false, true)
                             }
-                        })
-                }
+                        ])
+                ]
             );
 
             var document = subject.GetSwagger("v1");
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
-            Assert.Equal(new[] { "application/someMediaType" }, operation.RequestBody.Content.Keys);
+            Assert.Equal(["application/someMediaType"], operation.RequestBody.Content.Keys);
         }
 
         [Fact]
         public void GetSwagger_GeneratesResponses_ForSupportedResponseTypes()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithReturnValue),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        supportedResponseTypes: new []
-                        {
+                        supportedResponseTypes:
+                        [
                             new ApiResponseType
                             {
-                                ApiResponseFormats = new [] { new ApiResponseFormat { MediaType = "application/json" } },
+                                ApiResponseFormats = [new ApiResponseFormat { MediaType = "application/json" }],
                                 StatusCode = 200,
                             },
                             new ApiResponseType
                             {
-                                ApiResponseFormats = new [] { new ApiResponseFormat { MediaType = "application/json" } },
+                                ApiResponseFormats = [new ApiResponseFormat { MediaType = "application/json" }],
                                 StatusCode = 400
                             },
                             new ApiResponseType
                             {
-                                ApiResponseFormats = new [] { new ApiResponseFormat { MediaType = "application/json" } },
+                                ApiResponseFormats = [new ApiResponseFormat { MediaType = "application/json" }],
                                 StatusCode = 422
                             },
                             new ApiResponseType
                             {
-                                ApiResponseFormats = new [] { new ApiResponseFormat { MediaType = "application/json" } },
+                                ApiResponseFormats = [new ApiResponseFormat { MediaType = "application/json" }],
                                 IsDefaultResponse = true
                             }
 
-                        }
+                        ]
                     )
-                }
+                ]
             );
 
             var document = subject.GetSwagger("v1");
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
-            Assert.Equal(new[] { "200", "400", "422", "default" }, operation.Responses.Keys);
+            Assert.Equal(["200", "400", "422", "default"], operation.Responses.Keys);
             var response200 = operation.Responses["200"];
             Assert.Equal("OK", response200.Description);
-            Assert.Equal(new[] { "application/json" }, response200.Content.Keys);
+            Assert.Equal(["application/json"], response200.Content.Keys);
             var response400 = operation.Responses["400"];
             Assert.Equal("Bad Request", response400.Description);
             Assert.Empty(response400.Content.Keys);
@@ -1035,21 +1032,21 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 groupName: "v1",
                 httpMethod: "POST",
                 relativePath: "resource",
-                supportedResponseTypes: new[]
-                {
+                supportedResponseTypes:
+                [
                     new ApiResponseType
                     {
-                        ApiResponseFormats = new [] { new ApiResponseFormat { MediaType = "application/zip" } },
+                        ApiResponseFormats = [new ApiResponseFormat { MediaType = "application/zip" }],
                         StatusCode = 200,
                         Type = typeof(FileContentResult)
                     }
-                });
+                ]);
 
             // ASP.NET Core sets ModelMetadata to null for FileResults
             apiDescription.SupportedResponseTypes[0].ModelMetadata = null;
 
             var subject = Subject(
-                apiDescriptions: new[] { apiDescription }
+                apiDescriptions: [apiDescription]
             );
 
             var document = subject.GetSwagger("v1");
@@ -1065,39 +1062,39 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SetsResponseContentTypesFromAttribute_IfActionHasProducesAttribute()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithProducesAttribute),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        supportedResponseTypes: new []
-                        {
+                        supportedResponseTypes:
+                        [
                             new ApiResponseType
                             {
-                                ApiResponseFormats = new [] { new ApiResponseFormat { MediaType = "application/json" } },
+                                ApiResponseFormats = [new ApiResponseFormat { MediaType = "application/json" }],
                                 StatusCode = 200,
                             }
-                        })
-                }
+                        ])
+                ]
             );
 
             var document = subject.GetSwagger("v1");
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
-            Assert.Equal(new[] { "application/someMediaType" }, operation.Responses["200"].Content.Keys);
+            Assert.Equal(["application/someMediaType"], operation.Responses["200"].Content.Keys);
         }
 
         [Fact]
         public void GetSwagger_ThrowsUnknownSwaggerDocumentException_IfProvidedDocumentNameNotRegistered()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource"),
-                }
+                ]
             );
 
             var exception = Assert.Throws<UnknownSwaggerDocument>(() => subject.GetSwagger("v2"));
@@ -1110,11 +1107,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_ThrowsSwaggerGeneratorException_IfActionHasNoHttpBinding()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: null, relativePath: "resource")
-                }
+                ]
             );
 
             var exception = Assert.Throws<SwaggerGeneratorException>(() => subject.GetSwagger("v1"));
@@ -1128,14 +1125,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_ThrowsSwaggerGeneratorException_IfActionsHaveConflictingHttpMethodAndPath()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource"),
 
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource")
-                }
+                ]
             );
 
             var exception = Assert.Throws<SwaggerGeneratorException>(() => subject.GetSwagger("v1"));
@@ -1157,14 +1154,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "GET", relativePath: "resource"),
 
                     ApiDescriptionFactory.Create<FakeController>(
-                        c => nameof(c.ActionWithIntFromQueryParameter), groupName: "v1", httpMethod: "GET", relativePath: "resource", new ApiParameterDescription[]
-                        {
+                        c => nameof(c.ActionWithIntFromQueryParameter), groupName: "v1", httpMethod: "GET", relativePath: "resource",
+                        [
                             new()
                             {
                                 Name = "id",
                                 Source = BindingSource.Query,
                             }
-                        }),
+                        ]),
                 ]
             );
 
@@ -1181,14 +1178,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SupportsOption_IgnoreObsoleteActions()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource"),
 
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithObsoleteAttribute), groupName: "v1", httpMethod: "GET", relativePath: "resource")
-                },
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
@@ -1201,8 +1198,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var document = subject.GetSwagger("v1");
 
-            Assert.Equal(new[] { "/resource" }, document.Paths.Keys.ToArray());
-            Assert.Equal(new[] { OperationType.Post }, document.Paths["/resource"].Operations.Keys);
+            Assert.Equal(["/resource"], [.. document.Paths.Keys]);
+            Assert.Equal([OperationType.Post], document.Paths["/resource"].Operations.Keys);
             Assert.Single(document.Paths["/resource"].Operations);
         }
 
@@ -1210,8 +1207,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SupportsOption_SortKeySelector()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource3"),
 
@@ -1220,7 +1217,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource2"),
-                },
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
@@ -1233,7 +1230,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var document = subject.GetSwagger("v1");
 
-            Assert.Equal(new[] { "/resource1", "/resource2", "/resource3" }, document.Paths.Keys.ToArray());
+            Assert.Equal(["/resource1", "/resource2", "/resource3"], [.. document.Paths.Keys]);
             Assert.Single(document.Paths["/resource1"].Operations);
             Assert.Single(document.Paths["/resource2"].Operations);
             Assert.Single(document.Paths["/resource3"].Operations);
@@ -1243,24 +1240,24 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SupportsOption_TagSelector()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource"),
-                },
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
                     {
                         ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
                     },
-                    TagsSelector = (apiDesc) => new[] { apiDesc.RelativePath }
+                    TagsSelector = (apiDesc) => [apiDesc.RelativePath]
                 }
             );
 
             var document = subject.GetSwagger("v1");
 
-            Assert.Equal(new[] { "resource" }, document.Paths["/resource"].Operations[OperationType.Post].Tags.Select(t => t.Name));
+            Assert.Equal(["resource"], document.Paths["/resource"].Operations[OperationType.Post].Tags.Select(t => t.Name));
         }
 
         [Fact]
@@ -1269,22 +1266,22 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));
             var actionDescriptor = new ActionDescriptor
             {
-                EndpointMetadata = new List<object>() { new TagsAttribute("Some", "Tags", "Here") },
+                EndpointMetadata = [new TagsAttribute("Some", "Tags", "Here")],
                 RouteValues = new Dictionary<string, string>
                 {
                     ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
                 }
             };
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create(actionDescriptor, methodInfo, groupName: "v1", httpMethod: "POST", relativePath: "resource"),
-                }
+                ]
             );
 
             var document = subject.GetSwagger("v1");
 
-            Assert.Equal(new[] { "Some", "Tags", "Here" }, document.Paths["/resource"].Operations[OperationType.Post].Tags.Select(t => t.Name));
+            Assert.Equal(["Some", "Tags", "Here"], document.Paths["/resource"].Operations[OperationType.Post].Tags.Select(t => t.Name));
         }
 
 #if NET7_0_OR_GREATER
@@ -1294,17 +1291,17 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));
             var actionDescriptor = new ActionDescriptor
             {
-                EndpointMetadata = new List<object>() { new EndpointSummaryAttribute("A Test Summary") },
+                EndpointMetadata = [new EndpointSummaryAttribute("A Test Summary")],
                 RouteValues = new Dictionary<string, string>
                 {
                     ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
                 }
             };
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create(actionDescriptor, methodInfo, groupName: "v1", httpMethod: "POST", relativePath: "resource"),
-                }
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -1318,17 +1315,17 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));
             var actionDescriptor = new ActionDescriptor
             {
-                EndpointMetadata = new List<object>() { new EndpointDescriptionAttribute("A Test Description") },
+                EndpointMetadata = [new EndpointDescriptionAttribute("A Test Description")],
                 RouteValues = new Dictionary<string, string>
                 {
                     ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
                 }
             };
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create(actionDescriptor, methodInfo, groupName: "v1", httpMethod: "POST", relativePath: "resource"),
-                }
+                ]
             );
 
             var document = subject.GetSwagger("v1");
@@ -1341,14 +1338,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SupportsOption_ConflictingActionsResolver()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource"),
 
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource")
-                },
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
@@ -1361,8 +1358,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var document = subject.GetSwagger("v1");
 
-            Assert.Equal(new[] { "/resource" }, document.Paths.Keys.ToArray());
-            Assert.Equal(new[] { OperationType.Post }, document.Paths["/resource"].Operations.Keys);
+            Assert.Equal(["/resource"], [.. document.Paths.Keys]);
+            Assert.Equal([OperationType.Post], document.Paths["/resource"].Operations.Keys);
             Assert.Single(document.Paths["/resource"].Operations);
         }
 
@@ -1377,22 +1374,22 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             string expectedOpenApiParameterName)
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithParameter),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = parameterName,
                                 Source = BindingSource.Path
                             }
-                        })
-                },
+                        ])
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
@@ -1414,17 +1411,17 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SupportsOption_Servers()
         {
             var subject = Subject(
-                apiDescriptions: new ApiDescription[] { },
+                apiDescriptions: [],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
                     {
                         ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
                     },
-                    Servers = new List<OpenApiServer>
-                    {
+                    Servers =
+                    [
                         new OpenApiServer { Url = "http://tempuri.org/api" }
-                    }
+                    ]
                 }
             );
 
@@ -1438,7 +1435,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SupportsOption_SecuritySchemes()
         {
             var subject = Subject(
-                apiDescriptions: new ApiDescription[] { },
+                apiDescriptions: [],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
@@ -1454,7 +1451,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var document = subject.GetSwagger("v1");
 
-            Assert.Equal(new[] { "basic" }, document.Components.SecuritySchemes.Keys);
+            Assert.Equal(["basic"], document.Components.SecuritySchemes.Keys);
         }
 
         [Theory]
@@ -1466,11 +1463,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
         {
             var subject = Subject(
-                apiDescriptions: new ApiDescription[] { },
-                authenticationSchemes: new[] {
+                apiDescriptions: [],
+                authenticationSchemes: [
                     new AuthenticationScheme("Bearer", null, typeof(IAuthenticationHandler)),
                     new AuthenticationScheme("Cookies", null, typeof(IAuthenticationHandler))
-                },
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
@@ -1495,11 +1492,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
         {
             var subject = Subject(
-                apiDescriptions: new ApiDescription[] { },
-                authenticationSchemes: new[] {
+                apiDescriptions: [],
+                authenticationSchemes: [
                     new AuthenticationScheme("Bearer", null, typeof(IAuthenticationHandler)),
                     new AuthenticationScheme("Cookies", null, typeof(IAuthenticationHandler))
-                },
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
@@ -1524,28 +1521,28 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SupportsOption_ParameterFilters()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithParameter),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription { Name = "param", Source = BindingSource.Query }
-                        })
-                },
+                        ])
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
                     {
                         ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
                     },
-                    ParameterFilters = new List<IParameterFilter>
-                    {
+                    ParameterFilters =
+                    [
                         new TestParameterFilter()
-                    }
+                    ]
                 }
             );
 
@@ -1561,28 +1558,28 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SupportsOption_RequestBodyFilters()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithParameter),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription { Name = "param", Source = BindingSource.Body }
-                        })
-                },
+                        ])
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
                     {
                         ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
                     },
-                    RequestBodyFilters = new List<IRequestBodyFilter>
-                    {
+                    RequestBodyFilters =
+                    [
                         new TestRequestBodyFilter()
-                    }
+                    ]
                 }
             );
 
@@ -1598,21 +1595,21 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SupportsOption_OperationFilters()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource")
-                },
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
                     {
                         ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
                     },
-                    OperationFilters = new List<IOperationFilter>
-                    {
+                    OperationFilters =
+                    [
                         new TestOperationFilter()
-                    }
+                    ]
                 }
             );
 
@@ -1628,17 +1625,17 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_SupportsOption_DocumentFilters()
         {
             var subject = Subject(
-                apiDescriptions: new ApiDescription[] { },
+                apiDescriptions: [],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
                     {
                         ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
                     },
-                    DocumentFilters = new List<IDocumentFilter>
-                    {
+                    DocumentFilters =
+                    [
                         new TestDocumentFilter()
-                    }
+                    ]
                 }
             );
 
@@ -1654,21 +1651,21 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public async Task GetSwaggerAsync_SupportsOption_OperationFilters()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: "POST", relativePath: "resource")
-                },
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
                     {
                         ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
                     },
-                    OperationFilters = new List<IOperationFilter>
-                    {
+                    OperationFilters =
+                    [
                         new TestOperationFilter()
-                    }
+                    ]
                 }
             );
 
@@ -1740,7 +1737,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public async Task GetSwaggerAsync_SupportsOption_DocumentFilters()
         {
             var subject = Subject(
-                apiDescriptions: Array.Empty<ApiDescription>(),
+                apiDescriptions: [],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
@@ -1766,18 +1763,18 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public async Task GetSwaggerAsync_SupportsOption_RequestBodyAsyncFilters()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithParameter),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription { Name = "param", Source = BindingSource.Body }
-                        })
-                },
+                        ])
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
@@ -1803,28 +1800,28 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public async Task GetSwaggerAsync_SupportsOption_RequestBodyFilters()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithParameter),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription { Name = "param", Source = BindingSource.Body }
-                        })
-                },
+                        ])
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
                     {
                         ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
                     },
-                    RequestBodyFilters = new List<IRequestBodyFilter>
-                    {
+                    RequestBodyFilters =
+                    [
                         new TestRequestBodyFilter()
-                    }
+                    ]
                 }
             );
 
@@ -1840,28 +1837,28 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public async Task GetSwaggerAsync_SupportsOption_ParameterFilters()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithParameter),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription { Name = "param", Source = BindingSource.Query }
-                        })
-                },
+                        ])
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
                     {
                         ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
                     },
-                    ParameterFilters = new List<IParameterFilter>
-                    {
+                    ParameterFilters =
+                    [
                         new TestParameterFilter()
-                    }
+                    ]
                 }
             );
 
@@ -1877,18 +1874,18 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public async Task GetSwaggerAsync_SupportsOption_ParameterAsyncFilters()
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithParameter),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new []
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription { Name = "param", Source = BindingSource.Query }
-                        })
-                },
+                        ])
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
@@ -1917,11 +1914,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         public void GetSwagger_GeneratesSwaggerDocument_ThrowsIfHttpMethodNotSupported(string httpMethod)
         {
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: httpMethod, relativePath: "resource"),
-                },
+                ],
                 options: new SwaggerGeneratorOptions
                 {
                     SwaggerDocs = new Dictionary<string, OpenApiInfo>
@@ -1943,23 +1940,23 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 .GetParameters()[0];
 
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                    ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionHavingIFormFileParamWithFromFormAttribute),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new[]
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = "fileUpload", // Name of the parameter
                                 Type = typeof(IFormFile), // Type of the parameter
                                 ParameterDescriptor = new ControllerParameterDescriptor { ParameterInfo = parameterInfo }
                             }
-                        })
-                }
+                        ])
+                ]
             );
 
             Assert.Throws<SwaggerGeneratorException>(() => subject.GetSwagger("v1"));
@@ -1977,15 +1974,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 .GetParameters()[1];
 
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                    ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionHavingFromFormAttributeButNotWithIFormFile),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new[]
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = "param1", // Name of the parameter
@@ -1998,14 +1995,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                                 Type = typeof(IFormFile), // Type of the parameter
                                 ParameterDescriptor = new ControllerParameterDescriptor { ParameterInfo = fileUploadParameterInfo }
                             }
-                        })
-                }
+                        ])
+                ]
             );
 
             var document = subject.GetSwagger("v1");
             Assert.Equal("V1", document.Info.Version);
             Assert.Equal("Test API", document.Info.Title);
-            Assert.Equal(new[] { "/resource" }, document.Paths.Keys.ToArray());
+            Assert.Equal(["/resource"], [.. document.Paths.Keys]);
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.NotNull(operation.Parameters);
@@ -2029,15 +2026,15 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                                     new FakeICompositeMetadataDetailsProvider(),
                                     new DefaultMetadataDetails(ModelMetadataIdentity.ForProperty(propertyNotIgnored, typeof(string), typeof(SwaggerIngoreAnnotatedType)), ModelAttributes.GetAttributesForProperty(typeof(SwaggerIngoreAnnotatedType), propertyNotIgnored)));
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                    ApiDescriptionFactory.Create<FakeController>(
                         c => nameof(c.ActionHavingFromFormAttributeWithSwaggerIgnore),
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new[]
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = nameof(SwaggerIngoreAnnotatedType.IgnoredString),
@@ -2052,19 +2049,19 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                                 Type = typeof(string),
                                 ModelMetadata = modelMetadataNotIgnored
                             }
-                        })
-                }
+                        ])
+                ]
             );
             var document = subject.GetSwagger("v1");
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.NotNull(operation.RequestBody);
-            Assert.Equal(new[] { "multipart/form-data" }, operation.RequestBody.Content.Keys);
+            Assert.Equal(["multipart/form-data"], operation.RequestBody.Content.Keys);
             var mediaType = operation.RequestBody.Content["multipart/form-data"];
             Assert.NotNull(mediaType.Schema);
-            Assert.Equal(new[] { nameof(SwaggerIngoreAnnotatedType.NotIgnoredString) }, mediaType.Schema.Properties.Keys);
+            Assert.Equal([nameof(SwaggerIngoreAnnotatedType.NotIgnoredString)], mediaType.Schema.Properties.Keys);
             Assert.NotNull(mediaType.Encoding);
-            Assert.Equal(new[] { nameof(SwaggerIngoreAnnotatedType.NotIgnoredString) }, mediaType.Encoding.Keys);
+            Assert.Equal([nameof(SwaggerIngoreAnnotatedType.NotIgnoredString)], mediaType.Encoding.Keys);
         }
 
         [Fact]
@@ -2203,8 +2200,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                         groupName: "v1",
                         httpMethod: "POST",
                         relativePath: "resource",
-                        parameterDescriptions: new[]
-                        {
+                        parameterDescriptions:
+                        [
                             new ApiParameterDescription
                             {
                                 Name = nameof(TypeWithDefaultAttributeOnEnum.EnumWithDefault),
@@ -2219,7 +2216,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                                 Type = typeof(IntEnum[]),
                                 ModelMetadata = modelMetadataForEnumArray
                             }
-                        })
+                        ])
                ],
                schemaFilters: [new TestEnumSchemaFilter()]
            );
@@ -2489,8 +2486,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));
             var actionDescriptor = new ActionDescriptor
             {
-                EndpointMetadata = new List<object>()
-                {
+                EndpointMetadata =
+                [
                     new OpenApiOperation()
                     {
                         RequestBody = new OpenApiRequestBody()
@@ -2501,25 +2498,25 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                             }
                         }
                     }
-                },
+                ],
                 RouteValues = new Dictionary<string, string>
                 {
                     ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
                 }
             };
             var subject = Subject(
-                apiDescriptions: new[]
-                {
+                apiDescriptions:
+                [
                     ApiDescriptionFactory.Create(actionDescriptor, methodInfo, groupName: "v1", httpMethod: "POST", relativePath: "resource"),
-                }
+                ]
             );
 
             var document = subject.GetSwagger("v1");
 
             Assert.Equal("V1", document.Info.Version);
             Assert.Equal("Test API", document.Info.Title);
-            Assert.Equal(new[] { "/resource" }, document.Paths.Keys.ToArray());
-            Assert.Equal(new[] { OperationType.Post }, document.Paths["/resource"].Operations.Keys);
+            Assert.Equal(["/resource"], [.. document.Paths.Keys]);
+            Assert.Equal([OperationType.Post], document.Paths["/resource"].Operations.Keys);
             Assert.Single(document.Paths["/resource"].Operations);
         }
 
@@ -2582,7 +2579,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             );
         }
 
-        private static readonly SwaggerGeneratorOptions DefaultOptions = new SwaggerGeneratorOptions
+        private static readonly SwaggerGeneratorOptions DefaultOptions = new()
         {
             SwaggerDocs = new Dictionary<string, OpenApiInfo>
             {

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -337,13 +337,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.NotNull(content.Value.Schema.Reference);
             Assert.Equal("TestDto", content.Value.Schema.Reference.Id);
             Assert.Equal(2, operation.RequestBody.Extensions.Count);
-            Assert.Equal("bar", ((OpenApiString)operation.RequestBody.Extensions["X-foo"]).Value);
-            Assert.Equal("v1", ((OpenApiString)operation.RequestBody.Extensions["X-docName"]).Value);
+            Assert.Equal("bar", ((OpenApiAny)operation.RequestBody.Extensions["X-foo"]).Node.GetValue<string>());
+            Assert.Equal("v1", ((OpenApiAny)operation.RequestBody.Extensions["X-docName"]).Node.GetValue<string>());
             Assert.NotEmpty(operation.Parameters);
             Assert.Equal("paramQuery", operation.Parameters[0].Name);
             Assert.Equal(2, operation.Parameters[0].Extensions.Count);
-            Assert.Equal("bar", ((OpenApiString)operation.Parameters[0].Extensions["X-foo"]).Value);
-            Assert.Equal("v1", ((OpenApiString)operation.Parameters[0].Extensions["X-docName"]).Value);
+            Assert.Equal("bar", ((OpenApiAny)operation.Parameters[0].Extensions["X-foo"]).Node.GetValue<string>());
+            Assert.Equal("v1", ((OpenApiAny)operation.Parameters[0].Extensions["X-docName"]).Node.GetValue<string>());
         }
 
         [Fact]
@@ -397,7 +397,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal("OperationIdSetInMetadata", document.Paths["/resource"].Operations[OperationType.Post].OperationId);
             Assert.Equal("ParameterInMetadata", document.Paths["/resource"].Operations[OperationType.Post].Parameters[0].Name);
             Assert.NotNull(document.Paths["/resource"].Operations[OperationType.Post].Parameters[0].Schema);
-            Assert.Equal("string", document.Paths["/resource"].Operations[OperationType.Post].Parameters[0].Schema.Type);
+            Assert.Equal(JsonSchemaType.String, document.Paths["/resource"].Operations[OperationType.Post].Parameters[0].Schema.Type);
         }
 
         [Fact]
@@ -821,7 +821,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             var parameter = Assert.Single(operation.Parameters);
-            Assert.Equal("string", parameter.Schema.Type);
+            Assert.Equal(JsonSchemaType.String, parameter.Schema.Type);
         }
 
         [Fact]
@@ -1055,7 +1055,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var content = operation.Responses["200"].Content.FirstOrDefault();
             Assert.Equal("application/zip", content.Key);
             Assert.Equal("binary", content.Value.Schema.Format);
-            Assert.Equal("string", content.Value.Schema.Type);
+            Assert.Equal(JsonSchemaType.String, content.Value.Schema.Type);
         }
 
         [Fact]
@@ -1257,7 +1257,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var document = subject.GetSwagger("v1");
 
-            Assert.Equal(["resource"], document.Paths["/resource"].Operations[OperationType.Post].Tags.Select(t => t.Name));
+            Assert.Equal(["resource"], [.. document.Paths["/resource"].Operations[OperationType.Post].Tags?.Select(t => t.Name)]);
         }
 
         [Fact]
@@ -1281,7 +1281,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var document = subject.GetSwagger("v1");
 
-            Assert.Equal(["Some", "Tags", "Here"], document.Paths["/resource"].Operations[OperationType.Post].Tags.Select(t => t.Name));
+            Assert.Equal(["Some", "Tags", "Here"], [.. document.Paths["/resource"].Operations[OperationType.Post].Tags?.Select(t => t.Name)]);
         }
 
 #if NET7_0_OR_GREATER
@@ -1550,8 +1550,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(2, operation.Parameters[0].Extensions.Count);
-            Assert.Equal("bar", ((OpenApiString)operation.Parameters[0].Extensions["X-foo"]).Value);
-            Assert.Equal("v1", ((OpenApiString)operation.Parameters[0].Extensions["X-docName"]).Value);
+            Assert.Equal("bar", ((OpenApiAny)operation.Parameters[0].Extensions["X-foo"]).Node.GetValue<string>());
+            Assert.Equal("v1", ((OpenApiAny)operation.Parameters[0].Extensions["X-docName"]).Node.GetValue<string>());
         }
 
         [Fact]
@@ -1587,8 +1587,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(2, operation.RequestBody.Extensions.Count);
-            Assert.Equal("bar", ((OpenApiString)operation.RequestBody.Extensions["X-foo"]).Value);
-            Assert.Equal("v1", ((OpenApiString)operation.RequestBody.Extensions["X-docName"]).Value);
+            Assert.Equal("bar", ((OpenApiAny)operation.RequestBody.Extensions["X-foo"]).Node.GetValue<string>());
+            Assert.Equal("v1", ((OpenApiAny)operation.RequestBody.Extensions["X-docName"]).Node.GetValue<string>());
         }
 
         [Fact]
@@ -1617,8 +1617,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(2, operation.Extensions.Count);
-            Assert.Equal("bar", ((OpenApiString)operation.Extensions["X-foo"]).Value);
-            Assert.Equal("v1", ((OpenApiString)operation.Extensions["X-docName"]).Value);
+            Assert.Equal("bar", ((OpenApiAny)operation.Extensions["X-foo"]).Node.GetValue<string>());
+            Assert.Equal("v1", ((OpenApiAny)operation.Extensions["X-docName"]).Node.GetValue<string>());
         }
 
         [Fact]
@@ -1642,8 +1642,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var document = subject.GetSwagger("v1");
 
             Assert.Equal(2, document.Extensions.Count);
-            Assert.Equal("bar", ((OpenApiString)document.Extensions["X-foo"]).Value);
-            Assert.Equal("v1", ((OpenApiString)document.Extensions["X-docName"]).Value);
+            Assert.Equal("bar", ((OpenApiAny)document.Extensions["X-foo"]).Node.GetValue<string>());
+            Assert.Equal("v1", ((OpenApiAny)document.Extensions["X-docName"]).Node.GetValue<string>());
             Assert.Contains("ComplexType", document.Components.Schemas.Keys);
         }
 
@@ -1673,8 +1673,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(2, operation.Extensions.Count);
-            Assert.Equal("bar", ((OpenApiString)operation.Extensions["X-foo"]).Value);
-            Assert.Equal("v1", ((OpenApiString)operation.Extensions["X-docName"]).Value);
+            Assert.Equal("bar", ((OpenApiAny)operation.Extensions["X-foo"]).Node.GetValue<string>());
+            Assert.Equal("v1", ((OpenApiAny)operation.Extensions["X-docName"]).Node.GetValue<string>());
         }
 
         [Fact]
@@ -1703,8 +1703,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(2, operation.Extensions.Count);
-            Assert.Equal("bar", ((OpenApiString)operation.Extensions["X-foo"]).Value);
-            Assert.Equal("v1", ((OpenApiString)operation.Extensions["X-docName"]).Value);
+            Assert.Equal("bar", ((OpenApiAny)operation.Extensions["X-foo"]).Node.GetValue<string>());
+            Assert.Equal("v1", ((OpenApiAny)operation.Extensions["X-docName"]).Node.GetValue<string>());
         }
 
         [Fact]
@@ -1728,8 +1728,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var document = await subject.GetSwaggerAsync("v1");
 
             Assert.Equal(2, document.Extensions.Count);
-            Assert.Equal("bar", ((OpenApiString)document.Extensions["X-foo"]).Value);
-            Assert.Equal("v1", ((OpenApiString)document.Extensions["X-docName"]).Value);
+            Assert.Equal("bar", ((OpenApiAny)document.Extensions["X-foo"]).Node.GetValue<string>());
+            Assert.Equal("v1", ((OpenApiAny)document.Extensions["X-docName"]).Node.GetValue<string>());
             Assert.Contains("ComplexType", document.Components.Schemas.Keys);
         }
 
@@ -1754,8 +1754,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var document = await subject.GetSwaggerAsync("v1");
 
             Assert.Equal(2, document.Extensions.Count);
-            Assert.Equal("bar", ((OpenApiString)document.Extensions["X-foo"]).Value);
-            Assert.Equal("v1", ((OpenApiString)document.Extensions["X-docName"]).Value);
+            Assert.Equal("bar", ((OpenApiAny)document.Extensions["X-foo"]).Node.GetValue<string>());
+            Assert.Equal("v1", ((OpenApiAny)document.Extensions["X-docName"]).Node.GetValue<string>());
             Assert.Contains("ComplexType", document.Components.Schemas.Keys);
         }
 
@@ -1792,8 +1792,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(2, operation.RequestBody.Extensions.Count);
-            Assert.Equal("bar", ((OpenApiString)operation.RequestBody.Extensions["X-foo"]).Value);
-            Assert.Equal("v1", ((OpenApiString)operation.RequestBody.Extensions["X-docName"]).Value);
+            Assert.Equal("bar", ((OpenApiAny)operation.RequestBody.Extensions["X-foo"]).Node.GetValue<string>());
+            Assert.Equal("v1", ((OpenApiAny)operation.RequestBody.Extensions["X-docName"]).Node.GetValue<string>());
         }
 
         [Fact]
@@ -1829,8 +1829,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(2, operation.RequestBody.Extensions.Count);
-            Assert.Equal("bar", ((OpenApiString)operation.RequestBody.Extensions["X-foo"]).Value);
-            Assert.Equal("v1", ((OpenApiString)operation.RequestBody.Extensions["X-docName"]).Value);
+            Assert.Equal("bar", ((OpenApiAny)operation.RequestBody.Extensions["X-foo"]).Node.GetValue<string>());
+            Assert.Equal("v1", ((OpenApiAny)operation.RequestBody.Extensions["X-docName"]).Node.GetValue<string>());
         }
 
         [Fact]
@@ -1866,8 +1866,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(2, operation.Parameters[0].Extensions.Count);
-            Assert.Equal("bar", ((OpenApiString)operation.Parameters[0].Extensions["X-foo"]).Value);
-            Assert.Equal("v1", ((OpenApiString)operation.Parameters[0].Extensions["X-docName"]).Value);
+            Assert.Equal("bar", ((OpenApiAny)operation.Parameters[0].Extensions["X-foo"]).Node.GetValue<string>());
+            Assert.Equal("v1", ((OpenApiAny)operation.Parameters[0].Extensions["X-docName"]).Node.GetValue<string>());
         }
 
         [Fact]
@@ -1903,8 +1903,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             var operation = document.Paths["/resource"].Operations[OperationType.Post];
             Assert.Equal(2, operation.Parameters[0].Extensions.Count);
-            Assert.Equal("bar", ((OpenApiString)operation.Parameters[0].Extensions["X-foo"]).Value);
-            Assert.Equal("v1", ((OpenApiString)operation.Parameters[0].Extensions["X-docName"]).Value);
+            Assert.Equal("bar", ((OpenApiAny)operation.Parameters[0].Extensions["X-foo"]).Node.GetValue<string>());
+            Assert.Equal("v1", ((OpenApiAny)operation.Parameters[0].Extensions["X-docName"]).Node.GetValue<string>());
         }
 
         [Theory]
@@ -2345,10 +2345,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var content = Assert.Single(document.Paths["/resource"].Operations[OperationType.Post].RequestBody.Content);
             Assert.Equal("application/someMediaType", content.Key);
             Assert.NotNull(content.Value.Schema);
-            Assert.Equal("object", content.Value.Schema.Type);
+            Assert.Equal(JsonSchemaType.Object, content.Value.Schema.Type);
             Assert.NotEmpty(content.Value.Schema.Properties);
             Assert.NotNull(content.Value.Schema.Properties["param"]);
-            Assert.Equal("string", content.Value.Schema.Properties["param"].Type);
+            Assert.Equal(JsonSchemaType.String, content.Value.Schema.Properties["param"].Type);
             Assert.Equal("binary", content.Value.Schema.Properties["param"].Format);
             Assert.NotNull(content.Value.Encoding);
             Assert.NotNull(content.Value.Encoding["param"]);
@@ -2407,12 +2407,12 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var content = Assert.Single(document.Paths["/resource"].Operations[OperationType.Post].RequestBody.Content);
             Assert.Equal("application/someMediaType", content.Key);
             Assert.NotNull(content.Value.Schema);
-            Assert.Equal("object", content.Value.Schema.Type);
+            Assert.Equal(JsonSchemaType.Object, content.Value.Schema.Type);
             Assert.NotEmpty(content.Value.Schema.Properties);
             Assert.NotNull(content.Value.Schema.Properties["param"]);
-            Assert.Equal("array", content.Value.Schema.Properties["param"].Type);
+            Assert.Equal(JsonSchemaType.Array, content.Value.Schema.Properties["param"].Type);
             Assert.NotNull(content.Value.Schema.Properties["param"].Items);
-            Assert.Equal("string", content.Value.Schema.Properties["param"].Items.Type);
+            Assert.Equal(JsonSchemaType.String, content.Value.Schema.Properties["param"].Items.Type);
             Assert.Equal("binary", content.Value.Schema.Properties["param"].Items.Format);
             Assert.NotNull(content.Value.Encoding);
             Assert.NotNull(content.Value.Encoding["param"]);
@@ -2471,10 +2471,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var content = Assert.Single(document.Paths["/resource"].Operations[OperationType.Post].RequestBody.Content);
             Assert.Equal("application/someMediaType", content.Key);
             Assert.NotNull(content.Value.Schema);
-            Assert.Equal("object", content.Value.Schema.Type);
+            Assert.Equal(JsonSchemaType.Object, content.Value.Schema.Type);
             Assert.NotEmpty(content.Value.Schema.Properties);
             Assert.NotNull(content.Value.Schema.Properties["param"]);
-            Assert.Equal("string", content.Value.Schema.Properties["param"].Type);
+            Assert.Equal(JsonSchemaType.String, content.Value.Schema.Properties["param"].Type);
             Assert.NotNull(content.Value.Encoding);
             Assert.NotNull(content.Value.Encoding["param"]);
             Assert.Equal(ParameterStyle.Form, content.Value.Encoding["param"].Style);

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.ActionWithConsumesAttributeAndProvidedOpenApiOperation.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.ActionWithConsumesAttributeAndProvidedOpenApiOperation.verified.txt
@@ -1,4 +1,7 @@
 ﻿{
+  Workspace: {
+    BaseUrl: https://openapi.net/
+  },
   Info: {
     Title: Test API,
     Version: V1
@@ -14,14 +17,16 @@
             Content: {
               application/someMediaType: {
                 Schema: {
+                  UnEvaluatedProperties: false,
                   ReadOnly: false,
                   WriteOnly: false,
                   AdditionalPropertiesAllowed: true,
                   Nullable: false,
+                  UnevaluatedProperties: false,
                   Deprecated: false,
                   UnresolvedReference: false,
                   Reference: {
-                    IsFragrament: false,
+                    IsFragment: false,
                     Type: Schema,
                     Id: TestDto,
                     IsExternal: false,
@@ -42,26 +47,29 @@
   Components: {
     Schemas: {
       TestDto: {
-        Type: object,
+        UnEvaluatedProperties: false,
+        Type: Object,
         ReadOnly: false,
         WriteOnly: false,
         Properties: {
           Prop1: {
-            Type: string,
+            UnEvaluatedProperties: false,
+            Type: String,
             ReadOnly: false,
             WriteOnly: false,
             AdditionalPropertiesAllowed: true,
             Nullable: true,
+            UnevaluatedProperties: false,
             Deprecated: false,
             UnresolvedReference: false
           }
         },
         AdditionalPropertiesAllowed: false,
         Nullable: false,
+        UnevaluatedProperties: false,
         Deprecated: false,
         UnresolvedReference: false
       }
     }
-  },
-  HashCode: 59A5DD972A919CE8EF3F08E63BB492CCCA30B825146EA05B2BEF4690888EA52FB3CEC61C7F1F9A14629EDFF141CC49084DA127F3D6C5F555D8EA39F7B202C4E9
+  }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.ActionWithParameterAndProvidedOpenApiOperation.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.ActionWithParameterAndProvidedOpenApiOperation.verified.txt
@@ -1,4 +1,7 @@
 ﻿{
+  Workspace: {
+    BaseUrl: https://openapi.net/
+  },
   Info: {
     Title: Test API,
     Version: V1
@@ -19,11 +22,13 @@
               Explode: false,
               AllowReserved: false,
               Schema: {
-                Type: string,
+                UnEvaluatedProperties: false,
+                Type: String,
                 ReadOnly: false,
                 WriteOnly: false,
                 AdditionalPropertiesAllowed: true,
                 Nullable: false,
+                UnevaluatedProperties: false,
                 Deprecated: false,
                 UnresolvedReference: false
               }
@@ -35,6 +40,5 @@
       UnresolvedReference: false
     }
   },
-  Components: {},
-  HashCode: 80ACD622C6A7E73B1C5084D230E624A2A5897CCCC091D32500F9192221224A9A256D1E80276A6D47B85459035DFF93938E2378ACE8A3E854CB32390244297D61
+  Components: {}
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.ActionWithProducesAttributeAndProvidedOpenApiOperation.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.ActionWithProducesAttributeAndProvidedOpenApiOperation.verified.txt
@@ -1,4 +1,7 @@
 ﻿{
+  Workspace: {
+    BaseUrl: https://openapi.net/
+  },
   Info: {
     Title: Test API,
     Version: V1
@@ -13,14 +16,16 @@
               Content: {
                 application/someMediaType: {
                   Schema: {
+                    UnEvaluatedProperties: false,
                     ReadOnly: false,
                     WriteOnly: false,
                     AdditionalPropertiesAllowed: true,
                     Nullable: false,
+                    UnevaluatedProperties: false,
                     Deprecated: false,
                     UnresolvedReference: false,
                     Reference: {
-                      IsFragrament: false,
+                      IsFragment: false,
                       Type: Schema,
                       Id: TestDto,
                       IsExternal: false,
@@ -43,26 +48,29 @@
   Components: {
     Schemas: {
       TestDto: {
-        Type: object,
+        UnEvaluatedProperties: false,
+        Type: Object,
         ReadOnly: false,
         WriteOnly: false,
         Properties: {
           Prop1: {
-            Type: string,
+            UnEvaluatedProperties: false,
+            Type: String,
             ReadOnly: false,
             WriteOnly: false,
             AdditionalPropertiesAllowed: true,
             Nullable: true,
+            UnevaluatedProperties: false,
             Deprecated: false,
             UnresolvedReference: false
           }
         },
         AdditionalPropertiesAllowed: false,
         Nullable: false,
+        UnevaluatedProperties: false,
         Deprecated: false,
         UnresolvedReference: false
       }
     }
-  },
-  HashCode: 33EF286A101E847C16BF4B86DF410E6C22D16FEA221DEC72217642B13238E9C69382B5EBE1F7B9FEFC5E2819EA81D1C4C28A8E2AFF075F8E1CCF425F635F9532
+  }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.ActionWithProvidedOpenApiMetadata.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.ActionWithProvidedOpenApiMetadata.verified.txt
@@ -1,4 +1,7 @@
 ﻿{
+  Workspace: {
+    BaseUrl: https://openapi.net/
+  },
   Info: {
     Title: Test API,
     Version: V1
@@ -26,6 +29,5 @@
       UnresolvedReference: false
     }
   },
-  Components: {},
-  HashCode: 76DE54DD44D94D07BC803E615ECB0F6D290C3B8803EFB5EADF02C6B180682B1C20BFDD4C9CD50F71D5AD7042B7B4570903F3AF1CC7970ABCA1CEE20FBF971FFD
+  Components: {}
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFile.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFile.verified.txt
@@ -1,4 +1,7 @@
 ﻿{
+  Workspace: {
+    BaseUrl: https://openapi.net/
+  },
   Info: {
     Title: Test API,
     Version: V1
@@ -14,23 +17,27 @@
             Content: {
               application/someMediaType: {
                 Schema: {
-                  Type: object,
+                  UnEvaluatedProperties: false,
+                  Type: Object,
                   ReadOnly: false,
                   WriteOnly: false,
                   Properties: {
                     param: {
-                      Type: string,
+                      UnEvaluatedProperties: false,
+                      Type: String,
                       Format: binary,
                       ReadOnly: false,
                       WriteOnly: false,
                       AdditionalPropertiesAllowed: true,
                       Nullable: false,
+                      UnevaluatedProperties: false,
                       Deprecated: false,
                       UnresolvedReference: false
                     }
                   },
                   AdditionalPropertiesAllowed: true,
                   Nullable: false,
+                  UnevaluatedProperties: false,
                   Deprecated: false,
                   UnresolvedReference: false
                 },
@@ -48,6 +55,5 @@
       UnresolvedReference: false
     }
   },
-  Components: {},
-  HashCode: 7D034A2620C1D85B3AC60194DFA59693F727DE4704B2D02E124FDA37F843426C258EF2BEB84E6B8E8D315E23A4BCBE1F423B479E6CDF8AFFB8514D49B9A3CC9E
+  Components: {}
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFileCollection.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFileCollection.verified.txt
@@ -1,4 +1,7 @@
 ﻿{
+  Workspace: {
+    BaseUrl: https://openapi.net/
+  },
   Info: {
     Title: Test API,
     Version: V1
@@ -14,32 +17,38 @@
             Content: {
               application/someMediaType: {
                 Schema: {
-                  Type: object,
+                  UnEvaluatedProperties: false,
+                  Type: Object,
                   ReadOnly: false,
                   WriteOnly: false,
                   Properties: {
                     param: {
-                      Type: array,
+                      UnEvaluatedProperties: false,
+                      Type: Array,
                       ReadOnly: false,
                       WriteOnly: false,
                       Items: {
-                        Type: string,
+                        UnEvaluatedProperties: false,
+                        Type: String,
                         Format: binary,
                         ReadOnly: false,
                         WriteOnly: false,
                         AdditionalPropertiesAllowed: true,
                         Nullable: false,
+                        UnevaluatedProperties: false,
                         Deprecated: false,
                         UnresolvedReference: false
                       },
                       AdditionalPropertiesAllowed: true,
                       Nullable: false,
+                      UnevaluatedProperties: false,
                       Deprecated: false,
                       UnresolvedReference: false
                     }
                   },
                   AdditionalPropertiesAllowed: true,
                   Nullable: false,
+                  UnevaluatedProperties: false,
                   Deprecated: false,
                   UnresolvedReference: false
                 },
@@ -57,6 +66,5 @@
       UnresolvedReference: false
     }
   },
-  Components: {},
-  HashCode: 073D8B8E67D5100DD8AF06EC69A3C02B8DBF29E46621ED6EB590DEA519F2C8941398F6B95292D891CC4E18C2F4D5D38A8F904545CFFC219E4FF4613AD605E5A5
+  Components: {}
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithStringFromForm.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithStringFromForm.verified.txt
@@ -1,4 +1,7 @@
 ﻿{
+  Workspace: {
+    BaseUrl: https://openapi.net/
+  },
   Info: {
     Title: Test API,
     Version: V1
@@ -14,22 +17,26 @@
             Content: {
               application/someMediaType: {
                 Schema: {
-                  Type: object,
+                  UnEvaluatedProperties: false,
+                  Type: Object,
                   ReadOnly: false,
                   WriteOnly: false,
                   Properties: {
                     param: {
-                      Type: string,
+                      UnEvaluatedProperties: false,
+                      Type: String,
                       ReadOnly: false,
                       WriteOnly: false,
                       AdditionalPropertiesAllowed: true,
                       Nullable: false,
+                      UnevaluatedProperties: false,
                       Deprecated: false,
                       UnresolvedReference: false
                     }
                   },
                   AdditionalPropertiesAllowed: true,
                   Nullable: false,
+                  UnevaluatedProperties: false,
                   Deprecated: false,
                   UnresolvedReference: false
                 },
@@ -47,6 +54,5 @@
       UnresolvedReference: false
     }
   },
-  Components: {},
-  HashCode: 7639B8A665AFC72F5C8D9ED02AA2E6416B9F82FDCC86D490FD248D3B657355F3993BD00384468E8D23DC0AC9FACECD425824F9596F6183EBDF974B9343CEDCF7
+  Components: {}
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.IllegalHeaderParameterWithOpenApiOperation_action=ActionWithAcceptFromHeaderParameter.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.IllegalHeaderParameterWithOpenApiOperation_action=ActionWithAcceptFromHeaderParameter.verified.txt
@@ -1,4 +1,7 @@
 ﻿{
+  Workspace: {
+    BaseUrl: https://openapi.net/
+  },
   Info: {
     Title: Test API,
     Version: V1
@@ -29,11 +32,13 @@
               Explode: false,
               AllowReserved: false,
               Schema: {
-                Type: string,
+                UnEvaluatedProperties: false,
+                Type: String,
                 ReadOnly: false,
                 WriteOnly: false,
                 AdditionalPropertiesAllowed: true,
                 Nullable: false,
+                UnevaluatedProperties: false,
                 Deprecated: false,
                 UnresolvedReference: false
               }
@@ -45,6 +50,5 @@
       UnresolvedReference: false
     }
   },
-  Components: {},
-  HashCode: 48AB134AF00E0ED90AEA7E4E5BADDD7218AB02E7956DD5FAE3C500F4324F14066B32F2EF85E9C52A68431858FED77604C3ABE6CAED518CCB8EC46D22DF63A3DF
+  Components: {}
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.IllegalHeaderParameterWithOpenApiOperation_action=ActionWithAuthorizationFromHeaderParameter.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.IllegalHeaderParameterWithOpenApiOperation_action=ActionWithAuthorizationFromHeaderParameter.verified.txt
@@ -1,4 +1,7 @@
 ﻿{
+  Workspace: {
+    BaseUrl: https://openapi.net/
+  },
   Info: {
     Title: Test API,
     Version: V1
@@ -29,11 +32,13 @@
               Explode: false,
               AllowReserved: false,
               Schema: {
-                Type: string,
+                UnEvaluatedProperties: false,
+                Type: String,
                 ReadOnly: false,
                 WriteOnly: false,
                 AdditionalPropertiesAllowed: true,
                 Nullable: false,
+                UnevaluatedProperties: false,
                 Deprecated: false,
                 UnresolvedReference: false
               }
@@ -45,6 +50,5 @@
       UnresolvedReference: false
     }
   },
-  Components: {},
-  HashCode: 7B61DF19EC4750E8986D14FA33D86546B51021EA5782C80735BD0BE7A8937AB7CF57D19DDB31BAF396652C20AE904404BAF7116B4C6678720293B513806412ED
+  Components: {}
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.IllegalHeaderParameterWithOpenApiOperation_action=ActionWithContentTypeFromHeaderParameter.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.IllegalHeaderParameterWithOpenApiOperation_action=ActionWithContentTypeFromHeaderParameter.verified.txt
@@ -1,4 +1,7 @@
 ﻿{
+  Workspace: {
+    BaseUrl: https://openapi.net/
+  },
   Info: {
     Title: Test API,
     Version: V1
@@ -29,11 +32,13 @@
               Explode: false,
               AllowReserved: false,
               Schema: {
-                Type: string,
+                UnEvaluatedProperties: false,
+                Type: String,
                 ReadOnly: false,
                 WriteOnly: false,
                 AdditionalPropertiesAllowed: true,
                 Nullable: false,
+                UnevaluatedProperties: false,
                 Deprecated: false,
                 UnresolvedReference: false
               }
@@ -45,6 +50,5 @@
       UnresolvedReference: false
     }
   },
-  Components: {},
-  HashCode: F6CB61AEE648F54EC5BBCD1801BF8194997A0D5B99DDCFC0AF71CEDF79888B58EC1798313ECD4181CBAA61F377A80199CDB82412B744E9EF115F247F8A4A18EC
+  Components: {}
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.OperationHasSwaggerIgnoreAttribute.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.OperationHasSwaggerIgnoreAttribute.verified.txt
@@ -1,8 +1,10 @@
 ﻿{
+  Workspace: {
+    BaseUrl: https://openapi.net/
+  },
   Info: {
     Title: Test API,
     Version: V1
   },
-  Components: {},
-  HashCode: 862B7E551B2E991D5F9B640090999C8D4EA20752DC6C69FC82E176A30B2039344A80321E469E806BD3AEA3641DAD6DEE970423561F262A187C04F58915996596
+  Components: {}
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGeneratorVerifyTests/SwaggerGeneratorVerifyTests.cs
@@ -49,7 +49,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -126,7 +126,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -179,7 +179,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -230,7 +230,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -281,7 +281,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -297,7 +297,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -327,7 +327,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -351,7 +351,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -375,7 +375,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Theory]
@@ -406,7 +406,9 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document).UseParameters(bindingSourceId);
+        return Verifier.Verify(document)
+            .UseParameters(bindingSourceId)
+            .IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -427,7 +429,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -454,7 +456,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -482,7 +484,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Theory]
@@ -522,7 +524,9 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document).UseParameters(action);
+        return Verifier.Verify(document)
+            .UseParameters(action)
+            .IgnoreMember("BaseUri");
     }
 
     [Theory]
@@ -592,7 +596,8 @@ public class SwaggerGeneratorVerifyTests
 
         return Verifier.Verify(document)
             .UseParameters(action)
-            .UseMethodName("IllegalHeaderParameterWithOpenApiOperation");
+            .UseMethodName("IllegalHeaderParameterWithOpenApiOperation")
+            .IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -619,7 +624,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Theory]
@@ -648,7 +653,9 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document).UseParameters(action);
+        return Verifier.Verify(document)
+            .UseParameters(action)
+            .IgnoreMember("BaseUri");
     }
 
     [Theory]
@@ -681,7 +688,9 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document).UseParameters(action);
+        return Verifier.Verify(document)
+            .UseParameters(action)
+            .IgnoreMember("BaseUri");
     }
 
 #if NET7_0_OR_GREATER
@@ -710,7 +719,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -734,7 +743,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -758,7 +767,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 #endif
 
@@ -795,7 +804,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -822,7 +831,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -856,7 +865,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Theory]
@@ -885,7 +894,9 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document).UseParameters(bindingSourceId);
+        return Verifier.Verify(document)
+            .UseParameters(bindingSourceId)
+            .IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -929,7 +940,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -959,7 +970,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -986,7 +997,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -1013,7 +1024,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -1055,7 +1066,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -1101,7 +1112,7 @@ public class SwaggerGeneratorVerifyTests
         );
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -1129,7 +1140,7 @@ public class SwaggerGeneratorVerifyTests
         );
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -1164,7 +1175,7 @@ public class SwaggerGeneratorVerifyTests
         );
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -1193,7 +1204,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -1240,7 +1251,7 @@ public class SwaggerGeneratorVerifyTests
        );
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -1297,7 +1308,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -1348,7 +1359,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -1399,7 +1410,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     [Fact]
@@ -1450,7 +1461,7 @@ public class SwaggerGeneratorVerifyTests
 
         var document = subject.GetSwagger("v1");
 
-        return Verifier.Verify(document);
+        return Verifier.Verify(document).IgnoreMember("BaseUri");
     }
 
     private static SwaggerGenerator Subject(

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsExampleHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsExampleHelperTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.OpenApi.Any;
+﻿using System.Text.Json;
 using Microsoft.OpenApi.Models;
 using Xunit;
 
@@ -19,44 +19,44 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                 "[\"one\",\"two\",\"three\"]");
 
             Assert.NotNull(example);
-            var actual = Assert.IsType<OpenApiArray>(example);
+            Assert.Equal(JsonValueKind.Array, example.GetValueKind());
+            var actual = example.AsArray();
             Assert.Equal(3, actual.Count);
 
-            var item1 = Assert.IsType<OpenApiString>(actual[0]);
-            var item2 = Assert.IsType<OpenApiString>(actual[1]);
-            var item3 = Assert.IsType<OpenApiString>(actual[2]);
-            Assert.Equal("one",   item1.Value);
-            Assert.Equal("two",   item2.Value);
-            Assert.Equal("three", item3.Value);
+            Assert.Equal(JsonValueKind.String, actual[0].GetValueKind());
+            Assert.Equal(JsonValueKind.String, actual[1].GetValueKind());
+            Assert.Equal(JsonValueKind.String, actual[2].GetValueKind());
+            Assert.Equal("one",   actual[0].GetValue<string>());
+            Assert.Equal("two",   actual[1].GetValue<string>());
+            Assert.Equal("three", actual[2].GetValue<string>());
         }
 
         [Fact]
         public void Create_BuildsOpenApiString_When_TypeString()
         {
             string exampleString = "example string with special characters\"<>\r\n\"";
-            OpenApiSchema schema = new OpenApiSchema { Type = "string" };
+            var schema = new OpenApiSchema { Type = JsonSchemaType.String };
             schemaRepository.AddDefinition("test", schema);
-            
+
             var example = XmlCommentsExampleHelper.Create(
                 schemaRepository, schema, exampleString);
 
             Assert.NotNull(example);
-            var actual = Assert.IsType<OpenApiString>(example);
-            Assert.Equal(actual.Value, exampleString);
+            Assert.Equal(JsonValueKind.String, example.GetValueKind());
+            Assert.Equal(exampleString, example.GetValue<string>());
         }
 
         [Fact]
         public void Create_ReturnsNull_When_TypeString_and_ValueNull()
         {
-            var schema = new OpenApiSchema { Type = "string" };
+            var schema = new OpenApiSchema { Type = JsonSchemaType.String };
             schemaRepository.AddDefinition("test", schema);
 
             var example = XmlCommentsExampleHelper.Create(
                 schemaRepository, schema, "null");
 
             Assert.NotNull(example);
-            var actual = Assert.IsType<OpenApiNull>(example);
-            Assert.Equal(AnyType.Null, actual.AnyType);
+            Assert.Equal(JsonValueKind.Null, example.GetValueKind());
         }
 
         [Fact]
@@ -67,8 +67,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             var example = XmlCommentsExampleHelper.Create(schemaRepository, schema, "[]");
 
             Assert.NotNull(example);
-            var actual = Assert.IsType<OpenApiArray>(example);
-            Assert.Empty(actual);
+            Assert.Equal(JsonValueKind.Array, example.GetValueKind());
+            Assert.Empty(example.AsArray());
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsExampleHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsExampleHelperTests.cs
@@ -6,14 +6,14 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
     public class XmlCommentsExampleHelperTests
     {
-        private readonly SchemaRepository schemaRepository = new SchemaRepository();
+        private readonly SchemaRepository schemaRepository = new();
 
         [Fact]
         public void Create_BuildsOpenApiArrayJson__When_NotStringTypeAndDataIsArray()
         {
             var schema = new OpenApiSchema();
 
-            IOpenApiAny example = XmlCommentsExampleHelper.Create(
+            var example = XmlCommentsExampleHelper.Create(
                 schemaRepository,
                 schema,
                 "[\"one\",\"two\",\"three\"]");
@@ -37,7 +37,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             OpenApiSchema schema = new OpenApiSchema { Type = "string" };
             schemaRepository.AddDefinition("test", schema);
             
-            IOpenApiAny example = XmlCommentsExampleHelper.Create(
+            var example = XmlCommentsExampleHelper.Create(
                 schemaRepository, schema, exampleString);
 
             Assert.NotNull(example);
@@ -48,10 +48,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [Fact]
         public void Create_ReturnsNull_When_TypeString_and_ValueNull()
         {
-            OpenApiSchema schema = new OpenApiSchema { Type = "string" };
+            var schema = new OpenApiSchema { Type = "string" };
             schemaRepository.AddDefinition("test", schema);
 
-            IOpenApiAny example = XmlCommentsExampleHelper.Create(
+            var example = XmlCommentsExampleHelper.Create(
                 schemaRepository, schema, "null");
 
             Assert.NotNull(example);
@@ -64,7 +64,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         {
             OpenApiSchema schema = null;
 
-            IOpenApiAny example = XmlCommentsExampleHelper.Create(schemaRepository, schema, "[]");
+            var example = XmlCommentsExampleHelper.Create(schemaRepository, schema, "[]");
 
             Assert.NotNull(example);
             var actual = Assert.IsType<OpenApiArray>(example);

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsParameterFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsParameterFilterTests.cs
@@ -92,12 +92,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal("\"https://test.com/a?b=1&c=2\"", parameter.Example.ToJson());
         }
 
-        private XmlCommentsParameterFilter Subject()
+        private static XmlCommentsParameterFilter Subject()
         {
-            using (var xmlComments = File.OpenText(typeof(FakeControllerWithXmlComments).Assembly.GetName().Name + ".xml"))
-            {
-                return new XmlCommentsParameterFilter(new XPathDocument(xmlComments));
-            }
+            using var xmlComments = File.OpenText(typeof(FakeControllerWithXmlComments).Assembly.GetName().Name + ".xml");
+            return new XmlCommentsParameterFilter(new XPathDocument(xmlComments));
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsParameterFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsParameterFilterTests.cs
@@ -2,7 +2,6 @@
 using System.Xml.XPath;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi.Models;
-using Swashbuckle.AspNetCore.TestSupport;
 using Xunit;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen.Test
@@ -12,7 +11,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         [Fact]
         public void Apply_SetsDescriptionAndExample_FromActionParamTag()
         {
-            var parameter = new OpenApiParameter { Schema = new OpenApiSchema { Type = "string" } };
+            var parameter = new OpenApiParameter { Schema = new OpenApiSchema { Type = JsonSchemaType.String } };
             var parameterInfo = typeof(FakeControllerWithXmlComments)
                 .GetMethod(nameof(FakeControllerWithXmlComments.ActionWithParamTags))
                 .GetParameters()[0];
@@ -23,13 +22,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal("Description for param1", parameter.Description);
             Assert.NotNull(parameter.Example);
-            Assert.Equal("\"Example for \\\"param1\\\"\"", parameter.Example.ToJson());
+            Assert.Equal("\"Example for \\\"param1\\\"\"", parameter.Example.ToJsonString());
         }
 
         [Fact]
         public void Apply_SetsDescriptionAndExample_FromUriTypeActionParamTag()
         {
-            var parameter = new OpenApiParameter { Schema = new OpenApiSchema { Type = "string" } };
+            var parameter = new OpenApiParameter { Schema = new OpenApiSchema { Type = JsonSchemaType.String } };
             var parameterInfo = typeof(FakeControllerWithXmlComments)
                 .GetMethod(nameof(FakeControllerWithXmlComments.ActionWithParamTags))
                 .GetParameters()[1];
@@ -40,13 +39,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal("Description for param2", parameter.Description);
             Assert.NotNull(parameter.Example);
-            Assert.Equal("\"http://test.com/?param1=1&param2=2\"", parameter.Example.ToJson());
+            Assert.Equal("\"http://test.com/?param1=1&param2=2\"", parameter.Example.ToJsonString());
         }
 
         [Fact]
         public void Apply_SetsDescriptionAndExample_FromUnderlyingGenericTypeActionParamTag()
         {
-            var parameter = new OpenApiParameter { Schema = new OpenApiSchema { Type = "string" } };
+            var parameter = new OpenApiParameter { Schema = new OpenApiSchema { Type = JsonSchemaType.String } };
             var parameterInfo = typeof(FakeConstructedControllerWithXmlComments)
                 .GetMethod(nameof(FakeConstructedControllerWithXmlComments.ActionWithParamTags))
                 .GetParameters()[0];
@@ -57,13 +56,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal("Description for param1", parameter.Description);
             Assert.NotNull(parameter.Example);
-            Assert.Equal("\"Example for \\\"param1\\\"\"", parameter.Example.ToJson());
+            Assert.Equal("\"Example for \\\"param1\\\"\"", parameter.Example.ToJsonString());
         }
 
         [Fact]
         public void Apply_SetsDescriptionAndExample_FromPropertySummaryAndExampleTags()
         {
-            var parameter = new OpenApiParameter { Schema = new OpenApiSchema { Type = "string", Description = "schema-level description" } };
+            var parameter = new OpenApiParameter { Schema = new OpenApiSchema { Type = JsonSchemaType.String, Description = "schema-level description" } };
             var propertyInfo = typeof(XmlAnnotatedType).GetProperty(nameof(XmlAnnotatedType.StringProperty));
             var apiParameterDescription = new ApiParameterDescription { };
             var filterContext = new ParameterFilterContext(apiParameterDescription, null, null, propertyInfo: propertyInfo);
@@ -73,13 +72,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal("Summary for StringProperty", parameter.Description);
             Assert.Null(parameter.Schema.Description);
             Assert.NotNull(parameter.Example);
-            Assert.Equal("\"Example for StringProperty\"", parameter.Example.ToJson());
+            Assert.Equal("\"Example for StringProperty\"", parameter.Example.ToJsonString());
         }
 
         [Fact]
         public void Apply_SetsDescriptionAndExample_FromUriTypePropertySummaryAndExampleTags()
         {
-            var parameter = new OpenApiParameter { Schema = new OpenApiSchema { Type = "string", Description = "schema-level description" } };
+            var parameter = new OpenApiParameter { Schema = new OpenApiSchema { Type = JsonSchemaType.String, Description = "schema-level description" } };
             var propertyInfo = typeof(XmlAnnotatedType).GetProperty(nameof(XmlAnnotatedType.StringPropertyWithUri));
             var apiParameterDescription = new ApiParameterDescription { };
             var filterContext = new ParameterFilterContext(apiParameterDescription, null, null, propertyInfo: propertyInfo);
@@ -89,7 +88,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal("Summary for StringPropertyWithUri", parameter.Description);
             Assert.Null(parameter.Schema.Description);
             Assert.NotNull(parameter.Example);
-            Assert.Equal("\"https://test.com/a?b=1&c=2\"", parameter.Example.ToJson());
+            Assert.Equal("\"https://test.com/a?b=1&c=2\"", parameter.Example.ToJsonString());
         }
 
         private static XmlCommentsParameterFilter Subject()

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsRequestBodyFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsRequestBodyFilterTests.cs
@@ -19,7 +19,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             {
                 Content = new Dictionary<string, OpenApiMediaType>
                 {
-                    ["application/json"] = new OpenApiMediaType { Schema = new OpenApiSchema { Type = "string" } }
+                    ["application/json"] = new OpenApiMediaType { Schema = new OpenApiSchema { Type = JsonSchemaType.String } }
                 }
             };
             var parameterInfo = typeof(FakeControllerWithXmlComments)
@@ -35,7 +35,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal("Description for param1", requestBody.Description);
             Assert.NotNull(requestBody.Content["application/json"].Example);
-            Assert.Equal("\"Example for \\\"param1\\\"\"", requestBody.Content["application/json"].Example.ToJson());
+            Assert.Equal("\"Example for \\\"param1\\\"\"", requestBody.Content["application/json"].Example.ToJsonString());
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             {
                 Content = new Dictionary<string, OpenApiMediaType>
                 {
-                    ["application/json"] = new OpenApiMediaType { Schema = new OpenApiSchema { Type = "string" } }
+                    ["application/json"] = new OpenApiMediaType { Schema = new OpenApiSchema { Type = JsonSchemaType.String } }
                 }
             };
             var parameterInfo = typeof(FakeConstructedControllerWithXmlComments)
@@ -61,7 +61,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal("Description for param1", requestBody.Description);
             Assert.NotNull(requestBody.Content["application/json"].Example);
-            Assert.Equal("\"Example for \\\"param1\\\"\"", requestBody.Content["application/json"].Example.ToJson());
+            Assert.Equal("\"Example for \\\"param1\\\"\"", requestBody.Content["application/json"].Example.ToJsonString());
         }
 
         [Fact]
@@ -71,7 +71,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             {
                 Content = new Dictionary<string, OpenApiMediaType>
                 {
-                    ["application/json"] = new OpenApiMediaType { Schema = new OpenApiSchema { Type = "string" } }
+                    ["application/json"] = new OpenApiMediaType { Schema = new OpenApiSchema { Type = JsonSchemaType.String } }
                 }
             };
             var bodyParameterDescription = new ApiParameterDescription
@@ -84,7 +84,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal("Summary for StringProperty", requestBody.Description);
             Assert.NotNull(requestBody.Content["application/json"].Example);
-            Assert.Equal("\"Example for StringProperty\"", requestBody.Content["application/json"].Example.ToJson());
+            Assert.Equal("\"Example for StringProperty\"", requestBody.Content["application/json"].Example.ToJsonString());
         }
 
 
@@ -95,7 +95,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             {
                 Content = new Dictionary<string, OpenApiMediaType>
                 {
-                    ["application/json"] = new OpenApiMediaType { Schema = new OpenApiSchema { Type = "string" } }
+                    ["application/json"] = new OpenApiMediaType { Schema = new OpenApiSchema { Type = JsonSchemaType.String } }
                 }
             };
             var bodyParameterDescription = new ApiParameterDescription
@@ -108,7 +108,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 
             Assert.Equal("Summary for StringPropertyWithUri", requestBody.Description);
             Assert.NotNull(requestBody.Content["application/json"].Example);
-            Assert.Equal("\"https://test.com/a?b=1&c=2\"", requestBody.Content["application/json"].Example.ToJson());
+            Assert.Equal("\"https://test.com/a?b=1&c=2\"", requestBody.Content["application/json"].Example.ToJsonString());
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             {
                 Content = new Dictionary<string, OpenApiMediaType>
                 {
-                    ["application/json"] = new OpenApiMediaType { Schema = new OpenApiSchema { Type = "string" } }
+                    ["application/json"] = new OpenApiMediaType { Schema = new OpenApiSchema { Type = JsonSchemaType.String } }
                 }
             };
             var parameterInfo = typeof(FakeControllerWithXmlComments)
@@ -150,7 +150,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
                     {
                         Schema = new OpenApiSchema
                         {
-                            Type = "string",
+                            Type = JsonSchemaType.String,
                             Properties = new Dictionary<string, OpenApiSchema>()
                             {
                                 [parameterInfo.Name] = new()

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
@@ -57,35 +57,35 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
         }
 
         [Theory]
-        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.BoolProperty), "boolean", "true")]
-        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.IntProperty), "integer", "10")]
-        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.LongProperty), "integer", "4294967295")]
-        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.FloatProperty), "number", "1.2")]
-        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.DoubleProperty), "number", "1.25")]
-        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.DateTimeProperty), "string", "\"6/22/2022 12:00:00 AM\"")]
-        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.EnumProperty), "integer", "2")]
-        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.GuidProperty), "string", "\"d3966535-2637-48fa-b911-e3c27405ee09\"")]
-        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.StringProperty), "string", "\"Example for StringProperty\"")]
-        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.ObjectProperty), "object", "{\n  \"prop1\": 1,\n  \"prop2\": \"foobar\"\n}")]
-        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.StringPropertyWithNullExample), "string", "null")]
-        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.StringPropertyWithUri), "string", "\"https://test.com/a?b=1&c=2\"")]
-        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.BoolProperty), "boolean", "true")]
-        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.IntProperty), "integer", "10")]
-        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.LongProperty), "integer", "4294967295")]
-        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.FloatProperty), "number", "1.2")]
-        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.DoubleProperty), "number", "1.25")]
-        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.DateTimeProperty), "string", "\"6/22/2022 12:00:00 AM\"")]
-        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.EnumProperty), "integer", "2")]
-        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.GuidProperty), "string", "\"d3966535-2637-48fa-b911-e3c27405ee09\"")]
-        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.StringProperty), "string", "\"Example for StringProperty\"")]
-        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.ObjectProperty), "object", "{\n  \"prop1\": 1,\n  \"prop2\": \"foobar\"\n}")]
-        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.StringPropertyWithNullExample), "string", "null")]
-        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.StringPropertyWithUri), "string", "\"https://test.com/a?b=1&c=2\"")]
+        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.BoolProperty), JsonSchemaType.Boolean, "true")]
+        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.IntProperty), JsonSchemaType.Integer, "10")]
+        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.LongProperty), JsonSchemaType.Integer, "4294967295")]
+        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.FloatProperty), JsonSchemaType.Number, "1.2")]
+        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.DoubleProperty), JsonSchemaType.Number, "1.25")]
+        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.DateTimeProperty), JsonSchemaType.String, "\"6/22/2022 12:00:00 AM\"")]
+        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.EnumProperty), JsonSchemaType.Integer, "2")]
+        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.GuidProperty), JsonSchemaType.String, "\"d3966535-2637-48fa-b911-e3c27405ee09\"")]
+        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.StringProperty), JsonSchemaType.String, "\"Example for StringProperty\"")]
+        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.ObjectProperty), JsonSchemaType.Object, "{\n  \"prop1\": 1,\n  \"prop2\": \"foobar\"\n}")]
+        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.StringPropertyWithNullExample), JsonSchemaType.String, "null")]
+        [InlineData(typeof(XmlAnnotatedType), nameof(XmlAnnotatedType.StringPropertyWithUri), JsonSchemaType.String, "\"https://test.com/a?b=1&c=2\"")]
+        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.BoolProperty), JsonSchemaType.Boolean, "true")]
+        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.IntProperty), JsonSchemaType.Integer, "10")]
+        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.LongProperty), JsonSchemaType.Integer, "4294967295")]
+        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.FloatProperty), JsonSchemaType.Number, "1.2")]
+        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.DoubleProperty), JsonSchemaType.Number, "1.25")]
+        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.DateTimeProperty), JsonSchemaType.String, "\"6/22/2022 12:00:00 AM\"")]
+        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.EnumProperty), JsonSchemaType.Integer, "2")]
+        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.GuidProperty), JsonSchemaType.String, "\"d3966535-2637-48fa-b911-e3c27405ee09\"")]
+        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.StringProperty), JsonSchemaType.String, "\"Example for StringProperty\"")]
+        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.ObjectProperty), JsonSchemaType.Object, "{\n  \"prop1\": 1,\n  \"prop2\": \"foobar\"\n}")]
+        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.StringPropertyWithNullExample), JsonSchemaType.String, "null")]
+        [InlineData(typeof(XmlAnnotatedRecord), nameof(XmlAnnotatedRecord.StringPropertyWithUri), JsonSchemaType.String, "\"https://test.com/a?b=1&c=2\"")]
         [UseInvariantCulture]
         public void Apply_SetsExample_FromPropertyExampleTag(
             Type declaringType,
             string propertyName,
-            string schemaType,
+            JsonSchemaType schemaType,
             string expectedExampleAsJson)
         {
             var propertyInfo = declaringType.GetProperty(propertyName);
@@ -95,39 +95,39 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Subject().Apply(schema, filterContext);
 
             Assert.NotNull(schema.Example);
-            Assert.Equal(expectedExampleAsJson, schema.Example.ToJson());
+            Assert.Equal(expectedExampleAsJson, schema.Example.ToJsonString());
         }
 
         [Theory]
-        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.BoolProperty), "boolean")]
-        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.IntProperty), "integer")]
-        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.LongProperty), "integer")]
-        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.FloatProperty), "number")]
-        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.DoubleProperty), "number")]
-        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.DateTimeProperty), "string")]
-        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.EnumProperty), "integer")]
-        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.GuidProperty), "string")]
-        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.StringProperty), "string")]
-        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.ObjectProperty), "object")]
-        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.StringPropertyWithNullExample), "string")]
-        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.StringPropertyWithUri), "string")]
-        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.BoolProperty), "boolean")]
-        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.IntProperty), "integer")]
-        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.LongProperty), "integer")]
-        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.FloatProperty), "number")]
-        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.DoubleProperty), "number")]
-        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.DateTimeProperty), "string")]
-        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.EnumProperty), "integer")]
-        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.GuidProperty), "string")]
-        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.StringProperty), "string")]
-        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.ObjectProperty), "object")]
-        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.StringPropertyWithNullExample), "string")]
-        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.StringPropertyWithUri), "string")]
+        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.BoolProperty), JsonSchemaType.Boolean)]
+        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.IntProperty), JsonSchemaType.Integer)]
+        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.LongProperty), JsonSchemaType.Integer)]
+        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.FloatProperty), JsonSchemaType.Number)]
+        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.DoubleProperty), JsonSchemaType.Number)]
+        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.DateTimeProperty), JsonSchemaType.String)]
+        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.EnumProperty), JsonSchemaType.Integer)]
+        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.GuidProperty), JsonSchemaType.String)]
+        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.StringProperty), JsonSchemaType.String)]
+        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.ObjectProperty), JsonSchemaType.Object)]
+        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.StringPropertyWithNullExample), JsonSchemaType.String)]
+        [InlineData(typeof(XmlAnnotatedTypeWithoutExample), nameof(XmlAnnotatedTypeWithoutExample.StringPropertyWithUri), JsonSchemaType.String)]
+        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.BoolProperty), JsonSchemaType.Boolean)]
+        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.IntProperty), JsonSchemaType.Integer)]
+        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.LongProperty), JsonSchemaType.Integer)]
+        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.FloatProperty), JsonSchemaType.Number)]
+        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.DoubleProperty), JsonSchemaType.Number)]
+        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.DateTimeProperty), JsonSchemaType.String)]
+        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.EnumProperty), JsonSchemaType.Integer)]
+        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.GuidProperty), JsonSchemaType.String)]
+        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.StringProperty), JsonSchemaType.String)]
+        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.ObjectProperty), JsonSchemaType.Object)]
+        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.StringPropertyWithNullExample), JsonSchemaType.String)]
+        [InlineData(typeof(XmlAnnotatedRecordWithoutExample), nameof(XmlAnnotatedRecordWithoutExample.StringPropertyWithUri), JsonSchemaType.String)]
         [UseInvariantCulture]
         public void Apply_DoesNotSetExample_WhenPropertyExampleTagIsNotProvided(
             Type declaringType,
             string propertyName,
-            string schemaType)
+            JsonSchemaType schemaType)
         {
             var propertyInfo = declaringType.GetProperty(propertyName);
             var schema = new OpenApiSchema { Type = schemaType };
@@ -146,7 +146,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             float expectedValue)
         {
             var propertyInfo = typeof(XmlAnnotatedType).GetProperty(nameof(XmlAnnotatedType.FloatProperty));
-            var schema = new OpenApiSchema { Type = "number", Format = "float" };
+            var schema = new OpenApiSchema { Type = JsonSchemaType.Number, Format = "float" };
             var filterContext = new SchemaFilterContext(propertyInfo.PropertyType, null, null, memberInfo: propertyInfo);
 
             var defaultCulture = CultureInfo.CurrentCulture;

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Globalization;
-using System.Xml.XPath;
 using System.IO;
+using System.Xml.XPath;
 using Microsoft.OpenApi.Models;
-using Xunit;
 using Swashbuckle.AspNetCore.TestSupport;
+using Xunit;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
@@ -159,12 +159,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test
             Assert.Equal(expectedValue, schema.Example.GetType().GetProperty("Value").GetValue(schema.Example));
         }
 
-        private XmlCommentsSchemaFilter Subject()
+        private static XmlCommentsSchemaFilter Subject()
         {
-            using (var xmlComments = File.OpenText(typeof(XmlAnnotatedType).Assembly.GetName().Name + ".xml"))
-            {
-                return new XmlCommentsSchemaFilter(new XPathDocument(xmlComments));
-            }
+            using var xmlComments = File.OpenText(typeof(XmlAnnotatedType).Assembly.GetName().Name + ".xml");
+            return new XmlCommentsSchemaFilter(new XPathDocument(xmlComments));
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.TestSupport/Extensions/IOpenApiAnyExtensions.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Extensions/IOpenApiAnyExtensions.cs
@@ -7,7 +7,7 @@ namespace Swashbuckle.AspNetCore.TestSupport
 {
     public static class IOpenApiAnyExtensions
     {
-        public static string ToJson(this IOpenApiAny openApiAny)
+        public static string ToJson(this OpenApiAny openApiAny)
         {
             var stringWriter = new StringWriter();
             var jsonWriter = new OpenApiJsonWriter(stringWriter);

--- a/test/WebSites/Basic/Swagger/AssignOperationVendorExtensions.cs
+++ b/test/WebSites/Basic/Swagger/AssignOperationVendorExtensions.cs
@@ -8,7 +8,7 @@ namespace Basic.Swagger
     {
         public void Apply(OpenApiOperation operation, OperationFilterContext context)
         {
-            operation.Extensions.Add("x-purpose", new OpenApiString("test"));
+            operation.Extensions.Add("x-purpose", new OpenApiAny("test"));
         }
     }
 }

--- a/test/WebSites/Basic/Swagger/AssignRequestBodyVendorExtensions.cs
+++ b/test/WebSites/Basic/Swagger/AssignRequestBodyVendorExtensions.cs
@@ -8,7 +8,7 @@ namespace Basic.Swagger
     {
         public void Apply(OpenApiRequestBody requestBody, RequestBodyFilterContext context)
         {
-            requestBody.Extensions.Add("x-purpose", new OpenApiString("test"));
+            requestBody.Extensions.Add("x-purpose", new OpenApiAny("test"));
         }
     }
 }

--- a/test/WebSites/Basic/Swagger/ExamplesSchemaFilter.cs
+++ b/test/WebSites/Basic/Swagger/ExamplesSchemaFilter.cs
@@ -12,20 +12,18 @@ namespace Basic.Swagger
             schema.Example = GetExampleOrNullFor(context.Type);
         }
 
-        private IOpenApiAny GetExampleOrNullFor(Type type)
+        private static IOpenApiAny GetExampleOrNullFor(Type type)
         {
-            switch (type.Name)
+            return type.Name switch
             {
-                case "Product":
-                    return new OpenApiObject
-                    {
-                        [ "id" ] = new OpenApiInteger(123),
-                        [ "description" ] = new OpenApiString("foobar"),
-                        [ "price" ] = new OpenApiDouble(14.37)
-                    };
-                default:
-                    return null;
-            }
+                "Product" => new OpenApiObject
+                {
+                    ["id"] = new OpenApiInteger(123),
+                    ["description"] = new OpenApiString("foobar"),
+                    ["price"] = new OpenApiDouble(14.37)
+                },
+                _ => null,
+            };
         }
     }
 }

--- a/test/WebSites/Basic/Swagger/ExamplesSchemaFilter.cs
+++ b/test/WebSites/Basic/Swagger/ExamplesSchemaFilter.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Microsoft.OpenApi.Any;
+using System.Text.Json.Nodes;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -12,15 +12,15 @@ namespace Basic.Swagger
             schema.Example = GetExampleOrNullFor(context.Type);
         }
 
-        private static IOpenApiAny GetExampleOrNullFor(Type type)
+        private static JsonObject GetExampleOrNullFor(Type type)
         {
             return type.Name switch
             {
-                "Product" => new OpenApiObject
+                "Product" => new JsonObject
                 {
-                    ["id"] = new OpenApiInteger(123),
-                    ["description"] = new OpenApiString("foobar"),
-                    ["price"] = new OpenApiDouble(14.37)
+                    ["id"] = 123,
+                    ["description"] = "foobar",
+                    ["price"] = 14.37d
                 },
                 _ => null,
             };

--- a/test/WebSites/CliExample/wwwroot/swagger/v1/swagger_net8.0.json
+++ b/test/WebSites/CliExample/wwwroot/swagger/v1/swagger_net8.0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "CliExample",
     "version": "1.0"
@@ -22,9 +22,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Product"
-                  }
+                  "items": { }
                 }
               }
             }

--- a/test/WebSites/CliExample/wwwroot/swagger/v1/swagger_net9.0.json
+++ b/test/WebSites/CliExample/wwwroot/swagger/v1/swagger_net9.0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "CliExample",
     "version": "1.0"
@@ -22,9 +22,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Product"
-                  }
+                  "items": { }
                 }
               }
             }

--- a/test/WebSites/CliExampleWithFactory/wwwroot/swagger/v1/swagger_net8.0.json
+++ b/test/WebSites/CliExampleWithFactory/wwwroot/swagger/v1/swagger_net8.0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "CliExampleWithFactory",
     "version": "1.0"
@@ -22,9 +22,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Product"
-                  }
+                  "items": { }
                 }
               }
             }

--- a/test/WebSites/CliExampleWithFactory/wwwroot/swagger/v1/swagger_net9.0.json
+++ b/test/WebSites/CliExampleWithFactory/wwwroot/swagger/v1/swagger_net9.0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "CliExampleWithFactory",
     "version": "1.0"
@@ -22,9 +22,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Product"
-                  }
+                  "items": { }
                 }
               }
             }

--- a/test/WebSites/NswagClientExample/swagger_net8.0.json
+++ b/test/WebSites/NswagClientExample/swagger_net8.0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "NswagClientExample",
     "version": "1.0"
@@ -20,45 +20,27 @@
             "application/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/Animal"
-                  },
-                  {
-                    "$ref": "#/components/schemas/Cat"
-                  },
-                  {
-                    "$ref": "#/components/schemas/Dog"
-                  }
+                  { },
+                  { },
+                  { }
                 ]
               }
             },
             "text/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/Animal"
-                  },
-                  {
-                    "$ref": "#/components/schemas/Cat"
-                  },
-                  {
-                    "$ref": "#/components/schemas/Dog"
-                  }
+                  { },
+                  { },
+                  { }
                 ]
               }
             },
             "application/*+json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/Animal"
-                  },
-                  {
-                    "$ref": "#/components/schemas/Cat"
-                  },
-                  {
-                    "$ref": "#/components/schemas/Dog"
-                  }
+                  { },
+                  { },
+                  { }
                 ]
               }
             }
@@ -82,27 +64,21 @@
             "application/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SubSubType"
-                  }
+                  { }
                 ]
               }
             },
             "text/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SubSubType"
-                  }
+                  { }
                 ]
               }
             },
             "application/*+json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SubSubType"
-                  }
+                  { }
                 ]
               }
             }
@@ -133,45 +109,27 @@
             "application/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonAnimal"
-                  },
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonCat"
-                  },
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonDog"
-                  }
+                  { },
+                  { },
+                  { }
                 ]
               }
             },
             "text/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonAnimal"
-                  },
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonCat"
-                  },
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonDog"
-                  }
+                  { },
+                  { },
+                  { }
                 ]
               }
             },
             "application/*+json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonAnimal"
-                  },
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonCat"
-                  },
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonDog"
-                  }
+                  { },
+                  { },
+                  { }
                 ]
               }
             }
@@ -194,9 +152,7 @@
         ],
         "type": "object",
         "properties": {
-          "animalType": {
-            "$ref": "#/components/schemas/AnimalType"
-          }
+          "animalType": { }
         },
         "additionalProperties": false,
         "discriminator": {
@@ -238,9 +194,7 @@
       },
       "Cat": {
         "allOf": [
-          {
-            "$ref": "#/components/schemas/Animal"
-          },
+          { },
           {
             "type": "object",
             "properties": {
@@ -255,9 +209,7 @@
       },
       "Dog": {
         "allOf": [
-          {
-            "$ref": "#/components/schemas/Animal"
-          },
+          { },
           {
             "type": "object",
             "properties": {
@@ -272,9 +224,7 @@
       },
       "SubSubType": {
         "allOf": [
-          {
-            "$ref": "#/components/schemas/BaseType"
-          },
+          { },
           {
             "type": "object",
             "properties": {
@@ -309,9 +259,7 @@
       },
       "SystemTextJsonCat": {
         "allOf": [
-          {
-            "$ref": "#/components/schemas/SystemTextJsonAnimal"
-          },
+          { },
           {
             "type": "object",
             "properties": {
@@ -326,9 +274,7 @@
       },
       "SystemTextJsonDog": {
         "allOf": [
-          {
-            "$ref": "#/components/schemas/SystemTextJsonAnimal"
-          },
+          { },
           {
             "type": "object",
             "properties": {

--- a/test/WebSites/NswagClientExample/swagger_net9.0.json
+++ b/test/WebSites/NswagClientExample/swagger_net9.0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "NswagClientExample",
     "version": "1.0"
@@ -20,45 +20,27 @@
             "application/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/Animal"
-                  },
-                  {
-                    "$ref": "#/components/schemas/Cat"
-                  },
-                  {
-                    "$ref": "#/components/schemas/Dog"
-                  }
+                  { },
+                  { },
+                  { }
                 ]
               }
             },
             "text/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/Animal"
-                  },
-                  {
-                    "$ref": "#/components/schemas/Cat"
-                  },
-                  {
-                    "$ref": "#/components/schemas/Dog"
-                  }
+                  { },
+                  { },
+                  { }
                 ]
               }
             },
             "application/*+json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/Animal"
-                  },
-                  {
-                    "$ref": "#/components/schemas/Cat"
-                  },
-                  {
-                    "$ref": "#/components/schemas/Dog"
-                  }
+                  { },
+                  { },
+                  { }
                 ]
               }
             }
@@ -82,27 +64,21 @@
             "application/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SubSubType"
-                  }
+                  { }
                 ]
               }
             },
             "text/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SubSubType"
-                  }
+                  { }
                 ]
               }
             },
             "application/*+json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SubSubType"
-                  }
+                  { }
                 ]
               }
             }
@@ -133,45 +109,27 @@
             "application/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonAnimal"
-                  },
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonCat"
-                  },
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonDog"
-                  }
+                  { },
+                  { },
+                  { }
                 ]
               }
             },
             "text/json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonAnimal"
-                  },
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonCat"
-                  },
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonDog"
-                  }
+                  { },
+                  { },
+                  { }
                 ]
               }
             },
             "application/*+json": {
               "schema": {
                 "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonAnimal"
-                  },
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonCat"
-                  },
-                  {
-                    "$ref": "#/components/schemas/SystemTextJsonDog"
-                  }
+                  { },
+                  { },
+                  { }
                 ]
               }
             }
@@ -194,9 +152,7 @@
         ],
         "type": "object",
         "properties": {
-          "animalType": {
-            "$ref": "#/components/schemas/AnimalType"
-          }
+          "animalType": { }
         },
         "additionalProperties": false,
         "discriminator": {
@@ -238,9 +194,7 @@
       },
       "Cat": {
         "allOf": [
-          {
-            "$ref": "#/components/schemas/Animal"
-          },
+          { },
           {
             "type": "object",
             "properties": {
@@ -255,9 +209,7 @@
       },
       "Dog": {
         "allOf": [
-          {
-            "$ref": "#/components/schemas/Animal"
-          },
+          { },
           {
             "type": "object",
             "properties": {
@@ -272,9 +224,7 @@
       },
       "SubSubType": {
         "allOf": [
-          {
-            "$ref": "#/components/schemas/BaseType"
-          },
+          { },
           {
             "type": "object",
             "properties": {
@@ -309,9 +259,7 @@
       },
       "SystemTextJsonCat": {
         "allOf": [
-          {
-            "$ref": "#/components/schemas/SystemTextJsonAnimal"
-          },
+          { },
           {
             "type": "object",
             "properties": {
@@ -326,9 +274,7 @@
       },
       "SystemTextJsonDog": {
         "allOf": [
-          {
-            "$ref": "#/components/schemas/SystemTextJsonAnimal"
-          },
+          { },
           {
             "type": "object",
             "properties": {

--- a/test/WebSites/TestFirst.IntegrationTests/CreateProductTests.cs
+++ b/test/WebSites/TestFirst.IntegrationTests/CreateProductTests.cs
@@ -1,24 +1,17 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
 using Swashbuckle.AspNetCore.ApiTesting.Xunit;
 using Xunit;
 
 namespace TestFirst.IntegrationTests
 {
-    public class CreateProductTests : ApiTestFixture<TestFirst.Startup>
+    public class CreateProductTests(ApiTestRunner apiTestRunner, WebApplicationFactory<TestFirst.Startup> webApplicationFactory)
+        : ApiTestFixture<TestFirst.Startup>(apiTestRunner, webApplicationFactory, "v1-imported")
     {
-        public CreateProductTests(
-            ApiTestRunner apiTestRunner,
-            WebApplicationFactory<TestFirst.Startup> webApplicationFactory)
-            : base(apiTestRunner, webApplicationFactory, "v1-imported")
-        { }
-
         [Fact]
         public async Task CreateProduct_Returns201_IfContentIsValid()
         {

--- a/test/WebSites/TestFirst.IntegrationTests/CreateUserTests.cs
+++ b/test/WebSites/TestFirst.IntegrationTests/CreateUserTests.cs
@@ -21,7 +21,8 @@ namespace TestFirst.IntegrationTests
             Describe("/api/users", OperationType.Post, new OpenApiOperation
             {
                 OperationId = "CreateUser",
-                Tags = new List<OpenApiTag> { new OpenApiTag {  Name = "Users" } },
+                //// TODO Fix this
+                ////Tags = new List<OpenApiTagReference> { new OpenApiTag {  Name = "Users" } },
                 RequestBody = new OpenApiRequestBody
                 {
                     Content = new Dictionary<string, OpenApiMediaType>
@@ -30,11 +31,11 @@ namespace TestFirst.IntegrationTests
                         {
                             Schema = new OpenApiSchema
                             {
-                                Type = "object",
+                                Type = JsonSchemaType.Object,
                                 Properties = new Dictionary<string, OpenApiSchema>
                                 {
-                                    [ "email" ] = new OpenApiSchema {  Type = "string" },
-                                    [ "password" ] = new OpenApiSchema {  Type = "string" },
+                                    [ "email" ] = new OpenApiSchema {  Type = JsonSchemaType.String },
+                                    [ "password" ] = new OpenApiSchema {  Type = JsonSchemaType.String },
                                 },
                                 Required = new SortedSet<string> { "email", "password" }
                             }
@@ -52,7 +53,7 @@ namespace TestFirst.IntegrationTests
                             [ "Location" ] = new OpenApiHeader
                             {
                                 Required = true,
-                                Schema = new OpenApiSchema { Type = "string" }
+                                Schema = new OpenApiSchema { Type = JsonSchemaType.String }
                             }
                         }
                     },

--- a/test/WebSites/TestFirst.IntegrationTests/GetProductsTests.cs
+++ b/test/WebSites/TestFirst.IntegrationTests/GetProductsTests.cs
@@ -1,11 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.OpenApi.Models;
-using Newtonsoft.Json;
 using Swashbuckle.AspNetCore.ApiTesting.Xunit;
 using Xunit;
 

--- a/test/WebSites/TestFirst/wwwroot/swagger/v1-generated/openapi.json
+++ b/test/WebSites/TestFirst/wwwroot/swagger/v1-generated/openapi.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test-first Example API (Generated)",
     "version": "v1"

--- a/test/WebSites/TestFirst/wwwroot/swagger/v1-imported/openapi.json
+++ b/test/WebSites/TestFirst/wwwroot/swagger/v1-imported/openapi.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test-first Example API (Imported)",
     "version": "v1"

--- a/test/WebSites/WebApi/EndPoints/OpenApiEndpoints.cs
+++ b/test/WebSites/WebApi/EndPoints/OpenApiEndpoints.cs
@@ -48,7 +48,7 @@ namespace WebApi.EndPoints
                 return $"{file.FileName}{queryParameter}";
             }).WithOpenApi(o =>
             {
-                var parameter = o.Parameters.FirstOrDefault(p => p.Name.Equals("queryParameter", StringComparison.OrdinalIgnoreCase));
+                var parameter = o.Parameters?.FirstOrDefault(p => p.Name.Equals("queryParameter", StringComparison.OrdinalIgnoreCase));
                 if (parameter is not null)
                 {
                     parameter.Description = $"{parameter.Name} Description";


### PR DESCRIPTION
Upgrade to Microsoft.OpenApi v2, which would unlock support for OpenAPI 3.1.

Contributes to #2349.

<hr/>

This currently targets preview 5 and compiles, but **lots** of tests are broken.

The migration was guided by [the release notes for the first preview](https://github.com/microsoft/OpenAPI.NET/releases/tag/2.0.0-preview1).

Some might be bugs in the upgrade, others might be bugs in Microsoft.OpenApi v2 itself. I'll need to investigate further, then I can open any upstream issues as neccessary.

The most worrying failure so far is this one:

```text
System.MissingMethodException: Method not found: 'Void Microsoft.OpenApi.Models.OpenApiOperation.set_Tags(System.Collections.Generic.IList`1<Microsoft.OpenApi.Models.OpenApiTag>)'.
   at Microsoft.AspNetCore.OpenApi.OpenApiGenerator.GetOperation(String httpMethod, MethodInfo methodInfo, EndpointMetadataCollection metadata, RoutePattern pattern)
   at Microsoft.AspNetCore.OpenApi.OpenApiGenerator.GetOpenApiOperation(MethodInfo methodInfo, EndpointMetadataCollection metadata, RoutePattern pattern)
   at Microsoft.AspNetCore.Builder.OpenApiEndpointConventionBuilderExtensions.AddAndConfigureOperationForEndpoint(EndpointBuilder endpointBuilder, Func`2 configure)
   at Microsoft.AspNetCore.Builder.OpenApiEndpointConventionBuilderExtensions.<>c__0`1.<WithOpenApi>b__0_0(EndpointBuilder builder)
   at Microsoft.AspNetCore.Routing.RouteEndpointDataSource.CreateRouteEndpointBuilder(RouteEntry entry, RoutePattern groupPrefix, IReadOnlyList`1 groupConventions, IReadOnlyList`1 groupFinallyConventions)
   at Microsoft.AspNetCore.Routing.RouteEndpointDataSource.GetGroupedEndpoints(RouteGroupContext context)
   at Microsoft.AspNetCore.Routing.RouteGroupBuilder.GroupEndpointDataSource.GetGroupedEndpointsWithNullablePrefix(RoutePattern prefix, IReadOnlyList`1 conventions, IReadOnlyList`1 finallyConventions, IServiceProvider applicationServices)
   at Microsoft.AspNetCore.Routing.RouteGroupBuilder.GroupEndpointDataSource.get_Endpoints()
   at Microsoft.AspNetCore.Routing.CompositeEndpointDataSource.CreateEndpointsUnsynchronized()
   at Microsoft.AspNetCore.Routing.CompositeEndpointDataSource.EnsureEndpointsInitialized()
   at Microsoft.AspNetCore.Routing.CompositeEndpointDataSource.get_Endpoints()
   at Microsoft.AspNetCore.Routing.DataSourceDependentCache`1.Initialize()
   at System.Threading.LazyInitializer.EnsureInitializedCore[T](T& target, Boolean& initialized, Object& syncLock, Func`1 valueFactory)
   at Microsoft.AspNetCore.Routing.Matching.DataSourceDependentMatcher..ctor(EndpointDataSource dataSource, Lifetime lifetime, Func`1 matcherBuilderFactory)
   at Microsoft.AspNetCore.Routing.Matching.DfaMatcherFactory.CreateMatcher(EndpointDataSource dataSource)
   at Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware.InitializeCoreAsync()
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware.<Invoke>g__AwaitMatcher|10_0(EndpointRoutingMiddleware middleware, HttpContext httpContext, Task`1 matcherTask)
   at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddlewareImpl.Invoke(HttpContext context)
```

This suggests that the changes are so breaking that it is basically impossible to use Microsoft.OpenApi v2 with ASP.NET Core versions earlier than 10. This creates a difficult situation for us, as we would potentially need to conditionally compile across TFMs and only be able to support OpenAPI 3.1 with `net10.0` and need to stay on 1.x for lower TFMs while we still support them. This could get quite messy and complex quite quickly.

Maybe it's not actually that bad and it's an artifact of how our integration test suite is set up, but it's not an encouraging start. We can get further insight on that once ASP.NET Core 10 Preview 1 is available, as then this PR can be updated to additionally target `net10.0` as that has support for OpenAPI 3.1.

/cc @captainsafia For thoughts on the above.

~~Also applies some refactorings in files that needed to be touched, but those will be extracted out and merged ahead of time where possible in a future separate PR.~~ #3254
