### PR TITLE
Optional EOL for XmlComments (#2947)

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSwaggerGeneratorOptions.cs
@@ -117,6 +117,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             target.RequestBodyAsyncFilters = new List<IRequestBodyAsyncFilter>(source.RequestBodyAsyncFilters);
             target.SecuritySchemesSelector = source.SecuritySchemesSelector;
             target.PathGroupSelector = source.PathGroupSelector;
+            target.XmlCommentEndOfLine = source.XmlCommentEndOfLine;
         }
 
         private TFilter GetOrCreateFilter<TFilter>(FilterDescriptor filterDescriptor)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -706,10 +706,10 @@ namespace Microsoft.Extensions.DependencyInjection
             var xmlDoc = xmlDocFactory();
             var xmlDocMembers = XmlCommentsDocumentHelper.CreateMemberDictionary(xmlDoc);
 
-            swaggerGenOptions.AddParameterFilterInstance(new XmlCommentsParameterFilter(xmlDocMembers));
-            swaggerGenOptions.AddRequestBodyFilterInstance(new XmlCommentsRequestBodyFilter(xmlDocMembers));
-            swaggerGenOptions.AddOperationFilterInstance(new XmlCommentsOperationFilter(xmlDocMembers));
-            swaggerGenOptions.AddSchemaFilterInstance(new XmlCommentsSchemaFilter(xmlDocMembers));
+            swaggerGenOptions.AddParameterFilterInstance(new XmlCommentsParameterFilter(xmlDocMembers, swaggerGenOptions.SwaggerGeneratorOptions));
+            swaggerGenOptions.AddRequestBodyFilterInstance(new XmlCommentsRequestBodyFilter(xmlDocMembers, swaggerGenOptions.SwaggerGeneratorOptions));
+            swaggerGenOptions.AddOperationFilterInstance(new XmlCommentsOperationFilter(xmlDocMembers, swaggerGenOptions.SwaggerGeneratorOptions));
+            swaggerGenOptions.AddSchemaFilterInstance(new XmlCommentsSchemaFilter(xmlDocMembers, swaggerGenOptions.SwaggerGeneratorOptions));
 
             if (includeControllerXmlComments)
                 swaggerGenOptions.AddDocumentFilterInstance(new XmlCommentsDocumentFilter(xmlDocMembers, swaggerGenOptions.SwaggerGeneratorOptions));

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Shipped.txt
@@ -86,6 +86,7 @@ static Swashbuckle.AspNetCore.SwaggerGen.XmlCommentsNodeNameHelper.GetMemberName
 static Swashbuckle.AspNetCore.SwaggerGen.XmlCommentsNodeNameHelper.GetMemberNameForMethod(System.Reflection.MethodInfo method) -> string
 static Swashbuckle.AspNetCore.SwaggerGen.XmlCommentsNodeNameHelper.GetMemberNameForType(System.Type type) -> string
 static Swashbuckle.AspNetCore.SwaggerGen.XmlCommentsTextHelper.Humanize(string text) -> string
+static Swashbuckle.AspNetCore.SwaggerGen.XmlCommentsTextHelper.Humanize(string text, string xmlCommentEndOfLine) -> string
 Swashbuckle.AspNetCore.Annotations.SwaggerIgnoreAttribute
 Swashbuckle.AspNetCore.Annotations.SwaggerIgnoreAttribute.SwaggerIgnoreAttribute() -> void
 Swashbuckle.AspNetCore.SwaggerGen.ApiDescriptionExtensions
@@ -297,6 +298,8 @@ Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.SwaggerDocs.set -> voi
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.SwaggerGeneratorOptions() -> void
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.TagsSelector.get -> System.Func<Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription, System.Collections.Generic.IList<string>>
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.TagsSelector.set -> void
+Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.XmlCommentEndOfLine.get -> string
+Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.XmlCommentEndOfLine.set -> void
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions.DocumentFilterDescriptors.get -> System.Collections.Generic.List<Swashbuckle.AspNetCore.SwaggerGen.FilterDescriptor>
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions.DocumentFilterDescriptors.set -> void

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Shipped.txt
@@ -86,7 +86,6 @@ static Swashbuckle.AspNetCore.SwaggerGen.XmlCommentsNodeNameHelper.GetMemberName
 static Swashbuckle.AspNetCore.SwaggerGen.XmlCommentsNodeNameHelper.GetMemberNameForMethod(System.Reflection.MethodInfo method) -> string
 static Swashbuckle.AspNetCore.SwaggerGen.XmlCommentsNodeNameHelper.GetMemberNameForType(System.Type type) -> string
 static Swashbuckle.AspNetCore.SwaggerGen.XmlCommentsTextHelper.Humanize(string text) -> string
-static Swashbuckle.AspNetCore.SwaggerGen.XmlCommentsTextHelper.Humanize(string text, string xmlCommentEndOfLine) -> string
 Swashbuckle.AspNetCore.Annotations.SwaggerIgnoreAttribute
 Swashbuckle.AspNetCore.Annotations.SwaggerIgnoreAttribute.SwaggerIgnoreAttribute() -> void
 Swashbuckle.AspNetCore.SwaggerGen.ApiDescriptionExtensions
@@ -298,8 +297,6 @@ Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.SwaggerDocs.set -> voi
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.SwaggerGeneratorOptions() -> void
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.TagsSelector.get -> System.Func<Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription, System.Collections.Generic.IList<string>>
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.TagsSelector.set -> void
-Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.XmlCommentEndOfLine.get -> string
-Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.XmlCommentEndOfLine.set -> void
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions.DocumentFilterDescriptors.get -> System.Collections.Generic.List<Swashbuckle.AspNetCore.SwaggerGen.FilterDescriptor>
 Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions.DocumentFilterDescriptors.set -> void

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 static Swashbuckle.AspNetCore.SwaggerGen.OpenApiAnyFactory.CreateFromJson(string json, System.Text.Json.JsonSerializerOptions options) -> Microsoft.OpenApi.Any.IOpenApiAny
+static Swashbuckle.AspNetCore.SwaggerGen.XmlCommentsTextHelper.Humanize(string text, string xmlCommentEndOfLine) -> string
+Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.XmlCommentEndOfLine.get -> string
+Swashbuckle.AspNetCore.SwaggerGen.SwaggerGeneratorOptions.XmlCommentEndOfLine.set -> void

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
@@ -82,6 +82,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         public IList<IDocumentAsyncFilter> DocumentAsyncFilters { get; set; }
 
+        public string XmlCommentEndOfLine { get; set; }
+
         private bool DefaultDocInclusionPredicate(string documentName, ApiDescription apiDescription)
         {
             return apiDescription.GroupName == null || apiDescription.GroupName == documentName;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentFilter.cs
@@ -52,10 +52,11 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 {
                     swaggerDoc.Tags ??= new List<OpenApiTag>();
 
+                    var preferredEol = _options?.XmlCommentEndOfLine;
                     swaggerDoc.Tags.Add(new OpenApiTag
                     {
                         Name = nameAndType.Key,
-                        Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml)
+                        Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml, preferredEol)
                     });
                 }
             }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsDocumentFilter.cs
@@ -52,11 +52,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 {
                     swaggerDoc.Tags ??= new List<OpenApiTag>();
 
-                    var preferredEol = _options?.XmlCommentEndOfLine;
                     swaggerDoc.Tags.Add(new OpenApiTag
                     {
                         Name = nameAndType.Key,
-                        Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml, preferredEol)
+                        Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml, _options?.XmlCommentEndOfLine)
                     });
                 }
             }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsOperationFilter.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.OpenApi.Models;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -15,6 +16,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
         }
 
+        [ActivatorUtilitiesConstructor]
         internal XmlCommentsOperationFilter(IReadOnlyDictionary<string, XPathNavigator> xmlDocMembers, SwaggerGeneratorOptions options)
         {
             _xmlDocMembers = xmlDocMembers;
@@ -52,14 +54,13 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             if (!_xmlDocMembers.TryGetValue(methodMemberName, out var methodNode)) return;
 
-            var preferredEol = _options?.XmlCommentEndOfLine;
             var summaryNode = methodNode.SelectFirstChild("summary");
             if (summaryNode != null)
-                operation.Summary = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml, preferredEol);
+                operation.Summary = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml, _options?.XmlCommentEndOfLine);
 
             var remarksNode = methodNode.SelectFirstChild("remarks");
             if (remarksNode != null)
-                operation.Description = XmlCommentsTextHelper.Humanize(remarksNode.InnerXml, preferredEol);
+                operation.Description = XmlCommentsTextHelper.Humanize(remarksNode.InnerXml, _options?.XmlCommentEndOfLine);
 
             var responseNodes = methodNode.SelectChildren("response");
             ApplyResponseTags(operation, responseNodes);
@@ -67,8 +68,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private void ApplyResponseTags(OpenApiOperation operation, XPathNodeIterator responseNodes)
         {
-            var preferredEol = _options?.XmlCommentEndOfLine;
-
             while (responseNodes.MoveNext())
             {
                 var code = responseNodes.Current.GetAttribute("code");
@@ -78,7 +77,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     operation.Responses[code] = response;
                 }
 
-                response.Description = XmlCommentsTextHelper.Humanize(responseNodes.Current.InnerXml, preferredEol);
+                response.Description = XmlCommentsTextHelper.Humanize(responseNodes.Current.InnerXml, _options?.XmlCommentEndOfLine);
             }
         }
     }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.OpenApi.Models;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Xml.XPath;
@@ -14,6 +15,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
         }
 
+        [ActivatorUtilitiesConstructor]
         internal XmlCommentsParameterFilter(IReadOnlyDictionary<string, XPathNavigator> xmlDocMembers, SwaggerGeneratorOptions options)
         {
             _xmlDocMembers = xmlDocMembers;
@@ -41,8 +43,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             var summaryNode = propertyNode.SelectFirstChild("summary");
             if (summaryNode != null)
             {
-                var preferredEol = _options?.XmlCommentEndOfLine;
-                parameter.Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml, preferredEol);
+                parameter.Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml, _options?.XmlCommentEndOfLine);
                 parameter.Schema.Description = null; // no need to duplicate
             }
 
@@ -71,8 +72,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             if (paramNode != null)
             {
-                var preferredEol = _options?.XmlCommentEndOfLine;
-                parameter.Description = XmlCommentsTextHelper.Humanize(paramNode.InnerXml, preferredEol);
+                parameter.Description = XmlCommentsTextHelper.Humanize(paramNode.InnerXml, _options?.XmlCommentEndOfLine);
 
                 var example = paramNode.GetAttribute("example");
                 if (string.IsNullOrEmpty(example)) return;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
@@ -8,14 +8,16 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     public class XmlCommentsParameterFilter : IParameterFilter
     {
         private readonly IReadOnlyDictionary<string, XPathNavigator> _xmlDocMembers;
+        private readonly SwaggerGeneratorOptions _options;
 
-        public XmlCommentsParameterFilter(XPathDocument xmlDoc) : this(XmlCommentsDocumentHelper.CreateMemberDictionary(xmlDoc))
+        public XmlCommentsParameterFilter(XPathDocument xmlDoc) : this(XmlCommentsDocumentHelper.CreateMemberDictionary(xmlDoc), null)
         {
         }
 
-        internal XmlCommentsParameterFilter(IReadOnlyDictionary<string, XPathNavigator> xmlDocMembers)
+        internal XmlCommentsParameterFilter(IReadOnlyDictionary<string, XPathNavigator> xmlDocMembers, SwaggerGeneratorOptions options)
         {
             _xmlDocMembers = xmlDocMembers;
+            _options = options;
         }
 
         public void Apply(OpenApiParameter parameter, ParameterFilterContext context)
@@ -39,7 +41,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             var summaryNode = propertyNode.SelectFirstChild("summary");
             if (summaryNode != null)
             {
-                parameter.Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml);
+                var preferredEol = _options?.XmlCommentEndOfLine;
+                parameter.Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml, preferredEol);
                 parameter.Schema.Description = null; // no need to duplicate
             }
 
@@ -68,7 +71,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             if (paramNode != null)
             {
-                parameter.Description = XmlCommentsTextHelper.Humanize(paramNode.InnerXml);
+                var preferredEol = _options?.XmlCommentEndOfLine;
+                parameter.Description = XmlCommentsTextHelper.Humanize(paramNode.InnerXml, preferredEol);
 
                 var example = paramNode.GetAttribute("example");
                 if (string.IsNullOrEmpty(example)) return;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsRequestBodyFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsRequestBodyFilter.cs
@@ -9,14 +9,16 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     public class XmlCommentsRequestBodyFilter : IRequestBodyFilter
     {
         private readonly IReadOnlyDictionary<string, XPathNavigator> _xmlDocMembers;
+        private readonly SwaggerGeneratorOptions _options;
 
-        public XmlCommentsRequestBodyFilter(XPathDocument xmlDoc) : this(XmlCommentsDocumentHelper.CreateMemberDictionary(xmlDoc))
+        public XmlCommentsRequestBodyFilter(XPathDocument xmlDoc) : this(XmlCommentsDocumentHelper.CreateMemberDictionary(xmlDoc), null)
         {
         }
 
-        internal XmlCommentsRequestBodyFilter(IReadOnlyDictionary<string, XPathNavigator> xmlDocMembers)
+        internal XmlCommentsRequestBodyFilter(IReadOnlyDictionary<string, XPathNavigator> xmlDocMembers, SwaggerGeneratorOptions options)
         {
             _xmlDocMembers = xmlDocMembers;
+            _options = options;
         }
 
         public void Apply(OpenApiRequestBody requestBody, RequestBodyFilterContext context)
@@ -89,7 +91,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             var summaryNode = propertyNode.SelectFirstChild("summary");
             if (summaryNode is not null)
             {
-                summary = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml);
+                var preferredEol = _options?.XmlCommentEndOfLine;
+                summary = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml, preferredEol);
             }
 
             var exampleNode = propertyNode.SelectFirstChild("example");
@@ -147,7 +150,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 return (null, null);
             }
 
-            var summary = XmlCommentsTextHelper.Humanize(paramNode.InnerXml);
+            var preferredEol = _options?.XmlCommentEndOfLine;
+            var summary = XmlCommentsTextHelper.Humanize(paramNode.InnerXml, preferredEol);
             var example = paramNode.GetAttribute("example");
 
             return (summary, example);

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsRequestBodyFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsRequestBodyFilter.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Xml.XPath;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen
@@ -15,6 +16,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
         }
 
+        [ActivatorUtilitiesConstructor]
         internal XmlCommentsRequestBodyFilter(IReadOnlyDictionary<string, XPathNavigator> xmlDocMembers, SwaggerGeneratorOptions options)
         {
             _xmlDocMembers = xmlDocMembers;
@@ -91,8 +93,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             var summaryNode = propertyNode.SelectFirstChild("summary");
             if (summaryNode is not null)
             {
-                var preferredEol = _options?.XmlCommentEndOfLine;
-                summary = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml, preferredEol);
+                summary = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml, _options?.XmlCommentEndOfLine);
             }
 
             var exampleNode = propertyNode.SelectFirstChild("example");
@@ -150,8 +151,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 return (null, null);
             }
 
-            var preferredEol = _options?.XmlCommentEndOfLine;
-            var summary = XmlCommentsTextHelper.Humanize(paramNode.InnerXml, preferredEol);
+            var summary = XmlCommentsTextHelper.Humanize(paramNode.InnerXml, _options?.XmlCommentEndOfLine);
             var example = paramNode.GetAttribute("example");
 
             return (summary, example);

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.OpenApi.Models;
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
 using System;
 using System.Collections.Generic;
 using System.Xml.XPath;
@@ -14,6 +15,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
         {
         }
 
+        [ActivatorUtilitiesConstructor]
         internal XmlCommentsSchemaFilter(IReadOnlyDictionary<string, XPathNavigator> xmlDocMembers, SwaggerGeneratorOptions options)
         {
             _xmlDocMembers = xmlDocMembers;
@@ -40,8 +42,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             if (typeSummaryNode != null)
             {
-                var preferredEol = _options?.XmlCommentEndOfLine;
-                schema.Description = XmlCommentsTextHelper.Humanize(typeSummaryNode.InnerXml, preferredEol);
+                schema.Description = XmlCommentsTextHelper.Humanize(typeSummaryNode.InnerXml, _options?.XmlCommentEndOfLine);
             }
         }
 
@@ -60,8 +61,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     var summaryNode = recordDefaultConstructorProperty.Value;
                     if (summaryNode != null)
                     {
-                        var preferredEol = _options?.XmlCommentEndOfLine;
-                        schema.Description = XmlCommentsTextHelper.Humanize(summaryNode, preferredEol);
+                        schema.Description = XmlCommentsTextHelper.Humanize(summaryNode, _options?.XmlCommentEndOfLine);
                     }
 
                     var example = recordDefaultConstructorProperty.GetAttribute("example");
@@ -77,8 +77,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 var summaryNode = fieldOrPropertyNode.SelectFirstChild("summary");
                 if (summaryNode != null)
                 {
-                    var preferredEol = _options?.XmlCommentEndOfLine;
-                    schema.Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml, preferredEol);
+                    schema.Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml, _options?.XmlCommentEndOfLine);
                 }
 
                 var exampleNode = fieldOrPropertyNode.SelectFirstChild("example");

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
@@ -8,14 +8,16 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     public class XmlCommentsSchemaFilter : ISchemaFilter
     {
         private readonly IReadOnlyDictionary<string, XPathNavigator> _xmlDocMembers;
+        private readonly SwaggerGeneratorOptions _options;
 
-        public XmlCommentsSchemaFilter(XPathDocument xmlDoc) : this(XmlCommentsDocumentHelper.CreateMemberDictionary(xmlDoc))
+        public XmlCommentsSchemaFilter(XPathDocument xmlDoc) : this(XmlCommentsDocumentHelper.CreateMemberDictionary(xmlDoc), null)
         {
         }
 
-        internal XmlCommentsSchemaFilter(IReadOnlyDictionary<string, XPathNavigator> xmlDocMembers)
+        internal XmlCommentsSchemaFilter(IReadOnlyDictionary<string, XPathNavigator> xmlDocMembers, SwaggerGeneratorOptions options)
         {
             _xmlDocMembers = xmlDocMembers;
+            _options = options;
         }
 
         public void Apply(OpenApiSchema schema, SchemaFilterContext context)
@@ -38,7 +40,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             if (typeSummaryNode != null)
             {
-                schema.Description = XmlCommentsTextHelper.Humanize(typeSummaryNode.InnerXml);
+                var preferredEol = _options?.XmlCommentEndOfLine;
+                schema.Description = XmlCommentsTextHelper.Humanize(typeSummaryNode.InnerXml, preferredEol);
             }
         }
 
@@ -56,7 +59,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 {
                     var summaryNode = recordDefaultConstructorProperty.Value;
                     if (summaryNode != null)
-                        schema.Description = XmlCommentsTextHelper.Humanize(summaryNode);
+                    {
+                        var preferredEol = _options?.XmlCommentEndOfLine;
+                        schema.Description = XmlCommentsTextHelper.Humanize(summaryNode, preferredEol);
+                    }
 
                     var example = recordDefaultConstructorProperty.GetAttribute("example");
                     if (!string.IsNullOrEmpty(example))
@@ -70,7 +76,10 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             {
                 var summaryNode = fieldOrPropertyNode.SelectFirstChild("summary");
                 if (summaryNode != null)
-                    schema.Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml);
+                {
+                    var preferredEol = _options?.XmlCommentEndOfLine;
+                    schema.Description = XmlCommentsTextHelper.Humanize(summaryNode.InnerXml, preferredEol);
+                }
 
                 var exampleNode = fieldOrPropertyNode.SelectFirstChild("example");
                 TrySetExample(schema, context, exampleNode?.Value);

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
@@ -18,9 +18,6 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             if (text == null)
                 throw new ArgumentNullException(nameof(text));
 
-            // Using as a default behavior
-            xmlCommentEndOfLine ??= Environment.NewLine;
-
             //Call DecodeXml at last to avoid entities like &lt and &gt to break valid xml
 
             return text
@@ -54,7 +51,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             // remove leading empty lines, but not all leading padding
             // remove all trailing whitespace, regardless
-            return string.Join(xmlCommentEndOfLine, lines.SkipWhile(x => string.IsNullOrWhiteSpace(x))).TrimEnd();
+            return string.Join(xmlCommentEndOfLine ?? "\r\n", lines.SkipWhile(x => string.IsNullOrWhiteSpace(x))).TrimEnd();
         }
 
         private static string GetCommonLeadingWhitespace(string[] lines)
@@ -141,7 +138,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
         private static string HumanizeBrTags(this string text, string xmlCommentEndOfLine)
         {
-            return BrTag().Replace(text, _ => xmlCommentEndOfLine);
+            return BrTag().Replace(text, _ => xmlCommentEndOfLine ?? Environment.NewLine);
         }
 
         private static string DecodeXml(this string text)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
@@ -10,23 +10,31 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
     {
         public static string Humanize(string text)
         {
+            return Humanize(text, null);
+        }
+
+        public static string Humanize(string text, string xmlCommentEndOfLine)
+        {
             if (text == null)
                 throw new ArgumentNullException(nameof(text));
+
+            // Using as a default behavior
+            xmlCommentEndOfLine ??= Environment.NewLine;
 
             //Call DecodeXml at last to avoid entities like &lt and &gt to break valid xml
 
             return text
-                .NormalizeIndentation()
+                .NormalizeIndentation(xmlCommentEndOfLine)
                 .HumanizeRefTags()
                 .HumanizeHrefTags()
                 .HumanizeCodeTags()
                 .HumanizeMultilineCodeTags()
                 .HumanizeParaTags()
-                .HumanizeBrTags() // must be called after HumanizeParaTags() so that it replaces any additional <br> tags
+                .HumanizeBrTags(xmlCommentEndOfLine) // must be called after HumanizeParaTags() so that it replaces any additional <br> tags
                 .DecodeXml();
         }
 
-        private static string NormalizeIndentation(this string text)
+        private static string NormalizeIndentation(this string text, string xmlCommentEndOfLine)
         {
             string[] lines = text.Split('\n');
             string padding = GetCommonLeadingWhitespace(lines);
@@ -46,7 +54,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
 
             // remove leading empty lines, but not all leading padding
             // remove all trailing whitespace, regardless
-            return string.Join("\r\n", lines.SkipWhile(x => string.IsNullOrWhiteSpace(x))).TrimEnd();
+            return string.Join(xmlCommentEndOfLine, lines.SkipWhile(x => string.IsNullOrWhiteSpace(x))).TrimEnd();
         }
 
         private static string GetCommonLeadingWhitespace(string[] lines)
@@ -131,9 +139,9 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
             });
         }
 
-        private static string HumanizeBrTags(this string text)
+        private static string HumanizeBrTags(this string text, string xmlCommentEndOfLine)
         {
-            return BrTag().Replace(text, _ => Environment.NewLine);
+            return BrTag().Replace(text, _ => xmlCommentEndOfLine);
         }
 
         private static string DecodeXml(this string text)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSwaggerGeneratorOptionsTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSwaggerGeneratorOptionsTests.cs
@@ -18,7 +18,7 @@ public static class ConfigureSwaggerGeneratorOptionsTests
 
         // If this assertion fails, it means that a new property has been added
         // to SwaggerGeneratorOptions and ConfigureSwaggerGeneratorOptions.DeepCopy() needs to be updated
-        Assert.Equal(23, publicProperties.Length);
+        Assert.Equal(24, publicProperties.Length);
     }
 
     [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
@@ -155,12 +155,11 @@ A line of text",
 
             var output = XmlCommentsTextHelper.Humanize(input);
 
-            // Result view for Windows: This is a paragraph.\r\n\r\n\r\nA parameter after br tag.
-            var expected = string.Join(Environment.NewLine,
+            // Result view for Linux: This is a paragraph.\r\n\n\r\nA parameter after br tag.
+            var expected = string.Join("\r\n",
             [
                 "This is a paragraph.",
-                "",
-                "",
+                Environment.NewLine,
                 "A parameter after br tag."
             ]);
             Assert.Equal(expected, output, false, ignoreLineEndingDifferences: false);

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System;
+using Xunit;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen.Test
 {
@@ -142,6 +143,49 @@ A line of text",
             var output = XmlCommentsTextHelper.Humanize(input);
 
             Assert.Equal(expectedOutput, output, false, true);
+        }
+
+        [Fact]
+        public void Humanize_MultilineBrTag_EolNotSpecified()
+        {
+            const string input = @"
+            This is a paragraph.
+            <br>
+            A parameter after br tag.";
+
+            var output = XmlCommentsTextHelper.Humanize(input);
+
+            // Result view for Windows: This is a paragraph.\r\n\r\n\r\nA parameter after br tag.
+            var expected = string.Join(Environment.NewLine,
+            [
+                "This is a paragraph.",
+                "",
+                "",
+                "A parameter after br tag."
+            ]);
+            Assert.Equal(expected, output, false, ignoreLineEndingDifferences: false);
+        }
+
+        [Theory]
+        [InlineData("\r\n")]
+        [InlineData("\n")]
+        public void Humanize_MultilineBrTag_SpecificEol(string xmlCommentEndOfLine)
+        {
+            const string input = @"
+            This is a paragraph.
+            <br>
+            A parameter after br tag.";
+
+            var output = XmlCommentsTextHelper.Humanize(input, xmlCommentEndOfLine);
+
+            var expected = string.Join(xmlCommentEndOfLine,
+            [
+                "This is a paragraph.",
+                "",
+                "",
+                "A parameter after br tag."
+            ]);
+            Assert.Equal(expected, output, false, ignoreLineEndingDifferences: false);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

Fixes #2947 

<!-- Please include the existing GitHub issue number where relevant, e.g. "Fixes #123" -->

## Details on the issue fix or feature implementation

Before version [6.6.2,](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/milestone/21?closed=1) OpenAPI file generation was identical for Linux and Windows, which allowed to correctly process files from different OS (including comparing them on CI), after the version, the carets in the text began to differ. 
### Example of how it was
{
      “name": ‘SomeController’,
      “description": “Some description.\r\n\n\<br>\r\n\Some Parameter (para tag)\r\n\”
}
### Example of what became
{
      “name": ‘SomeController’,
      “description": “Some description.\r\n[\r\n]|[\n]\r\n\Some Parameter (para tag)\r\n\”
}

That is, instead of <br> being identical when generated on different OS, different strings started to be generated.
The pool requester replaces the generation based on the EOL of the operating system with the EOL generation previously specified in this file (CLRF).

<!-- Information about your changes -->
