### PR TITLE
add concrete schema for discriminated types into 'oneOf' for base type

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -211,7 +211,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 ? new[] { dataContract.UnderlyingType }.Union(subTypes)
                 : subTypes;
 
-            knownTypesDataContracts = knownTypes.Select(knownType => GetDataContractFor(knownType));
+            knownTypesDataContracts = knownTypes.Select(GetDataContractFor);
             return true;
         }
 
@@ -415,7 +415,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                     foreach (var knownTypeDataContract in knownTypesDataContracts)
                     {
                         // Ensure schema is generated for all known types
-                        GenerateConcreteSchema(knownTypeDataContract, schemaRepository);
+                        schema.OneOf.Add(GenerateConcreteSchema(knownTypeDataContract, schemaRepository));
                     }
 
                     if (TryGetDiscriminatorFor(dataContract, schemaRepository, knownTypesDataContracts, out var discriminator))

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.verified.txt
@@ -1550,6 +1550,14 @@
           "TypeName"
         ],
         "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/Rectangle"
+          },
+          {
+            "$ref": "#/components/schemas/Circle"
+          }
+        ],
         "properties": {
           "TypeName": {
             "type": "string"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=NSwagClientExample.Startup_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerVerifyIntegrationTest.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=NSwagClientExample.Startup_swaggerRequestUri=v1.verified.txt
@@ -188,6 +188,17 @@
           "animalType"
         ],
         "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/Animal"
+          },
+          {
+            "$ref": "#/components/schemas/Cat"
+          },
+          {
+            "$ref": "#/components/schemas/Dog"
+          }
+        ],
         "properties": {
           "animalType": {
             "$ref": "#/components/schemas/AnimalType"
@@ -214,6 +225,11 @@
           "discriminator"
         ],
         "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SubSubType"
+          }
+        ],
         "properties": {
           "discriminator": {
             "type": "string"
@@ -287,6 +303,17 @@
           "animalType"
         ],
         "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SystemTextJsonAnimal"
+          },
+          {
+            "$ref": "#/components/schemas/SystemTextJsonCat"
+          },
+          {
+            "$ref": "#/components/schemas/SystemTextJsonDog"
+          }
+        ],
         "properties": {
           "animalType": {
             "type": "string",


### PR DESCRIPTION
fix for #3166

## Details on the issue fix or feature implementation

I am not happy how it looks like in Swagger UI, I open for any suggestions

here's how looks [Animal](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/master/test/WebSites/NswagClientExample/Controllers/AnimalsController.cs#L24-L43) class with subtypes. Having refs to himself can easily lead to such unpleasant view
![image](https://github.com/user-attachments/assets/236224a4-bc46-451b-9a9c-5b84259c1e82)

BaseType with SubSubType [link](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/master/test/WebSites/NswagClientExample/Controllers/SecondLevelController.cs#L21-L33)
![image](https://github.com/user-attachments/assets/09e75dc6-b401-437d-8317-324ff98d1a5f)

