### PR TITLE
Snapshot OpenApiDocument as JSON

### DIFF
--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasConsumesAttribute_bindingSourceId=Body.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasConsumesAttribute_bindingSourceId=Body.DotNet8_0.verified.txt
@@ -1,47 +1,31 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              application/someMediaType: {
-                Schema: {
-                  Type: string,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                }
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "requestBody": {
+          "content": {
+            "application/someMediaType": {
+              "schema": {
+                "type": "string"
               }
             }
-          },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 4CB047722B57E9853D09B038EC48DB9A63B1EE5C19DDFD234A172615EE6225134356F1B92FB3881C2D7DAA40B77D534CB317F93B407B4E7B6B74480224A9E7B7
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasConsumesAttribute_bindingSourceId=Body.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasConsumesAttribute_bindingSourceId=Body.DotNet9_0.verified.txt
@@ -1,47 +1,31 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              application/someMediaType: {
-                Schema: {
-                  Type: string,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                }
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "requestBody": {
+          "content": {
+            "application/someMediaType": {
+              "schema": {
+                "type": "string"
               }
             }
-          },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 4CB047722B57E9853D09B038EC48DB9A63B1EE5C19DDFD234A172615EE6225134356F1B92FB3881C2D7DAA40B77D534CB317F93B407B4E7B6B74480224A9E7B7
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasConsumesAttribute_bindingSourceId=Form.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasConsumesAttribute_bindingSourceId=Form.DotNet8_0.verified.txt
@@ -1,63 +1,41 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              application/someMediaType: {
-                Schema: {
-                  Type: object,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  Properties: {
-                    param: {
-                      Type: string,
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false
-                    }
-                  },
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                },
-                Encoding: {
-                  param: {
-                    Style: Form
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "requestBody": {
+          "content": {
+            "application/someMediaType": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "param": {
+                    "type": "string"
                   }
+                }
+              },
+              "encoding": {
+                "param": {
+                  "style": "form"
                 }
               }
             }
-          },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: E5B7D5A3A69521A769EA033C2E26073D98F03E899B1DFE0A7CF240CE54D26EA3294FDF9D39DCABBB4F32CA029376F8CF147C001935036911E75750C367FD288E
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasConsumesAttribute_bindingSourceId=Form.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasConsumesAttribute_bindingSourceId=Form.DotNet9_0.verified.txt
@@ -1,63 +1,41 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              application/someMediaType: {
-                Schema: {
-                  Type: object,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  Properties: {
-                    param: {
-                      Type: string,
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false
-                    }
-                  },
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                },
-                Encoding: {
-                  param: {
-                    Style: Form
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "requestBody": {
+          "content": {
+            "application/someMediaType": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "param": {
+                    "type": "string"
                   }
+                }
+              },
+              "encoding": {
+                "param": {
+                  "style": "form"
                 }
               }
             }
-          },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: E5B7D5A3A69521A769EA033C2E26073D98F03E899B1DFE0A7CF240CE54D26EA3294FDF9D39DCABBB4F32CA029376F8CF147C001935036911E75750C367FD288E
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasFileResult.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasFileResult.DotNet8_0.verified.txt
@@ -1,44 +1,30 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              Content: {
-                application/zip: {
-                  Schema: {
-                    Type: string,
-                    Format: binary,
-                    ReadOnly: false,
-                    WriteOnly: false,
-                    AdditionalPropertiesAllowed: true,
-                    Nullable: false,
-                    Deprecated: false,
-                    UnresolvedReference: false
-                  }
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
                 }
-              },
-              UnresolvedReference: false
+              }
             }
-          },
-          Deprecated: false
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 83ACD9647CC5FE2F4D9CB77158BC1B03C790DCF45575DD944B54B1B223692F2F000674EA282E908E25354FD80FD6843770F1CA8B70289B8BE70C58F919A2FDDA
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasFileResult.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasFileResult.DotNet9_0.verified.txt
@@ -1,44 +1,30 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              Content: {
-                application/zip: {
-                  Schema: {
-                    Type: string,
-                    Format: binary,
-                    ReadOnly: false,
-                    WriteOnly: false,
-                    AdditionalPropertiesAllowed: true,
-                    Nullable: false,
-                    Deprecated: false,
-                    UnresolvedReference: false
-                  }
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
                 }
-              },
-              UnresolvedReference: false
+              }
             }
-          },
-          Deprecated: false
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 83ACD9647CC5FE2F4D9CB77158BC1B03C790DCF45575DD944B54B1B223692F2F000674EA282E908E25354FD80FD6843770F1CA8B70289B8BE70C58F919A2FDDA
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasObsoleteAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasObsoleteAttribute.DotNet8_0.verified.txt
@@ -1,30 +1,23 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: true
-        }
-      },
-      UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "deprecated": true
+      }
     }
   },
-  Components: {},
-  HashCode: 6ED193BE1E35B9D7BF0B260B931947E4AAC0931E500AA8ED441B6D9D2A5AFA228C99ED8B295DB246E18AFAD63CB63455167621785F98F447EBF31A5431F61380
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasObsoleteAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasObsoleteAttribute.DotNet9_0.verified.txt
@@ -1,30 +1,23 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: true
-        }
-      },
-      UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "deprecated": true
+      }
     }
   },
-  Components: {},
-  HashCode: 6ED193BE1E35B9D7BF0B260B931947E4AAC0931E500AA8ED441B6D9D2A5AFA228C99ED8B295DB246E18AFAD63CB63455167621785F98F447EBF31A5431F61380
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasProducesAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasProducesAttribute.DotNet8_0.verified.txt
@@ -1,44 +1,30 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              Content: {
-                application/someMediaType: {
-                  Schema: {
-                    Type: integer,
-                    Format: int32,
-                    ReadOnly: false,
-                    WriteOnly: false,
-                    AdditionalPropertiesAllowed: true,
-                    Nullable: false,
-                    Deprecated: false,
-                    UnresolvedReference: false
-                  }
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/someMediaType": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
                 }
-              },
-              UnresolvedReference: false
+              }
             }
-          },
-          Deprecated: false
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 70543EA64D7658413247389AF5490AD05BEEDF3D5FDCEC1436353732D8D2F1566EDB6CE23863A45C135B8715D60FA95B90E6D460181B1FEABD2CD061914DFE13
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasProducesAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasProducesAttribute.DotNet9_0.verified.txt
@@ -1,44 +1,30 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              Content: {
-                application/someMediaType: {
-                  Schema: {
-                    Type: integer,
-                    Format: int32,
-                    ReadOnly: false,
-                    WriteOnly: false,
-                    AdditionalPropertiesAllowed: true,
-                    Nullable: false,
-                    Deprecated: false,
-                    UnresolvedReference: false
-                  }
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/someMediaType": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
                 }
-              },
-              UnresolvedReference: false
+              }
             }
-          },
-          Deprecated: false
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 70543EA64D7658413247389AF5490AD05BEEDF3D5FDCEC1436353732D8D2F1566EDB6CE23863A45C135B8715D60FA95B90E6D460181B1FEABD2CD061914DFE13
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHavingFromFormAttributeButNotWithIFormFile.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHavingFromFormAttributeButNotWithIFormFile.DotNet8_0.verified.txt
@@ -1,73 +1,39 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param1,
-              In: Query,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            },
-            {
-              UnresolvedReference: false,
-              Name: param2,
-              In: Query,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                Format: binary,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param1",
+            "in": "query",
+            "schema": {
+              "type": "string"
             }
           },
-          Deprecated: false
+          {
+            "name": "param2",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 0FB4C6819BEAFC6E91679E56836641A46864BF8AB09F4C5439146C4B568315AE89C2FE246798FEB6DFF832DE97AE90010624CB9342E8E41AC45064041DE39A25
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHavingFromFormAttributeButNotWithIFormFile.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHavingFromFormAttributeButNotWithIFormFile.DotNet9_0.verified.txt
@@ -1,73 +1,39 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param1,
-              In: Query,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            },
-            {
-              UnresolvedReference: false,
-              Name: param2,
-              In: Query,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                Format: binary,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param1",
+            "in": "query",
+            "schema": {
+              "type": "string"
             }
           },
-          Deprecated: false
+          {
+            "name": "param2",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 0FB4C6819BEAFC6E91679E56836641A46864BF8AB09F4C5439146C4B568315AE89C2FE246798FEB6DFF832DE97AE90010624CB9342E8E41AC45064041DE39A25
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHavingFromFormAttributeWithSwaggerIgnore.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHavingFromFormAttributeWithSwaggerIgnore.DotNet8_0.verified.txt
@@ -1,63 +1,41 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              multipart/form-data: {
-                Schema: {
-                  Type: object,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  Properties: {
-                    NotIgnoredString: {
-                      Type: string,
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false
-                    }
-                  },
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                },
-                Encoding: {
-                  NotIgnoredString: {
-                    Style: Form
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "NotIgnoredString": {
+                    "type": "string"
                   }
+                }
+              },
+              "encoding": {
+                "NotIgnoredString": {
+                  "style": "form"
                 }
               }
             }
-          },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: F2D8CE9F78193258F625FBA0732E8543EACC9F98F35622C7D834B9A4CF30328B824D914FFE1E1C94E268978D828FE142ED48EBAB9F468EF288FFD238C56C20E1
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHavingFromFormAttributeWithSwaggerIgnore.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHavingFromFormAttributeWithSwaggerIgnore.DotNet9_0.verified.txt
@@ -1,63 +1,41 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              multipart/form-data: {
-                Schema: {
-                  Type: object,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  Properties: {
-                    NotIgnoredString: {
-                      Type: string,
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false
-                    }
-                  },
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                },
-                Encoding: {
-                  NotIgnoredString: {
-                    Style: Form
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "NotIgnoredString": {
+                    "type": "string"
                   }
+                }
+              },
+              "encoding": {
+                "NotIgnoredString": {
+                  "style": "form"
                 }
               }
             }
-          },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: F2D8CE9F78193258F625FBA0732E8543EACC9F98F35622C7D834B9A4CF30328B824D914FFE1E1C94E268978D828FE142ED48EBAB9F468EF288FFD238C56C20E1
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionParameterHasBindNeverAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionParameterHasBindNeverAttribute.DotNet8_0.verified.txt
@@ -1,30 +1,22 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 0E75218C57C662359EC554B377E7600D033FDF17E191A0E468F1E402807067F96CA4BF92320CC0B13E796E1E39DF7997BCF9A2F00DEF42D6D1AD6F47A7F35666
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionParameterHasBindNeverAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionParameterHasBindNeverAttribute.DotNet9_0.verified.txt
@@ -1,30 +1,22 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 0E75218C57C662359EC554B377E7600D033FDF17E191A0E468F1E402807067F96CA4BF92320CC0B13E796E1E39DF7997BCF9A2F00DEF42D6D1AD6F47A7F35666
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionParameterHasSwaggerIgnoreAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionParameterHasSwaggerIgnoreAttribute.DotNet8_0.verified.txt
@@ -1,30 +1,22 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 0E75218C57C662359EC554B377E7600D033FDF17E191A0E468F1E402807067F96CA4BF92320CC0B13E796E1E39DF7997BCF9A2F00DEF42D6D1AD6F47A7F35666
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionParameterHasSwaggerIgnoreAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionParameterHasSwaggerIgnoreAttribute.DotNet9_0.verified.txt
@@ -1,30 +1,22 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 0E75218C57C662359EC554B377E7600D033FDF17E191A0E468F1E402807067F96CA4BF92320CC0B13E796E1E39DF7997BCF9A2F00DEF42D6D1AD6F47A7F35666
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithConsumesAttributeAndProvidedOpenApiOperation.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithConsumesAttributeAndProvidedOpenApiOperation.DotNet8_0.verified.txt
@@ -1,67 +1,38 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          OperationId: OperationIdSetInMetadata,
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              application/someMediaType: {
-                Schema: {
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false,
-                  Reference: {
-                    IsFragrament: false,
-                    Type: Schema,
-                    Id: TestDto,
-                    IsExternal: false,
-                    IsLocal: true,
-                    ReferenceV3: #/components/schemas/TestDto,
-                    ReferenceV2: #/definitions/TestDto
-                  }
-                }
+  "paths": {
+    "/resource": {
+      "post": {
+        "operationId": "OperationIdSetInMetadata",
+        "requestBody": {
+          "content": {
+            "application/someMediaType": {
+              "schema": {
+                "$ref": "#/components/schemas/TestDto"
               }
             }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
-    }
-  },
-  Components: {
-    Schemas: {
-      TestDto: {
-        Type: object,
-        ReadOnly: false,
-        WriteOnly: false,
-        Properties: {
-          Prop1: {
-            Type: string,
-            ReadOnly: false,
-            WriteOnly: false,
-            AdditionalPropertiesAllowed: true,
-            Nullable: true,
-            Deprecated: false,
-            UnresolvedReference: false
           }
         },
-        AdditionalPropertiesAllowed: false,
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
+        "responses": { }
       }
     }
   },
-  HashCode: 59A5DD972A919CE8EF3F08E63BB492CCCA30B825146EA05B2BEF4690888EA52FB3CEC61C7F1F9A14629EDFF141CC49084DA127F3D6C5F555D8EA39F7B202C4E9
+  "components": {
+    "schemas": {
+      "TestDto": {
+        "type": "object",
+        "properties": {
+          "Prop1": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithConsumesAttributeAndProvidedOpenApiOperation.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithConsumesAttributeAndProvidedOpenApiOperation.DotNet9_0.verified.txt
@@ -1,67 +1,38 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          OperationId: OperationIdSetInMetadata,
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              application/someMediaType: {
-                Schema: {
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false,
-                  Reference: {
-                    IsFragrament: false,
-                    Type: Schema,
-                    Id: TestDto,
-                    IsExternal: false,
-                    IsLocal: true,
-                    ReferenceV3: #/components/schemas/TestDto,
-                    ReferenceV2: #/definitions/TestDto
-                  }
-                }
+  "paths": {
+    "/resource": {
+      "post": {
+        "operationId": "OperationIdSetInMetadata",
+        "requestBody": {
+          "content": {
+            "application/someMediaType": {
+              "schema": {
+                "$ref": "#/components/schemas/TestDto"
               }
             }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
-    }
-  },
-  Components: {
-    Schemas: {
-      TestDto: {
-        Type: object,
-        ReadOnly: false,
-        WriteOnly: false,
-        Properties: {
-          Prop1: {
-            Type: string,
-            ReadOnly: false,
-            WriteOnly: false,
-            AdditionalPropertiesAllowed: true,
-            Nullable: true,
-            Deprecated: false,
-            UnresolvedReference: false
           }
         },
-        AdditionalPropertiesAllowed: false,
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
+        "responses": { }
       }
     }
   },
-  HashCode: 59A5DD972A919CE8EF3F08E63BB492CCCA30B825146EA05B2BEF4690888EA52FB3CEC61C7F1F9A14629EDFF141CC49084DA127F3D6C5F555D8EA39F7B202C4E9
+  "components": {
+    "schemas": {
+      "TestDto": {
+        "type": "object",
+        "properties": {
+          "Prop1": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithEndpointNameMetadata.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithEndpointNameMetadata.DotNet8_0.verified.txt
@@ -1,31 +1,23 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          OperationId: SomeEndpointName,
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "operationId": "SomeEndpointName",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: A0047BEEDFB7C084AF6BF3412F47917E1914849406956B23249FD5A555B9545157FBFF5C1EAFC073B55E59FDE9BDB1774670EFE402C7319D5EC6A6A43D94E439
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithEndpointNameMetadata.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithEndpointNameMetadata.DotNet9_0.verified.txt
@@ -1,31 +1,23 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          OperationId: SomeEndpointName,
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "operationId": "SomeEndpointName",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: A0047BEEDFB7C084AF6BF3412F47917E1914849406956B23249FD5A555B9545157FBFF5C1EAFC073B55E59FDE9BDB1774670EFE402C7319D5EC6A6A43D94E439
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithParameterAndProvidedOpenApiOperation.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithParameterAndProvidedOpenApiOperation.DotNet8_0.verified.txt
@@ -1,40 +1,24 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          OperationId: OperationIdSetInMetadata,
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: ParameterInMetadata,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
+  "paths": {
+    "/resource": {
+      "post": {
+        "operationId": "OperationIdSetInMetadata",
+        "parameters": [
+          {
+            "name": "ParameterInMetadata",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
+          }
+        ],
+        "responses": { }
+      }
     }
   },
-  Components: {},
-  HashCode: 80ACD622C6A7E73B1C5084D230E624A2A5897CCCC091D32500F9192221224A9A256D1E80276A6D47B85459035DFF93938E2378ACE8A3E854CB32390244297D61
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithParameterAndProvidedOpenApiOperation.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithParameterAndProvidedOpenApiOperation.DotNet9_0.verified.txt
@@ -1,40 +1,24 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          OperationId: OperationIdSetInMetadata,
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: ParameterInMetadata,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
+  "paths": {
+    "/resource": {
+      "post": {
+        "operationId": "OperationIdSetInMetadata",
+        "parameters": [
+          {
+            "name": "ParameterInMetadata",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
+          }
+        ],
+        "responses": { }
+      }
     }
   },
-  Components: {},
-  HashCode: 80ACD622C6A7E73B1C5084D230E624A2A5897CCCC091D32500F9192221224A9A256D1E80276A6D47B85459035DFF93938E2378ACE8A3E854CB32390244297D61
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithProducesAttributeAndProvidedOpenApiOperation.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithProducesAttributeAndProvidedOpenApiOperation.DotNet8_0.verified.txt
@@ -1,68 +1,40 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          OperationId: OperationIdSetInMetadata,
-          Responses: {
-            200: {
-              Content: {
-                application/someMediaType: {
-                  Schema: {
-                    ReadOnly: false,
-                    WriteOnly: false,
-                    AdditionalPropertiesAllowed: true,
-                    Nullable: false,
-                    Deprecated: false,
-                    UnresolvedReference: false,
-                    Reference: {
-                      IsFragrament: false,
-                      Type: Schema,
-                      Id: TestDto,
-                      IsExternal: false,
-                      IsLocal: true,
-                      ReferenceV3: #/components/schemas/TestDto,
-                      ReferenceV2: #/definitions/TestDto
-                    }
-                  }
+  "paths": {
+    "/resource": {
+      "post": {
+        "operationId": "OperationIdSetInMetadata",
+        "responses": {
+          "200": {
+            "description": null,
+            "content": {
+              "application/someMediaType": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestDto"
                 }
-              },
-              UnresolvedReference: false
+              }
             }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
-    }
-  },
-  Components: {
-    Schemas: {
-      TestDto: {
-        Type: object,
-        ReadOnly: false,
-        WriteOnly: false,
-        Properties: {
-          Prop1: {
-            Type: string,
-            ReadOnly: false,
-            WriteOnly: false,
-            AdditionalPropertiesAllowed: true,
-            Nullable: true,
-            Deprecated: false,
-            UnresolvedReference: false
           }
-        },
-        AdditionalPropertiesAllowed: false,
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
+        }
       }
     }
   },
-  HashCode: 33EF286A101E847C16BF4B86DF410E6C22D16FEA221DEC72217642B13238E9C69382B5EBE1F7B9FEFC5E2819EA81D1C4C28A8E2AFF075F8E1CCF425F635F9532
+  "components": {
+    "schemas": {
+      "TestDto": {
+        "type": "object",
+        "properties": {
+          "Prop1": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithProducesAttributeAndProvidedOpenApiOperation.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithProducesAttributeAndProvidedOpenApiOperation.DotNet9_0.verified.txt
@@ -1,68 +1,40 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          OperationId: OperationIdSetInMetadata,
-          Responses: {
-            200: {
-              Content: {
-                application/someMediaType: {
-                  Schema: {
-                    ReadOnly: false,
-                    WriteOnly: false,
-                    AdditionalPropertiesAllowed: true,
-                    Nullable: false,
-                    Deprecated: false,
-                    UnresolvedReference: false,
-                    Reference: {
-                      IsFragrament: false,
-                      Type: Schema,
-                      Id: TestDto,
-                      IsExternal: false,
-                      IsLocal: true,
-                      ReferenceV3: #/components/schemas/TestDto,
-                      ReferenceV2: #/definitions/TestDto
-                    }
-                  }
+  "paths": {
+    "/resource": {
+      "post": {
+        "operationId": "OperationIdSetInMetadata",
+        "responses": {
+          "200": {
+            "description": null,
+            "content": {
+              "application/someMediaType": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestDto"
                 }
-              },
-              UnresolvedReference: false
+              }
             }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
-    }
-  },
-  Components: {
-    Schemas: {
-      TestDto: {
-        Type: object,
-        ReadOnly: false,
-        WriteOnly: false,
-        Properties: {
-          Prop1: {
-            Type: string,
-            ReadOnly: false,
-            WriteOnly: false,
-            AdditionalPropertiesAllowed: true,
-            Nullable: true,
-            Deprecated: false,
-            UnresolvedReference: false
           }
-        },
-        AdditionalPropertiesAllowed: false,
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
+        }
       }
     }
   },
-  HashCode: 33EF286A101E847C16BF4B86DF410E6C22D16FEA221DEC72217642B13238E9C69382B5EBE1F7B9FEFC5E2819EA81D1C4C28A8E2AFF075F8E1CCF425F635F9532
+  "components": {
+    "schemas": {
+      "TestDto": {
+        "type": "object",
+        "properties": {
+          "Prop1": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithProvidedOpenApiMetadata.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithProvidedOpenApiMetadata.DotNet8_0.verified.txt
@@ -1,31 +1,21 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          OperationId: OperationIdSetInMetadata,
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: ParameterInMetadata,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false
-            }
-          ],
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "operationId": "OperationIdSetInMetadata",
+        "parameters": [
+          {
+            "name": "ParameterInMetadata"
+          }
+        ],
+        "responses": { }
+      }
     }
   },
-  Components: {},
-  HashCode: 76DE54DD44D94D07BC803E615ECB0F6D290C3B8803EFB5EADF02C6B180682B1C20BFDD4C9CD50F71D5AD7042B7B4570903F3AF1CC7970ABCA1CEE20FBF971FFD
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithProvidedOpenApiMetadata.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithProvidedOpenApiMetadata.DotNet9_0.verified.txt
@@ -1,31 +1,21 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          OperationId: OperationIdSetInMetadata,
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: ParameterInMetadata,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false
-            }
-          ],
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "operationId": "OperationIdSetInMetadata",
+        "parameters": [
+          {
+            "name": "ParameterInMetadata"
+          }
+        ],
+        "responses": { }
+      }
     }
   },
-  Components: {},
-  HashCode: 76DE54DD44D94D07BC803E615ECB0F6D290C3B8803EFB5EADF02C6B180682B1C20BFDD4C9CD50F71D5AD7042B7B4570903F3AF1CC7970ABCA1CEE20FBF971FFD
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredBodyParameter_action=ActionWithParameterWithBindRequiredAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredBodyParameter_action=ActionWithParameterWithBindRequiredAttribute.DotNet8_0.verified.txt
@@ -1,47 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: true,
-            Content: {
-              application/json: {
-                Schema: {
-                  Type: string,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                }
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
               }
             }
           },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 804D6F0C92F4BE50ED4B40A4DD1F6D3FB0F279B348764AC01ABFD0218A5DE81B9CDA62C18D1345F64751D4FA1CA98298834D12D7AF7799F4845203B45FE40CFE
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredBodyParameter_action=ActionWithParameterWithBindRequiredAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredBodyParameter_action=ActionWithParameterWithBindRequiredAttribute.DotNet9_0.verified.txt
@@ -1,47 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: true,
-            Content: {
-              application/json: {
-                Schema: {
-                  Type: string,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                }
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
               }
             }
           },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 804D6F0C92F4BE50ED4B40A4DD1F6D3FB0F279B348764AC01ABFD0218A5DE81B9CDA62C18D1345F64751D4FA1CA98298834D12D7AF7799F4845203B45FE40CFE
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredBodyParameter_action=ActionWithParameterWithRequiredAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredBodyParameter_action=ActionWithParameterWithRequiredAttribute.DotNet8_0.verified.txt
@@ -1,47 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: true,
-            Content: {
-              application/json: {
-                Schema: {
-                  Type: string,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                }
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
               }
             }
           },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 804D6F0C92F4BE50ED4B40A4DD1F6D3FB0F279B348764AC01ABFD0218A5DE81B9CDA62C18D1345F64751D4FA1CA98298834D12D7AF7799F4845203B45FE40CFE
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredBodyParameter_action=ActionWithParameterWithRequiredAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredBodyParameter_action=ActionWithParameterWithRequiredAttribute.DotNet9_0.verified.txt
@@ -1,47 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: true,
-            Content: {
-              application/json: {
-                Schema: {
-                  Type: string,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                }
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
               }
             }
           },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 804D6F0C92F4BE50ED4B40A4DD1F6D3FB0F279B348764AC01ABFD0218A5DE81B9CDA62C18D1345F64751D4FA1CA98298834D12D7AF7799F4845203B45FE40CFE
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredMember.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredMember.DotNet8_0.verified.txt
@@ -1,52 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Query,
-              Required: true,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: A2DDB9D84BC2303C2E8B82FEE969073D4DCAE3D40331C1ED8376E3F427E46C7CAE5AE2791BC5FE1FFFE026EBE90FC10DE8A0409D9F0B6EBC5DBE6CB294DD6A84
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredMember.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredMember.DotNet9_0.verified.txt
@@ -1,52 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Query,
-              Required: true,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: A2DDB9D84BC2303C2E8B82FEE969073D4DCAE3D40331C1ED8376E3F427E46C7CAE5AE2791BC5FE1FFFE026EBE90FC10DE8A0409D9F0B6EBC5DBE6CB294DD6A84
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredQueryParameter_action=ActionWithParameterWithBindRequiredAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredQueryParameter_action=ActionWithParameterWithBindRequiredAttribute.DotNet8_0.verified.txt
@@ -1,52 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Query,
-              Required: true,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: A2DDB9D84BC2303C2E8B82FEE969073D4DCAE3D40331C1ED8376E3F427E46C7CAE5AE2791BC5FE1FFFE026EBE90FC10DE8A0409D9F0B6EBC5DBE6CB294DD6A84
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredQueryParameter_action=ActionWithParameterWithBindRequiredAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredQueryParameter_action=ActionWithParameterWithBindRequiredAttribute.DotNet9_0.verified.txt
@@ -1,52 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Query,
-              Required: true,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: A2DDB9D84BC2303C2E8B82FEE969073D4DCAE3D40331C1ED8376E3F427E46C7CAE5AE2791BC5FE1FFFE026EBE90FC10DE8A0409D9F0B6EBC5DBE6CB294DD6A84
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredQueryParameter_action=ActionWithParameterWithRequiredAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredQueryParameter_action=ActionWithParameterWithRequiredAttribute.DotNet8_0.verified.txt
@@ -1,52 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Query,
-              Required: true,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: A2DDB9D84BC2303C2E8B82FEE969073D4DCAE3D40331C1ED8376E3F427E46C7CAE5AE2791BC5FE1FFFE026EBE90FC10DE8A0409D9F0B6EBC5DBE6CB294DD6A84
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredQueryParameter_action=ActionWithParameterWithRequiredAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredQueryParameter_action=ActionWithParameterWithRequiredAttribute.DotNet9_0.verified.txt
@@ -1,52 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Query,
-              Required: true,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: A2DDB9D84BC2303C2E8B82FEE969073D4DCAE3D40331C1ED8376E3F427E46C7CAE5AE2791BC5FE1FFFE026EBE90FC10DE8A0409D9F0B6EBC5DBE6CB294DD6A84
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithReturnValueAndSupportedResponseTypes.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithReturnValueAndSupportedResponseTypes.DotNet8_0.verified.txt
@@ -1,56 +1,39 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              Content: {
-                application/json: {
-                  Schema: {
-                    Type: integer,
-                    Format: int32,
-                    ReadOnly: false,
-                    WriteOnly: false,
-                    AdditionalPropertiesAllowed: true,
-                    Nullable: false,
-                    Deprecated: false,
-                    UnresolvedReference: false
-                  }
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
                 }
-              },
-              UnresolvedReference: false
-            },
-            400: {
-              Description: Bad Request,
-              UnresolvedReference: false
-            },
-            422: {
-              Description: Unprocessable Content,
-              UnresolvedReference: false
-            },
-            default: {
-              Description: Error,
-              UnresolvedReference: false
+              }
             }
           },
-          Deprecated: false
+          "400": {
+            "description": "Bad Request"
+          },
+          "422": {
+            "description": "Unprocessable Content"
+          },
+          "default": {
+            "description": "Error"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 49491612C8548E72072C4BF9884EBB4F3B076CB8FA86B0ADA736DD5AA2A7EFBDE1E5E4E2698AD9241CCB5A6AA19E150B7B558356C9F7B4A6027DCC77657B5685
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithReturnValueAndSupportedResponseTypes.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithReturnValueAndSupportedResponseTypes.DotNet9_0.verified.txt
@@ -1,56 +1,39 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              Content: {
-                application/json: {
-                  Schema: {
-                    Type: integer,
-                    Format: int32,
-                    ReadOnly: false,
-                    WriteOnly: false,
-                    AdditionalPropertiesAllowed: true,
-                    Nullable: false,
-                    Deprecated: false,
-                    UnresolvedReference: false
-                  }
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
                 }
-              },
-              UnresolvedReference: false
-            },
-            400: {
-              Description: Bad Request,
-              UnresolvedReference: false
-            },
-            422: {
-              Description: Unprocessable Content,
-              UnresolvedReference: false
-            },
-            default: {
-              Description: Error,
-              UnresolvedReference: false
+              }
             }
           },
-          Deprecated: false
+          "400": {
+            "description": "Bad Request"
+          },
+          "422": {
+            "description": "Unprocessable Content"
+          },
+          "default": {
+            "description": "Error"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 49491612C8548E72072C4BF9884EBB4F3B076CB8FA86B0ADA736DD5AA2A7EFBDE1E5E4E2698AD9241CCB5A6AA19E150B7B558356C9F7B4A6027DCC77657B5685
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRouteNameMetadata.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRouteNameMetadata.DotNet8_0.verified.txt
@@ -1,31 +1,23 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          OperationId: SomeRouteName,
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "operationId": "SomeRouteName",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 8A51577C0837548151E3938DC7033AF6AFDE7FD4E5F6F2FE20CC8931B3D18A883C1FB3FE92120D0A44EC31DDE90DDEDE4A237B3138AD45A37278F8924958D5A7
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRouteNameMetadata.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRouteNameMetadata.DotNet9_0.verified.txt
@@ -1,31 +1,23 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          OperationId: SomeRouteName,
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "operationId": "SomeRouteName",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 8A51577C0837548151E3938DC7033AF6AFDE7FD4E5F6F2FE20CC8931B3D18A883C1FB3FE92120D0A44EC31DDE90DDEDE4A237B3138AD45A37278F8924958D5A7
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithAcceptFromHeaderParameter.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithAcceptFromHeaderParameter.DotNet8_0.verified.txt
@@ -1,52 +1,31 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Get: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "header",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Header,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: E126911C7FB97665966DB7EA833EA70FDF82A779304ECD9B963D5A50C6E0AE51A3180983631720BDCD1BCDA3CAA7E79F0F0042120949EA990884D6188CE77AF1
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithAcceptFromHeaderParameter.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithAcceptFromHeaderParameter.DotNet9_0.verified.txt
@@ -1,52 +1,31 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Get: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "header",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Header,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: E126911C7FB97665966DB7EA833EA70FDF82A779304ECD9B963D5A50C6E0AE51A3180983631720BDCD1BCDA3CAA7E79F0F0042120949EA990884D6188CE77AF1
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithAuthorizationFromHeaderParameter.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithAuthorizationFromHeaderParameter.DotNet8_0.verified.txt
@@ -1,52 +1,31 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Get: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "header",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Header,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: E126911C7FB97665966DB7EA833EA70FDF82A779304ECD9B963D5A50C6E0AE51A3180983631720BDCD1BCDA3CAA7E79F0F0042120949EA990884D6188CE77AF1
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithAuthorizationFromHeaderParameter.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithAuthorizationFromHeaderParameter.DotNet9_0.verified.txt
@@ -1,52 +1,31 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Get: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "header",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Header,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: E126911C7FB97665966DB7EA833EA70FDF82A779304ECD9B963D5A50C6E0AE51A3180983631720BDCD1BCDA3CAA7E79F0F0042120949EA990884D6188CE77AF1
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithContentTypeFromHeaderParameter.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithContentTypeFromHeaderParameter.DotNet8_0.verified.txt
@@ -1,52 +1,31 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Get: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "header",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Header,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: E126911C7FB97665966DB7EA833EA70FDF82A779304ECD9B963D5A50C6E0AE51A3180983631720BDCD1BCDA3CAA7E79F0F0042120949EA990884D6188CE77AF1
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithContentTypeFromHeaderParameter.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithContentTypeFromHeaderParameter.DotNet9_0.verified.txt
@@ -1,52 +1,31 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Get: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "header",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Header,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: E126911C7FB97665966DB7EA833EA70FDF82A779304ECD9B963D5A50C6E0AE51A3180983631720BDCD1BCDA3CAA7E79F0F0042120949EA990884D6188CE77AF1
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiDescriptionsWithMatchingGroupName.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiDescriptionsWithMatchingGroupName.DotNet8_0.verified.txt
@@ -1,45 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Get: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
-        },
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
       },
-      UnresolvedReference: false
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     }
   },
-  Components: {},
-  HashCode: 0F1036F23326E2BD7543491DEC0E03ABCA5BC97AF845BEE30C164155D616F306F6F6E21A77507DA6BE2A85DF1A17B1F07AE23E7608E37C971BAF1CBA2491E899
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiDescriptionsWithMatchingGroupName.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiDescriptionsWithMatchingGroupName.DotNet9_0.verified.txt
@@ -1,45 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Get: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
-        },
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
       },
-      UnresolvedReference: false
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     }
   },
-  Components: {},
-  HashCode: 0F1036F23326E2BD7543491DEC0E03ABCA5BC97AF845BEE30C164155D616F306F6F6E21A77507DA6BE2A85DF1A17B1F07AE23E7608E37C971BAF1CBA2491E899
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterDescriptionForBodyIsRequired.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterDescriptionForBodyIsRequired.DotNet8_0.verified.txt
@@ -1,34 +1,26 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Foo,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: true
-          },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Foo"
+        ],
+        "requestBody": {
+          "content": { },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 19A6400D0649D9875F38AAD5D6902D74BB45BC7435F3C76982D8CC6022ABD2DF08CB9083F22D74D4B915231556A80FA79185EC43D3775D1D46B53BBA970FAB59
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterDescriptionForBodyIsRequired.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterDescriptionForBodyIsRequired.DotNet9_0.verified.txt
@@ -1,34 +1,26 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Foo,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: true
-          },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Foo"
+        ],
+        "requestBody": {
+          "content": { },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 19A6400D0649D9875F38AAD5D6902D74BB45BC7435F3C76982D8CC6022ABD2DF08CB9083F22D74D4B915231556A80FA79185EC43D3775D1D46B53BBA970FAB59
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterHasNoCorrespondingActionParameter.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterHasNoCorrespondingActionParameter.DotNet8_0.verified.txt
@@ -1,52 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Path,
-              Required: true,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 38B7A774F1E494464B7C8CDF5CEBD39D2F2E60726F987D4E54C8C38D7B7FB8EB46AF4D81E8F4A34122ADCEB174E9309FE336E72723AC7578A6E7AE249CEF35A2
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterHasNoCorrespondingActionParameter.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterHasNoCorrespondingActionParameter.DotNet9_0.verified.txt
@@ -1,52 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Path,
-              Required: true,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 38B7A774F1E494464B7C8CDF5CEBD39D2F2E60726F987D4E54C8C38D7B7FB8EB46AF4D81E8F4A34122ADCEB174E9309FE336E72723AC7578A6E7AE249CEF35A2
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterIsBoundToPath.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterIsBoundToPath.DotNet8_0.verified.txt
@@ -1,52 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Path,
-              Required: true,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 38B7A774F1E494464B7C8CDF5CEBD39D2F2E60726F987D4E54C8C38D7B7FB8EB46AF4D81E8F4A34122ADCEB174E9309FE336E72723AC7578A6E7AE249CEF35A2
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterIsBoundToPath.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterIsBoundToPath.DotNet9_0.verified.txt
@@ -1,52 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Path,
-              Required: true,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 38B7A774F1E494464B7C8CDF5CEBD39D2F2E60726F987D4E54C8C38D7B7FB8EB46AF4D81E8F4A34122ADCEB174E9309FE336E72723AC7578A6E7AE249CEF35A2
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreBoundToForm.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreBoundToForm.DotNet8_0.verified.txt
@@ -1,76 +1,48 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              multipart/form-data: {
-                Schema: {
-                  Type: object,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  Properties: {
-                    param1: {
-                      Type: string,
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false
-                    },
-                    param2: {
-                      Type: integer,
-                      Format: int32,
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false
-                    }
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "param1": {
+                    "type": "string"
                   },
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                },
-                Encoding: {
-                  param1: {
-                    Style: Form
-                  },
-                  param2: {
-                    Style: Form
+                  "param2": {
+                    "type": "integer",
+                    "format": "int32"
                   }
+                }
+              },
+              "encoding": {
+                "param1": {
+                  "style": "form"
+                },
+                "param2": {
+                  "style": "form"
                 }
               }
             }
-          },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: CC72B9C2B39FBC08D572E3EC1D511C5CE6706B54BF2DE5B3D381BAC8ABFCA83D8DDDDB402CDC8AD50122D927D56937A1B4F47078D561007DA2EFD4DA82FAF8CF
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreBoundToForm.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreBoundToForm.DotNet9_0.verified.txt
@@ -1,76 +1,48 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              multipart/form-data: {
-                Schema: {
-                  Type: object,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  Properties: {
-                    param1: {
-                      Type: string,
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false
-                    },
-                    param2: {
-                      Type: integer,
-                      Format: int32,
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false
-                    }
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "param1": {
+                    "type": "string"
                   },
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                },
-                Encoding: {
-                  param1: {
-                    Style: Form
-                  },
-                  param2: {
-                    Style: Form
+                  "param2": {
+                    "type": "integer",
+                    "format": "int32"
                   }
+                }
+              },
+              "encoding": {
+                "param1": {
+                  "style": "form"
+                },
+                "param2": {
+                  "style": "form"
                 }
               }
             }
-          },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: CC72B9C2B39FBC08D572E3EC1D511C5CE6706B54BF2DE5B3D381BAC8ABFCA83D8DDDDB402CDC8AD50122D927D56937A1B4F47078D561007DA2EFD4DA82FAF8CF
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Header.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Header.DotNet8_0.verified.txt
@@ -1,52 +1,31 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "header",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Header,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 7B5009B038667AE7A48CBB1ABC73A6971D6453FAA7FBC670A231E82A45223BE46E36B2A10F66D6BC665D2C89EE2A2159EF4CBB45D66220D13291A7B5D1CFBA21
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Header.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Header.DotNet9_0.verified.txt
@@ -1,52 +1,31 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "header",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Header,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 7B5009B038667AE7A48CBB1ABC73A6971D6453FAA7FBC670A231E82A45223BE46E36B2A10F66D6BC665D2C89EE2A2159EF4CBB45D66220D13291A7B5D1CFBA21
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Path.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Path.DotNet8_0.verified.txt
@@ -1,52 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Path,
-              Required: true,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 38B7A774F1E494464B7C8CDF5CEBD39D2F2E60726F987D4E54C8C38D7B7FB8EB46AF4D81E8F4A34122ADCEB174E9309FE336E72723AC7578A6E7AE249CEF35A2
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Path.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Path.DotNet9_0.verified.txt
@@ -1,52 +1,32 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Path,
-              Required: true,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 38B7A774F1E494464B7C8CDF5CEBD39D2F2E60726F987D4E54C8C38D7B7FB8EB46AF4D81E8F4A34122ADCEB174E9309FE336E72723AC7578A6E7AE249CEF35A2
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Query.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Query.DotNet8_0.verified.txt
@@ -1,52 +1,31 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Query,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 58CF9F0306B53D071A6262CED2A4A2D41D0DB9D62C183D00CFF85A74891E812B0AD9E56AF4F9F84E5DE4D0864EF33832BA39E5397CC6E2D2EE560075E91B4FC2
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Query.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Query.DotNet9_0.verified.txt
@@ -1,52 +1,31 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Query,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 58CF9F0306B53D071A6262CED2A4A2D41D0DB9D62C183D00CFF85A74891E812B0AD9E56AF4F9F84E5DE4D0864EF33832BA39E5397CC6E2D2EE560075E91B4FC2
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=null.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=null.DotNet8_0.verified.txt
@@ -1,52 +1,31 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Query,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 58CF9F0306B53D071A6262CED2A4A2D41D0DB9D62C183D00CFF85A74891E812B0AD9E56AF4F9F84E5DE4D0864EF33832BA39E5397CC6E2D2EE560075E91B4FC2
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=null.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=null.DotNet9_0.verified.txt
@@ -1,52 +1,31 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param,
-              In: Query,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 58CF9F0306B53D071A6262CED2A4A2D41D0DB9D62C183D00CFF85A74891E812B0AD9E56AF4F9F84E5DE4D0864EF33832BA39E5397CC6E2D2EE560075E91B4FC2
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ConflictingActionsResolverIsSpecified.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ConflictingActionsResolverIsSpecified.DotNet8_0.verified.txt
@@ -1,30 +1,22 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 0E75218C57C662359EC554B377E7600D033FDF17E191A0E468F1E402807067F96CA4BF92320CC0B13E796E1E39DF7997BCF9A2F00DEF42D6D1AD6F47A7F35666
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ConflictingActionsResolverIsSpecified.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ConflictingActionsResolverIsSpecified.DotNet9_0.verified.txt
@@ -1,30 +1,22 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 0E75218C57C662359EC554B377E7600D033FDF17E191A0E468F1E402807067F96CA4BF92320CC0B13E796E1E39DF7997BCF9A2F00DEF42D6D1AD6F47A7F35666
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasDescriptionAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasDescriptionAttribute.DotNet8_0.verified.txt
@@ -1,31 +1,23 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Description: A Test Description,
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "description": "A Test Description",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 377D7B06298BAF6A0588F14C290399EBDBB413894F0CD99EF1925572243C3E5A5327372612D817C05797EA624236A755956F038D6EE98703FC1B5D50CEF6DA12
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasDescriptionAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasDescriptionAttribute.DotNet9_0.verified.txt
@@ -1,31 +1,23 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Description: A Test Description,
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "description": "A Test Description",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 377D7B06298BAF6A0588F14C290399EBDBB413894F0CD99EF1925572243C3E5A5327372612D817C05797EA624236A755956F038D6EE98703FC1B5D50CEF6DA12
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasSummaryAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasSummaryAttribute.DotNet8_0.verified.txt
@@ -1,31 +1,23 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Summary: A Test Summary,
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "summary": "A Test Summary",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 7FA24A4FA7C42D165A62545BD3562D78996223809931B2053BCD1658D0460D8F72824735CF34E0A5CF73E80E26F219BE05D1CCEB6CB197B29FF72EFB24DE00F5
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasSummaryAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasSummaryAttribute.DotNet9_0.verified.txt
@@ -1,31 +1,23 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Summary: A Test Summary,
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "summary": "A Test Summary",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 7FA24A4FA7C42D165A62545BD3562D78996223809931B2053BCD1658D0460D8F72824735CF34E0A5CF73E80E26F219BE05D1CCEB6CB197B29FF72EFB24DE00F5
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasTags.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasTags.DotNet8_0.verified.txt
@@ -1,38 +1,24 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Some,
-              UnresolvedReference: false
-            },
-            {
-              Name: Tags,
-              UnresolvedReference: false
-            },
-            {
-              Name: Here,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Some",
+          "Tags",
+          "Here"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 6F8975472729E3A264232F09327A9B51A158FC6D0952BFC812CA902D14346E719EDB456AC1247F9020009B8A3A813011BB9CC7E9699A064E91F4A73A32FD7A0D
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasTags.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasTags.DotNet9_0.verified.txt
@@ -1,38 +1,24 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Some,
-              UnresolvedReference: false
-            },
-            {
-              Name: Tags,
-              UnresolvedReference: false
-            },
-            {
-              Name: Here,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Some",
+          "Tags",
+          "Here"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 6F8975472729E3A264232F09327A9B51A158FC6D0952BFC812CA902D14346E719EDB456AC1247F9020009B8A3A813011BB9CC7E9699A064E91F4A73A32FD7A0D
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Copies_Description_From_GeneratedSchema.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Copies_Description_From_GeneratedSchema.DotNet8_0.verified.txt
@@ -1,130 +1,60 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: EnumWithDefault,
-              In: Query,
-              Description: <p>Members:</p><ul><li>Value2 - 2</li><li>Value4 - 4</li><li>Value8 - 8</li></ul>,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false,
-                Reference: {
-                  IsFragrament: false,
-                  Type: Schema,
-                  Id: IntEnum,
-                  IsExternal: false,
-                  IsLocal: true,
-                  ReferenceV3: #/components/schemas/IntEnum,
-                  ReferenceV2: #/definitions/IntEnum
-                }
-              }
-            },
-            {
-              UnresolvedReference: false,
-              Name: EnumArrayWithDefault,
-              In: Query,
-              Description: <p>Members:</p><ul><li>Value2 - 2</li><li>Value4 - 4</li><li>Value8 - 8</li></ul>,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                Type: array,
-                Description: <p>Members:</p><ul><li>Value2 - 2</li><li>Value4 - 4</li><li>Value8 - 8</li></ul>,
-                Default: [
-                  {
-                    Value: 4
-                  }
-                ],
-                ReadOnly: false,
-                WriteOnly: false,
-                Items: {
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false,
-                  Reference: {
-                    IsFragrament: false,
-                    Type: Schema,
-                    Id: IntEnum,
-                    IsExternal: false,
-                    IsLocal: true,
-                    ReferenceV3: #/components/schemas/IntEnum,
-                    ReferenceV2: #/definitions/IntEnum
-                  }
-                },
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "EnumWithDefault",
+            "in": "query",
+            "description": "<p>Members:</p><ul><li>Value2 - 2</li><li>Value4 - 4</li><li>Value8 - 8</li></ul>",
+            "schema": {
+              "$ref": "#/components/schemas/IntEnum"
             }
           },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
-    }
-  },
-  Components: {
-    Schemas: {
-      IntEnum: {
-        Type: integer,
-        Format: int32,
-        Description: <p>Members:</p><ul><li>Value2 - 2</li><li>Value4 - 4</li><li>Value8 - 8</li></ul>,
-        ReadOnly: false,
-        WriteOnly: false,
-        AdditionalPropertiesAllowed: true,
-        Enum: [
           {
-            Value: 2
-          },
-          {
-            Value: 4
-          },
-          {
-            Value: 8
+            "name": "EnumArrayWithDefault",
+            "in": "query",
+            "description": "<p>Members:</p><ul><li>Value2 - 2</li><li>Value4 - 4</li><li>Value8 - 8</li></ul>",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/IntEnum"
+              },
+              "description": "<p>Members:</p><ul><li>Value2 - 2</li><li>Value4 - 4</li><li>Value8 - 8</li></ul>",
+              "default": [
+                4
+              ]
+            }
           }
         ],
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     }
   },
-  HashCode: 29A4A89ADE3B75E921A9EF9CE77F3E1517293B167A0B1513F55C57F3E84194193E8B24F875170DE0524C73CF5AB9DDCDF6556F1BDC2E6EA1F8171340F4C0F0B1
+  "components": {
+    "schemas": {
+      "IntEnum": {
+        "enum": [
+          2,
+          4,
+          8
+        ],
+        "type": "integer",
+        "description": "<p>Members:</p><ul><li>Value2 - 2</li><li>Value4 - 4</li><li>Value8 - 8</li></ul>",
+        "format": "int32"
+      }
+    }
+  }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Copies_Description_From_GeneratedSchema.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Copies_Description_From_GeneratedSchema.DotNet9_0.verified.txt
@@ -1,130 +1,60 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: EnumWithDefault,
-              In: Query,
-              Description: <p>Members:</p><ul><li>Value2 - 2</li><li>Value4 - 4</li><li>Value8 - 8</li></ul>,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false,
-                Reference: {
-                  IsFragrament: false,
-                  Type: Schema,
-                  Id: IntEnum,
-                  IsExternal: false,
-                  IsLocal: true,
-                  ReferenceV3: #/components/schemas/IntEnum,
-                  ReferenceV2: #/definitions/IntEnum
-                }
-              }
-            },
-            {
-              UnresolvedReference: false,
-              Name: EnumArrayWithDefault,
-              In: Query,
-              Description: <p>Members:</p><ul><li>Value2 - 2</li><li>Value4 - 4</li><li>Value8 - 8</li></ul>,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                Type: array,
-                Description: <p>Members:</p><ul><li>Value2 - 2</li><li>Value4 - 4</li><li>Value8 - 8</li></ul>,
-                Default: [
-                  {
-                    Value: 4
-                  }
-                ],
-                ReadOnly: false,
-                WriteOnly: false,
-                Items: {
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false,
-                  Reference: {
-                    IsFragrament: false,
-                    Type: Schema,
-                    Id: IntEnum,
-                    IsExternal: false,
-                    IsLocal: true,
-                    ReferenceV3: #/components/schemas/IntEnum,
-                    ReferenceV2: #/definitions/IntEnum
-                  }
-                },
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "EnumWithDefault",
+            "in": "query",
+            "description": "<p>Members:</p><ul><li>Value2 - 2</li><li>Value4 - 4</li><li>Value8 - 8</li></ul>",
+            "schema": {
+              "$ref": "#/components/schemas/IntEnum"
             }
           },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
-    }
-  },
-  Components: {
-    Schemas: {
-      IntEnum: {
-        Type: integer,
-        Format: int32,
-        Description: <p>Members:</p><ul><li>Value2 - 2</li><li>Value4 - 4</li><li>Value8 - 8</li></ul>,
-        ReadOnly: false,
-        WriteOnly: false,
-        AdditionalPropertiesAllowed: true,
-        Enum: [
           {
-            Value: 2
-          },
-          {
-            Value: 4
-          },
-          {
-            Value: 8
+            "name": "EnumArrayWithDefault",
+            "in": "query",
+            "description": "<p>Members:</p><ul><li>Value2 - 2</li><li>Value4 - 4</li><li>Value8 - 8</li></ul>",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/IntEnum"
+              },
+              "description": "<p>Members:</p><ul><li>Value2 - 2</li><li>Value4 - 4</li><li>Value8 - 8</li></ul>",
+              "default": [
+                4
+              ]
+            }
           }
         ],
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     }
   },
-  HashCode: 29A4A89ADE3B75E921A9EF9CE77F3E1517293B167A0B1513F55C57F3E84194193E8B24F875170DE0524C73CF5AB9DDCDF6556F1BDC2E6EA1F8171340F4C0F0B1
+  "components": {
+    "schemas": {
+      "IntEnum": {
+        "enum": [
+          2,
+          4,
+          8
+        ],
+        "type": "integer",
+        "description": "<p>Members:</p><ul><li>Value2 - 2</li><li>Value4 - 4</li><li>Value8 - 8</li></ul>",
+        "format": "int32"
+      }
+    }
+  }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFile.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFile.DotNet8_0.verified.txt
@@ -1,53 +1,36 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          OperationId: OperationIdSetInMetadata,
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              application/someMediaType: {
-                Schema: {
-                  Type: object,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  Properties: {
-                    param: {
-                      Type: string,
-                      Format: binary,
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false
-                    }
-                  },
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                },
-                Encoding: {
-                  param: {
-                    Style: Form
+  "paths": {
+    "/resource": {
+      "post": {
+        "operationId": "OperationIdSetInMetadata",
+        "requestBody": {
+          "content": {
+            "application/someMediaType": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "param": {
+                    "type": "string",
+                    "format": "binary"
                   }
+                }
+              },
+              "encoding": {
+                "param": {
+                  "style": "form"
                 }
               }
             }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
+          }
+        },
+        "responses": { }
+      }
     }
   },
-  Components: {},
-  HashCode: 7D034A2620C1D85B3AC60194DFA59693F727DE4704B2D02E124FDA37F843426C258EF2BEB84E6B8E8D315E23A4BCBE1F423B479E6CDF8AFFB8514D49B9A3CC9E
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFile.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFile.DotNet9_0.verified.txt
@@ -1,53 +1,36 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          OperationId: OperationIdSetInMetadata,
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              application/someMediaType: {
-                Schema: {
-                  Type: object,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  Properties: {
-                    param: {
-                      Type: string,
-                      Format: binary,
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false
-                    }
-                  },
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                },
-                Encoding: {
-                  param: {
-                    Style: Form
+  "paths": {
+    "/resource": {
+      "post": {
+        "operationId": "OperationIdSetInMetadata",
+        "requestBody": {
+          "content": {
+            "application/someMediaType": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "param": {
+                    "type": "string",
+                    "format": "binary"
                   }
+                }
+              },
+              "encoding": {
+                "param": {
+                  "style": "form"
                 }
               }
             }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
+          }
+        },
+        "responses": { }
+      }
     }
   },
-  Components: {},
-  HashCode: 7D034A2620C1D85B3AC60194DFA59693F727DE4704B2D02E124FDA37F843426C258EF2BEB84E6B8E8D315E23A4BCBE1F423B479E6CDF8AFFB8514D49B9A3CC9E
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFileCollection.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFileCollection.DotNet8_0.verified.txt
@@ -1,62 +1,39 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          OperationId: OperationIdSetInMetadata,
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              application/someMediaType: {
-                Schema: {
-                  Type: object,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  Properties: {
-                    param: {
-                      Type: array,
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      Items: {
-                        Type: string,
-                        Format: binary,
-                        ReadOnly: false,
-                        WriteOnly: false,
-                        AdditionalPropertiesAllowed: true,
-                        Nullable: false,
-                        Deprecated: false,
-                        UnresolvedReference: false
-                      },
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "operationId": "OperationIdSetInMetadata",
+        "requestBody": {
+          "content": {
+            "application/someMediaType": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "param": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
                     }
-                  },
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                },
-                Encoding: {
-                  param: {
-                    Style: Form
                   }
+                }
+              },
+              "encoding": {
+                "param": {
+                  "style": "form"
                 }
               }
             }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
+          }
+        },
+        "responses": { }
+      }
     }
   },
-  Components: {},
-  HashCode: 073D8B8E67D5100DD8AF06EC69A3C02B8DBF29E46621ED6EB590DEA519F2C8941398F6B95292D891CC4E18C2F4D5D38A8F904545CFFC219E4FF4613AD605E5A5
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFileCollection.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFileCollection.DotNet9_0.verified.txt
@@ -1,62 +1,39 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          OperationId: OperationIdSetInMetadata,
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              application/someMediaType: {
-                Schema: {
-                  Type: object,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  Properties: {
-                    param: {
-                      Type: array,
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      Items: {
-                        Type: string,
-                        Format: binary,
-                        ReadOnly: false,
-                        WriteOnly: false,
-                        AdditionalPropertiesAllowed: true,
-                        Nullable: false,
-                        Deprecated: false,
-                        UnresolvedReference: false
-                      },
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "operationId": "OperationIdSetInMetadata",
+        "requestBody": {
+          "content": {
+            "application/someMediaType": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "param": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
                     }
-                  },
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                },
-                Encoding: {
-                  param: {
-                    Style: Form
                   }
+                }
+              },
+              "encoding": {
+                "param": {
+                  "style": "form"
                 }
               }
             }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
+          }
+        },
+        "responses": { }
+      }
     }
   },
-  Components: {},
-  HashCode: 073D8B8E67D5100DD8AF06EC69A3C02B8DBF29E46621ED6EB590DEA519F2C8941398F6B95292D891CC4E18C2F4D5D38A8F904545CFFC219E4FF4613AD605E5A5
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithSeveralFromForms.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithSeveralFromForms.DotNet8_0.verified.txt
@@ -1,174 +1,73 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          OperationId: OperationIdSetInMetadata,
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              application/someMediaType: {
-                Schema: {
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  AllOf: [
-                    {
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false,
-                      Reference: {
-                        IsFragrament: false,
-                        Type: Schema,
-                        Id: TestDto,
-                        IsExternal: false,
-                        IsLocal: true,
-                        ReferenceV3: #/components/schemas/TestDto,
-                        ReferenceV2: #/definitions/TestDto
-                      }
-                    },
-                    {
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false,
-                      Reference: {
-                        IsFragrament: false,
-                        Type: Schema,
-                        Id: TypeWithDefaultAttributeOnEnum,
-                        IsExternal: false,
-                        IsLocal: true,
-                        ReferenceV3: #/components/schemas/TypeWithDefaultAttributeOnEnum,
-                        ReferenceV2: #/definitions/TypeWithDefaultAttributeOnEnum
-                      }
-                    }
-                  ],
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                }
+  "paths": {
+    "/resource": {
+      "post": {
+        "operationId": "OperationIdSetInMetadata",
+        "requestBody": {
+          "content": {
+            "application/someMediaType": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TestDto"
+                  },
+                  {
+                    "$ref": "#/components/schemas/TypeWithDefaultAttributeOnEnum"
+                  }
+                ]
               }
-            }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
-    }
-  },
-  Components: {
-    Schemas: {
-      IntEnum: {
-        Type: integer,
-        Format: int32,
-        ReadOnly: false,
-        WriteOnly: false,
-        AdditionalPropertiesAllowed: true,
-        Enum: [
-          {
-            Value: 2
-          },
-          {
-            Value: 4
-          },
-          {
-            Value: 8
-          }
-        ],
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
-      },
-      TestDto: {
-        Type: object,
-        ReadOnly: false,
-        WriteOnly: false,
-        Properties: {
-          Prop1: {
-            Type: string,
-            ReadOnly: false,
-            WriteOnly: false,
-            AdditionalPropertiesAllowed: true,
-            Nullable: true,
-            Deprecated: false,
-            UnresolvedReference: false
-          }
-        },
-        AdditionalPropertiesAllowed: false,
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
-      },
-      TypeWithDefaultAttributeOnEnum: {
-        Type: object,
-        ReadOnly: false,
-        WriteOnly: false,
-        Properties: {
-          EnumArrayWithDefault: {
-            Type: array,
-            Default: [
-              {
-                Value: 4
-              }
-            ],
-            ReadOnly: false,
-            WriteOnly: false,
-            Items: {
-              ReadOnly: false,
-              WriteOnly: false,
-              AdditionalPropertiesAllowed: true,
-              Nullable: false,
-              Deprecated: false,
-              UnresolvedReference: false,
-              Reference: {
-                IsFragrament: false,
-                Type: Schema,
-                Id: IntEnum,
-                IsExternal: false,
-                IsLocal: true,
-                ReferenceV3: #/components/schemas/IntEnum,
-                ReferenceV2: #/definitions/IntEnum
-              }
-            },
-            AdditionalPropertiesAllowed: true,
-            Nullable: true,
-            Deprecated: false,
-            UnresolvedReference: false
-          },
-          EnumWithDefault: {
-            ReadOnly: false,
-            WriteOnly: false,
-            AdditionalPropertiesAllowed: true,
-            Nullable: false,
-            Deprecated: false,
-            UnresolvedReference: false,
-            Reference: {
-              IsFragrament: false,
-              Type: Schema,
-              Id: IntEnum,
-              IsExternal: false,
-              IsLocal: true,
-              ReferenceV3: #/components/schemas/IntEnum,
-              ReferenceV2: #/definitions/IntEnum
             }
           }
         },
-        AdditionalPropertiesAllowed: false,
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
+        "responses": { }
       }
     }
   },
-  HashCode: 41D7DF10C7C0CE16E982FDA61A24E00E80C545544532DDE161A3189D46D8B3F2FD312173BC4F903FA4F3D695D66A00CEF815217B8B865479D45961D02D3B8609
+  "components": {
+    "schemas": {
+      "IntEnum": {
+        "enum": [
+          2,
+          4,
+          8
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "TestDto": {
+        "type": "object",
+        "properties": {
+          "Prop1": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TypeWithDefaultAttributeOnEnum": {
+        "type": "object",
+        "properties": {
+          "EnumWithDefault": {
+            "$ref": "#/components/schemas/IntEnum"
+          },
+          "EnumArrayWithDefault": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IntEnum"
+            },
+            "default": [
+              4
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithSeveralFromForms.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithSeveralFromForms.DotNet9_0.verified.txt
@@ -1,174 +1,73 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          OperationId: OperationIdSetInMetadata,
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              application/someMediaType: {
-                Schema: {
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  AllOf: [
-                    {
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false,
-                      Reference: {
-                        IsFragrament: false,
-                        Type: Schema,
-                        Id: TestDto,
-                        IsExternal: false,
-                        IsLocal: true,
-                        ReferenceV3: #/components/schemas/TestDto,
-                        ReferenceV2: #/definitions/TestDto
-                      }
-                    },
-                    {
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false,
-                      Reference: {
-                        IsFragrament: false,
-                        Type: Schema,
-                        Id: TypeWithDefaultAttributeOnEnum,
-                        IsExternal: false,
-                        IsLocal: true,
-                        ReferenceV3: #/components/schemas/TypeWithDefaultAttributeOnEnum,
-                        ReferenceV2: #/definitions/TypeWithDefaultAttributeOnEnum
-                      }
-                    }
-                  ],
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                }
+  "paths": {
+    "/resource": {
+      "post": {
+        "operationId": "OperationIdSetInMetadata",
+        "requestBody": {
+          "content": {
+            "application/someMediaType": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TestDto"
+                  },
+                  {
+                    "$ref": "#/components/schemas/TypeWithDefaultAttributeOnEnum"
+                  }
+                ]
               }
-            }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
-    }
-  },
-  Components: {
-    Schemas: {
-      IntEnum: {
-        Type: integer,
-        Format: int32,
-        ReadOnly: false,
-        WriteOnly: false,
-        AdditionalPropertiesAllowed: true,
-        Enum: [
-          {
-            Value: 2
-          },
-          {
-            Value: 4
-          },
-          {
-            Value: 8
-          }
-        ],
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
-      },
-      TestDto: {
-        Type: object,
-        ReadOnly: false,
-        WriteOnly: false,
-        Properties: {
-          Prop1: {
-            Type: string,
-            ReadOnly: false,
-            WriteOnly: false,
-            AdditionalPropertiesAllowed: true,
-            Nullable: true,
-            Deprecated: false,
-            UnresolvedReference: false
-          }
-        },
-        AdditionalPropertiesAllowed: false,
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
-      },
-      TypeWithDefaultAttributeOnEnum: {
-        Type: object,
-        ReadOnly: false,
-        WriteOnly: false,
-        Properties: {
-          EnumArrayWithDefault: {
-            Type: array,
-            Default: [
-              {
-                Value: 4
-              }
-            ],
-            ReadOnly: false,
-            WriteOnly: false,
-            Items: {
-              ReadOnly: false,
-              WriteOnly: false,
-              AdditionalPropertiesAllowed: true,
-              Nullable: false,
-              Deprecated: false,
-              UnresolvedReference: false,
-              Reference: {
-                IsFragrament: false,
-                Type: Schema,
-                Id: IntEnum,
-                IsExternal: false,
-                IsLocal: true,
-                ReferenceV3: #/components/schemas/IntEnum,
-                ReferenceV2: #/definitions/IntEnum
-              }
-            },
-            AdditionalPropertiesAllowed: true,
-            Nullable: true,
-            Deprecated: false,
-            UnresolvedReference: false
-          },
-          EnumWithDefault: {
-            ReadOnly: false,
-            WriteOnly: false,
-            AdditionalPropertiesAllowed: true,
-            Nullable: false,
-            Deprecated: false,
-            UnresolvedReference: false,
-            Reference: {
-              IsFragrament: false,
-              Type: Schema,
-              Id: IntEnum,
-              IsExternal: false,
-              IsLocal: true,
-              ReferenceV3: #/components/schemas/IntEnum,
-              ReferenceV2: #/definitions/IntEnum
             }
           }
         },
-        AdditionalPropertiesAllowed: false,
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
+        "responses": { }
       }
     }
   },
-  HashCode: 41D7DF10C7C0CE16E982FDA61A24E00E80C545544532DDE161A3189D46D8B3F2FD312173BC4F903FA4F3D695D66A00CEF815217B8B865479D45961D02D3B8609
+  "components": {
+    "schemas": {
+      "IntEnum": {
+        "enum": [
+          2,
+          4,
+          8
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "TestDto": {
+        "type": "object",
+        "properties": {
+          "Prop1": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TypeWithDefaultAttributeOnEnum": {
+        "type": "object",
+        "properties": {
+          "EnumWithDefault": {
+            "$ref": "#/components/schemas/IntEnum"
+          },
+          "EnumArrayWithDefault": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IntEnum"
+            },
+            "default": [
+              4
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithStringFromForm.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithStringFromForm.DotNet8_0.verified.txt
@@ -1,52 +1,35 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          OperationId: OperationIdSetInMetadata,
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              application/someMediaType: {
-                Schema: {
-                  Type: object,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  Properties: {
-                    param: {
-                      Type: string,
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false
-                    }
-                  },
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                },
-                Encoding: {
-                  param: {
-                    Style: Form
+  "paths": {
+    "/resource": {
+      "post": {
+        "operationId": "OperationIdSetInMetadata",
+        "requestBody": {
+          "content": {
+            "application/someMediaType": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "param": {
+                    "type": "string"
                   }
+                }
+              },
+              "encoding": {
+                "param": {
+                  "style": "form"
                 }
               }
             }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
+          }
+        },
+        "responses": { }
+      }
     }
   },
-  Components: {},
-  HashCode: 7639B8A665AFC72F5C8D9ED02AA2E6416B9F82FDCC86D490FD248D3B657355F3993BD00384468E8D23DC0AC9FACECD425824F9596F6183EBDF974B9343CEDCF7
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithStringFromForm.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithStringFromForm.DotNet9_0.verified.txt
@@ -1,52 +1,35 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          OperationId: OperationIdSetInMetadata,
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              application/someMediaType: {
-                Schema: {
-                  Type: object,
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  Properties: {
-                    param: {
-                      Type: string,
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false
-                    }
-                  },
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                },
-                Encoding: {
-                  param: {
-                    Style: Form
+  "paths": {
+    "/resource": {
+      "post": {
+        "operationId": "OperationIdSetInMetadata",
+        "requestBody": {
+          "content": {
+            "application/someMediaType": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "param": {
+                    "type": "string"
                   }
+                }
+              },
+              "encoding": {
+                "param": {
+                  "style": "form"
                 }
               }
             }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
+          }
+        },
+        "responses": { }
+      }
     }
   },
-  Components: {},
-  HashCode: 7639B8A665AFC72F5C8D9ED02AA2E6416B9F82FDCC86D490FD248D3B657355F3993BD00384468E8D23DC0AC9FACECD425824F9596F6183EBDF974B9343CEDCF7
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject.DotNet8_0.verified.txt
@@ -1,78 +1,44 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              multipart/form-data: {
-                Schema: {
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false,
-                  Reference: {
-                    IsFragrament: false,
-                    Type: Schema,
-                    Id: SwaggerIngoreAnnotatedType,
-                    IsExternal: false,
-                    IsLocal: true,
-                    ReferenceV3: #/components/schemas/SwaggerIngoreAnnotatedType,
-                    ReferenceV2: #/definitions/SwaggerIngoreAnnotatedType
-                  }
-                }
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/SwaggerIngoreAnnotatedType"
               }
             }
-          },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
-    }
-  },
-  Components: {
-    Schemas: {
-      SwaggerIngoreAnnotatedType: {
-        Type: object,
-        ReadOnly: false,
-        WriteOnly: false,
-        Properties: {
-          NotIgnoredString: {
-            Type: string,
-            ReadOnly: false,
-            WriteOnly: false,
-            AdditionalPropertiesAllowed: true,
-            Nullable: true,
-            Deprecated: false,
-            UnresolvedReference: false
           }
         },
-        AdditionalPropertiesAllowed: false,
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     }
   },
-  HashCode: 0E2C58414C7ED713D3719C648D84DD5BD89DA32B914B93EB79C850258F556DDBB26E7B3CE9D60B6FFC5F288B4A255E3A9B947C7CD3F5ED921B2416BB9F155882
+  "components": {
+    "schemas": {
+      "SwaggerIngoreAnnotatedType": {
+        "type": "object",
+        "properties": {
+          "NotIgnoredString": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject.DotNet9_0.verified.txt
@@ -1,78 +1,44 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              multipart/form-data: {
-                Schema: {
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false,
-                  Reference: {
-                    IsFragrament: false,
-                    Type: Schema,
-                    Id: SwaggerIngoreAnnotatedType,
-                    IsExternal: false,
-                    IsLocal: true,
-                    ReferenceV3: #/components/schemas/SwaggerIngoreAnnotatedType,
-                    ReferenceV2: #/definitions/SwaggerIngoreAnnotatedType
-                  }
-                }
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/SwaggerIngoreAnnotatedType"
               }
             }
-          },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
-    }
-  },
-  Components: {
-    Schemas: {
-      SwaggerIngoreAnnotatedType: {
-        Type: object,
-        ReadOnly: false,
-        WriteOnly: false,
-        Properties: {
-          NotIgnoredString: {
-            Type: string,
-            ReadOnly: false,
-            WriteOnly: false,
-            AdditionalPropertiesAllowed: true,
-            Nullable: true,
-            Deprecated: false,
-            UnresolvedReference: false
           }
         },
-        AdditionalPropertiesAllowed: false,
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     }
   },
-  HashCode: 0E2C58414C7ED713D3719C648D84DD5BD89DA32B914B93EB79C850258F556DDBB26E7B3CE9D60B6FFC5F288B4A255E3A9B947C7CD3F5ED921B2416BB9F155882
+  "components": {
+    "schemas": {
+      "SwaggerIngoreAnnotatedType": {
+        "type": "object",
+        "properties": {
+          "NotIgnoredString": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject_AndString.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject_AndString.DotNet8_0.verified.txt
@@ -1,113 +1,61 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              multipart/form-data: {
-                Schema: {
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  AllOf: [
-                    {
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false,
-                      Reference: {
-                        IsFragrament: false,
-                        Type: Schema,
-                        Id: SwaggerIngoreAnnotatedType,
-                        IsExternal: false,
-                        IsLocal: true,
-                        ReferenceV3: #/components/schemas/SwaggerIngoreAnnotatedType,
-                        ReferenceV2: #/definitions/SwaggerIngoreAnnotatedType
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SwaggerIngoreAnnotatedType"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "param2": {
+                        "type": "string"
                       }
-                    },
-                    {
-                      Type: object,
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      Properties: {
-                        param2: {
-                          Type: string,
-                          ReadOnly: false,
-                          WriteOnly: false,
-                          AdditionalPropertiesAllowed: true,
-                          Nullable: false,
-                          Deprecated: false,
-                          UnresolvedReference: false
-                        }
-                      },
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false
                     }
-                  ],
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                },
-                Encoding: {
-                  param2: {
-                    Style: Form
                   }
+                ]
+              },
+              "encoding": {
+                "param2": {
+                  "style": "form"
                 }
               }
             }
-          },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
-    }
-  },
-  Components: {
-    Schemas: {
-      SwaggerIngoreAnnotatedType: {
-        Type: object,
-        ReadOnly: false,
-        WriteOnly: false,
-        Properties: {
-          NotIgnoredString: {
-            Type: string,
-            ReadOnly: false,
-            WriteOnly: false,
-            AdditionalPropertiesAllowed: true,
-            Nullable: true,
-            Deprecated: false,
-            UnresolvedReference: false
           }
         },
-        AdditionalPropertiesAllowed: false,
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     }
   },
-  HashCode: 7E7750D2523B09ED937BC8BD153C28310201A9806AA769317BC100C6D938DCB55AA32E2290EB9A7563A8907012DB9BA0FA3035FE63823769A229BD27AFE98FA6
+  "components": {
+    "schemas": {
+      "SwaggerIngoreAnnotatedType": {
+        "type": "object",
+        "properties": {
+          "NotIgnoredString": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject_AndString.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject_AndString.DotNet9_0.verified.txt
@@ -1,113 +1,61 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          RequestBody: {
-            UnresolvedReference: false,
-            Required: false,
-            Content: {
-              multipart/form-data: {
-                Schema: {
-                  ReadOnly: false,
-                  WriteOnly: false,
-                  AllOf: [
-                    {
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false,
-                      Reference: {
-                        IsFragrament: false,
-                        Type: Schema,
-                        Id: SwaggerIngoreAnnotatedType,
-                        IsExternal: false,
-                        IsLocal: true,
-                        ReferenceV3: #/components/schemas/SwaggerIngoreAnnotatedType,
-                        ReferenceV2: #/definitions/SwaggerIngoreAnnotatedType
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SwaggerIngoreAnnotatedType"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "param2": {
+                        "type": "string"
                       }
-                    },
-                    {
-                      Type: object,
-                      ReadOnly: false,
-                      WriteOnly: false,
-                      Properties: {
-                        param2: {
-                          Type: string,
-                          ReadOnly: false,
-                          WriteOnly: false,
-                          AdditionalPropertiesAllowed: true,
-                          Nullable: false,
-                          Deprecated: false,
-                          UnresolvedReference: false
-                        }
-                      },
-                      AdditionalPropertiesAllowed: true,
-                      Nullable: false,
-                      Deprecated: false,
-                      UnresolvedReference: false
                     }
-                  ],
-                  AdditionalPropertiesAllowed: true,
-                  Nullable: false,
-                  Deprecated: false,
-                  UnresolvedReference: false
-                },
-                Encoding: {
-                  param2: {
-                    Style: Form
                   }
+                ]
+              },
+              "encoding": {
+                "param2": {
+                  "style": "form"
                 }
               }
             }
-          },
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
-    }
-  },
-  Components: {
-    Schemas: {
-      SwaggerIngoreAnnotatedType: {
-        Type: object,
-        ReadOnly: false,
-        WriteOnly: false,
-        Properties: {
-          NotIgnoredString: {
-            Type: string,
-            ReadOnly: false,
-            WriteOnly: false,
-            AdditionalPropertiesAllowed: true,
-            Nullable: true,
-            Deprecated: false,
-            UnresolvedReference: false
           }
         },
-        AdditionalPropertiesAllowed: false,
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     }
   },
-  HashCode: 7E7750D2523B09ED937BC8BD153C28310201A9806AA769317BC100C6D938DCB55AA32E2290EB9A7563A8907012DB9BA0FA3035FE63823769A229BD27AFE98FA6
+  "components": {
+    "schemas": {
+      "SwaggerIngoreAnnotatedType": {
+        "type": "object",
+        "properties": {
+          "NotIgnoredString": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_TypeIsEnum_AndModelMetadataTypeIsString.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_TypeIsEnum_AndModelMetadataTypeIsString.DotNet8_0.verified.txt
@@ -1,84 +1,43 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param1,
-              In: Query,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false,
-                Reference: {
-                  IsFragrament: false,
-                  Type: Schema,
-                  Id: IntEnum,
-                  IsExternal: false,
-                  IsLocal: true,
-                  ReferenceV3: #/components/schemas/IntEnum,
-                  ReferenceV2: #/definitions/IntEnum
-                }
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
-    }
-  },
-  Components: {
-    Schemas: {
-      IntEnum: {
-        Type: integer,
-        Format: int32,
-        ReadOnly: false,
-        WriteOnly: false,
-        AdditionalPropertiesAllowed: true,
-        Enum: [
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
           {
-            Value: 2
-          },
-          {
-            Value: 4
-          },
-          {
-            Value: 8
+            "name": "param1",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/IntEnum"
+            }
           }
         ],
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     }
   },
-  HashCode: F2B8FE01A8D273C628EBD9F65C7F1E80622E3C5CBBB8F150E247A34C4558F617F1D056F7B1113ABE978F9E433A9FBCA1C65A6387FB918AF00AFB54E6F5A47C5D
+  "components": {
+    "schemas": {
+      "IntEnum": {
+        "enum": [
+          2,
+          4,
+          8
+        ],
+        "type": "integer",
+        "format": "int32"
+      }
+    }
+  }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_TypeIsEnum_AndModelMetadataTypeIsString.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_TypeIsEnum_AndModelMetadataTypeIsString.DotNet9_0.verified.txt
@@ -1,84 +1,43 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: param1,
-              In: Query,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Form,
-              Explode: true,
-              AllowReserved: false,
-              Schema: {
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false,
-                Reference: {
-                  IsFragrament: false,
-                  Type: Schema,
-                  Id: IntEnum,
-                  IsExternal: false,
-                  IsLocal: true,
-                  ReferenceV3: #/components/schemas/IntEnum,
-                  ReferenceV2: #/definitions/IntEnum
-                }
-              }
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
-    }
-  },
-  Components: {
-    Schemas: {
-      IntEnum: {
-        Type: integer,
-        Format: int32,
-        ReadOnly: false,
-        WriteOnly: false,
-        AdditionalPropertiesAllowed: true,
-        Enum: [
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
           {
-            Value: 2
-          },
-          {
-            Value: 4
-          },
-          {
-            Value: 8
+            "name": "param1",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/IntEnum"
+            }
           }
         ],
-        Nullable: false,
-        Deprecated: false,
-        UnresolvedReference: false
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     }
   },
-  HashCode: F2B8FE01A8D273C628EBD9F65C7F1E80622E3C5CBBB8F150E247A34C4558F617F1D056F7B1113ABE978F9E433A9FBCA1C65A6387FB918AF00AFB54E6F5A47C5D
+  "components": {
+    "schemas": {
+      "IntEnum": {
+        "enum": [
+          2,
+          4,
+          8
+        ],
+        "type": "integer",
+        "format": "int32"
+      }
+    }
+  }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithAcceptFromHeaderParameter.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithAcceptFromHeaderParameter.DotNet8_0.verified.txt
@@ -1,50 +1,27 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Get: {
-          OperationId: OperationIdSetInMetadata,
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: accept,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false
-            },
-            {
-              UnresolvedReference: false,
-              Name: param,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
+  "paths": {
+    "/resource": {
+      "get": {
+        "operationId": "OperationIdSetInMetadata",
+        "parameters": [
+          {
+            "name": "accept"
+          },
+          {
+            "name": "param",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
+          }
+        ],
+        "responses": { }
+      }
     }
   },
-  Components: {},
-  HashCode: 48AB134AF00E0ED90AEA7E4E5BADDD7218AB02E7956DD5FAE3C500F4324F14066B32F2EF85E9C52A68431858FED77604C3ABE6CAED518CCB8EC46D22DF63A3DF
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithAcceptFromHeaderParameter.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithAcceptFromHeaderParameter.DotNet9_0.verified.txt
@@ -1,50 +1,27 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Get: {
-          OperationId: OperationIdSetInMetadata,
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: accept,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false
-            },
-            {
-              UnresolvedReference: false,
-              Name: param,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
+  "paths": {
+    "/resource": {
+      "get": {
+        "operationId": "OperationIdSetInMetadata",
+        "parameters": [
+          {
+            "name": "accept"
+          },
+          {
+            "name": "param",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
+          }
+        ],
+        "responses": { }
+      }
     }
   },
-  Components: {},
-  HashCode: 48AB134AF00E0ED90AEA7E4E5BADDD7218AB02E7956DD5FAE3C500F4324F14066B32F2EF85E9C52A68431858FED77604C3ABE6CAED518CCB8EC46D22DF63A3DF
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithAuthorizationFromHeaderParameter.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithAuthorizationFromHeaderParameter.DotNet8_0.verified.txt
@@ -1,50 +1,27 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Get: {
-          OperationId: OperationIdSetInMetadata,
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: authorization,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false
-            },
-            {
-              UnresolvedReference: false,
-              Name: param,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
+  "paths": {
+    "/resource": {
+      "get": {
+        "operationId": "OperationIdSetInMetadata",
+        "parameters": [
+          {
+            "name": "authorization"
+          },
+          {
+            "name": "param",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
+          }
+        ],
+        "responses": { }
+      }
     }
   },
-  Components: {},
-  HashCode: 7B61DF19EC4750E8986D14FA33D86546B51021EA5782C80735BD0BE7A8937AB7CF57D19DDB31BAF396652C20AE904404BAF7116B4C6678720293B513806412ED
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithAuthorizationFromHeaderParameter.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithAuthorizationFromHeaderParameter.DotNet9_0.verified.txt
@@ -1,50 +1,27 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Get: {
-          OperationId: OperationIdSetInMetadata,
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: authorization,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false
-            },
-            {
-              UnresolvedReference: false,
-              Name: param,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
+  "paths": {
+    "/resource": {
+      "get": {
+        "operationId": "OperationIdSetInMetadata",
+        "parameters": [
+          {
+            "name": "authorization"
+          },
+          {
+            "name": "param",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
+          }
+        ],
+        "responses": { }
+      }
     }
   },
-  Components: {},
-  HashCode: 7B61DF19EC4750E8986D14FA33D86546B51021EA5782C80735BD0BE7A8937AB7CF57D19DDB31BAF396652C20AE904404BAF7116B4C6678720293B513806412ED
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithContentTypeFromHeaderParameter.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithContentTypeFromHeaderParameter.DotNet8_0.verified.txt
@@ -1,50 +1,27 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Get: {
-          OperationId: OperationIdSetInMetadata,
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: Content-Type,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false
-            },
-            {
-              UnresolvedReference: false,
-              Name: param,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
+  "paths": {
+    "/resource": {
+      "get": {
+        "operationId": "OperationIdSetInMetadata",
+        "parameters": [
+          {
+            "name": "Content-Type"
+          },
+          {
+            "name": "param",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
+          }
+        ],
+        "responses": { }
+      }
     }
   },
-  Components: {},
-  HashCode: F6CB61AEE648F54EC5BBCD1801BF8194997A0D5B99DDCFC0AF71CEDF79888B58EC1798313ECD4181CBAA61F377A80199CDB82412B744E9EF115F247F8A4A18EC
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithContentTypeFromHeaderParameter.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithContentTypeFromHeaderParameter.DotNet9_0.verified.txt
@@ -1,50 +1,27 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Get: {
-          OperationId: OperationIdSetInMetadata,
-          Parameters: [
-            {
-              UnresolvedReference: false,
-              Name: Content-Type,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false
-            },
-            {
-              UnresolvedReference: false,
-              Name: param,
-              Required: false,
-              Deprecated: false,
-              AllowEmptyValue: false,
-              Style: Simple,
-              Explode: false,
-              AllowReserved: false,
-              Schema: {
-                Type: string,
-                ReadOnly: false,
-                WriteOnly: false,
-                AdditionalPropertiesAllowed: true,
-                Nullable: false,
-                Deprecated: false,
-                UnresolvedReference: false
-              }
+  "paths": {
+    "/resource": {
+      "get": {
+        "operationId": "OperationIdSetInMetadata",
+        "parameters": [
+          {
+            "name": "Content-Type"
+          },
+          {
+            "name": "param",
+            "schema": {
+              "type": "string"
             }
-          ],
-          Deprecated: false
-        }
-      },
-      UnresolvedReference: false
+          }
+        ],
+        "responses": { }
+      }
     }
   },
-  Components: {},
-  HashCode: F6CB61AEE648F54EC5BBCD1801BF8194997A0D5B99DDCFC0AF71CEDF79888B58EC1798313ECD4181CBAA61F377A80199CDB82412B744E9EF115F247F8A4A18EC
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.OperationHasSwaggerIgnoreAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.OperationHasSwaggerIgnoreAttribute.DotNet8_0.verified.txt
@@ -1,8 +1,9 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Components: {},
-  HashCode: 862B7E551B2E991D5F9B640090999C8D4EA20752DC6C69FC82E176A30B2039344A80321E469E806BD3AEA3641DAD6DEE970423561F262A187C04F58915996596
+  "paths": { },
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.OperationHasSwaggerIgnoreAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.OperationHasSwaggerIgnoreAttribute.DotNet9_0.verified.txt
@@ -1,8 +1,9 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Components: {},
-  HashCode: 862B7E551B2E991D5F9B640090999C8D4EA20752DC6C69FC82E176A30B2039344A80321E469E806BD3AEA3641DAD6DEE970423561F262A187C04F58915996596
+  "paths": { },
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.SortKeySelectorIsSpecified.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.SortKeySelectorIsSpecified.DotNet8_0.verified.txt
@@ -1,70 +1,46 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource1: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource1": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     },
-    /resource2: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+    "/resource2": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     },
-    /resource3: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+    "/resource3": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 6A7EE4850A3B6C88EFE631633A4697175A2BD849DD792CC4F3182CBE0F1480315A7C7BDEE0EA3243913A2D1632B10B91554A10C017B345B76018EBF3A2AF774B
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.SortKeySelectorIsSpecified.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.SortKeySelectorIsSpecified.DotNet9_0.verified.txt
@@ -1,70 +1,46 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource1: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource1": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     },
-    /resource2: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+    "/resource2": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     },
-    /resource3: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: Fake,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+    "/resource3": {
+      "post": {
+        "tags": [
+          "Fake"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 6A7EE4850A3B6C88EFE631633A4697175A2BD849DD792CC4F3182CBE0F1480315A7C7BDEE0EA3243913A2D1632B10B91554A10C017B345B76018EBF3A2AF774B
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.TagSelectorIsSpecified.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.TagSelectorIsSpecified.DotNet8_0.verified.txt
@@ -1,30 +1,22 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: resource,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "resource"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 69CCB42286A25F56E56EAA7871BD9DA98131363AC8B40108CAE81CC37239B4120053F46BCE3E442D28004982C097C4712D8646DE2B588BBFCA085557BC0488F7
+  "components": { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.TagSelectorIsSpecified.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.TagSelectorIsSpecified.DotNet9_0.verified.txt
@@ -1,30 +1,22 @@
 ﻿{
-  Info: {
-    Title: Test API,
-    Version: V1
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
   },
-  Paths: {
-    /resource: {
-      Operations: {
-        Post: {
-          Tags: [
-            {
-              Name: resource,
-              UnresolvedReference: false
-            }
-          ],
-          Responses: {
-            200: {
-              Description: OK,
-              UnresolvedReference: false
-            }
-          },
-          Deprecated: false
+  "paths": {
+    "/resource": {
+      "post": {
+        "tags": [
+          "resource"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
         }
-      },
-      UnresolvedReference: false
+      }
     }
   },
-  Components: {},
-  HashCode: 69CCB42286A25F56E56EAA7871BD9DA98131363AC8B40108CAE81CC37239B4120053F46BCE3E442D28004982C097C4712D8646DE2B588BBFCA085557BC0488F7
+  "components": { }
 }


### PR DESCRIPTION
Serialize the document before snapshotting to avoid test failures caused by internal refactoring in Microsoft.OpenApi ahead of v2.
