### PR TITLE
Fix DescribeAllParametersInCamelCase usage in GenerateOpenApiOperationFromMetadataAsync

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -409,6 +409,7 @@ namespace Swashbuckle.AspNetCore.SwaggerGen
                 if (apiParameter is not null)
                 {
                     var (parameterAndContext, filterContext) = GenerateParameterAndContext(apiParameter, schemaRepository);
+                    parameter.Name = parameterAndContext.Name;
                     parameter.Schema = parameterAndContext.Schema;
                     parameter.Description ??= parameterAndContext.Description;
 


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

Fixes #3271 

## Details on the issue fix or feature implementation

The correct parameter name was generated in the `GenerateParameterAndContext` method, but was not used further.

Added assignment of a new parameter name to the `GenerateOpenApiOperationFromMetadataAsync` method.
Added a unit test.
