### PR TITLE
Bump NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,23 +6,23 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="IdentityServer4" Version="3.1.4" />
     <PackageVersion Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.1.0" />
+    <PackageVersion Include="Microsoft.AspNetCore" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.32" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Routing" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Razor.Design" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Routing" Version="2.3.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.StaticFiles" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="6.0.32" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="1.6.22" />
-    <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.22" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="1.6.23" />
+    <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.23" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />

--- a/src/Swashbuckle.AspNetCore.ApiTesting/Swashbuckle.AspNetCore.ApiTesting.csproj
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/Swashbuckle.AspNetCore.ApiTesting.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="2.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="2.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerIntegrationTests.cs
@@ -98,7 +98,7 @@ namespace Swashbuckle.AspNetCore.IntegrationTests
         }
 
         [Theory]
-        [InlineData("/swagger/v1/swagger.json", "openapi", "3.0.1")]
+        [InlineData("/swagger/v1/swagger.json", "openapi", "3.0.4")]
         [InlineData("/swagger/v1/swaggerv2.json", "swagger", "2.0")]
         public async Task SwaggerMiddleware_CanBeConfiguredMultipleTimes(
             string swaggerUrl,

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_ForAutofaq.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_ForAutofaq.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "CliExampleWithFactory",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_ForAutofaq.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_ForAutofaq.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "CliExampleWithFactory",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API V1",
     "description": "A sample API for testing Swashbuckle",

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API V1",
     "description": "A sample API for testing Swashbuckle",

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=CliExample.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=CliExample.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "CliExample",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=CliExample.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=CliExample.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "CliExample",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=ConfigFromFile.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=ConfigFromFile.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "ConfigFromFile",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=ConfigFromFile.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=ConfigFromFile.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "ConfigFromFile",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=CustomUIConfig.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=CustomUIConfig.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "CustomUIConfig",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=CustomUIConfig.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=CustomUIConfig.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "CustomUIConfig",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=CustomUIIndex.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=CustomUIIndex.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "CustomUIIndex",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=CustomUIIndex.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=CustomUIIndex.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "CustomUIIndex",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=GenericControllers.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=GenericControllers.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "1"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=GenericControllers.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=GenericControllers.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "1"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=MultipleVersions.Startup_swaggerRequestUri=1.0.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=MultipleVersions.Startup_swaggerRequestUri=1.0.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Sample API 1.0",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=MultipleVersions.Startup_swaggerRequestUri=1.0.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=MultipleVersions.Startup_swaggerRequestUri=1.0.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Sample API 1.0",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=MultipleVersions.Startup_swaggerRequestUri=2.0.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=MultipleVersions.Startup_swaggerRequestUri=2.0.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Sample API 2.0",
     "version": "2.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=MultipleVersions.Startup_swaggerRequestUri=2.0.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=MultipleVersions.Startup_swaggerRequestUri=2.0.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Sample API 2.0",
     "version": "2.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=NSwagClientExample.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=NSwagClientExample.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "NswagClientExample",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=NSwagClientExample.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=NSwagClientExample.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "NswagClientExample",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=OAuth2Integration.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=OAuth2Integration.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API V1",
     "version": "v1"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=OAuth2Integration.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=OAuth2Integration.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API V1",
     "version": "v1"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=TestFirst.Startup_swaggerRequestUri=v1-generated.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=TestFirst.Startup_swaggerRequestUri=v1-generated.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test-first Example API (Generated)",
     "version": "v1"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=TestFirst.Startup_swaggerRequestUri=v1-generated.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=TestFirst.Startup_swaggerRequestUri=v1-generated.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test-first Example API (Generated)",
     "version": "v1"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=MinimalApp.Program_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=MinimalApp.Program_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "MinimalApp",
     "version": "v1"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=MinimalApp.Program_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=MinimalApp.Program_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "MinimalApp",
     "version": "v1"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=MvcWithNullable.Program_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=MvcWithNullable.Program_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "MvcWithNullable",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=MvcWithNullable.Program_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=MvcWithNullable.Program_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "MvcWithNullable",
     "version": "1.0"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=TopLevelSwaggerDoc.Program_swaggerRequestUri=.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=TopLevelSwaggerDoc.Program_swaggerRequestUri=.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "1"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=TopLevelSwaggerDoc.Program_swaggerRequestUri=.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=TopLevelSwaggerDoc.Program_swaggerRequestUri=.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "1"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Aot.Program_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Aot.Program_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Native AoT API V1",
     "description": "A sample API for testing Swashbuckle with native AoT",

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Aot.Program_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Aot.Program_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Native AoT API V1",
     "description": "A sample API for testing Swashbuckle with native AoT",

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "WebApi",
     "version": "v1"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "WebApi",
     "version": "v1"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.TypesAreRenderedCorrectly.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.TypesAreRenderedCorrectly.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "WebApi",
     "version": "v1"

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.TypesAreRenderedCorrectly.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.TypesAreRenderedCorrectly.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "WebApi",
     "version": "v1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasConsumesAttribute_bindingSourceId=Body.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasConsumesAttribute_bindingSourceId=Body.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasConsumesAttribute_bindingSourceId=Body.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasConsumesAttribute_bindingSourceId=Body.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasConsumesAttribute_bindingSourceId=Form.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasConsumesAttribute_bindingSourceId=Form.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasConsumesAttribute_bindingSourceId=Form.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasConsumesAttribute_bindingSourceId=Form.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasFileResult.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasFileResult.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasFileResult.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasFileResult.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasObsoleteAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasObsoleteAttribute.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasObsoleteAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasObsoleteAttribute.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasProducesAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasProducesAttribute.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasProducesAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHasProducesAttribute.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHavingFromFormAttributeButNotWithIFormFile.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHavingFromFormAttributeButNotWithIFormFile.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHavingFromFormAttributeButNotWithIFormFile.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHavingFromFormAttributeButNotWithIFormFile.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHavingFromFormAttributeWithSwaggerIgnore.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHavingFromFormAttributeWithSwaggerIgnore.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHavingFromFormAttributeWithSwaggerIgnore.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionHavingFromFormAttributeWithSwaggerIgnore.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionParameterHasBindNeverAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionParameterHasBindNeverAttribute.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionParameterHasBindNeverAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionParameterHasBindNeverAttribute.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionParameterHasSwaggerIgnoreAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionParameterHasSwaggerIgnoreAttribute.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionParameterHasSwaggerIgnoreAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionParameterHasSwaggerIgnoreAttribute.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithConsumesAttributeAndProvidedOpenApiOperation.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithConsumesAttributeAndProvidedOpenApiOperation.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithConsumesAttributeAndProvidedOpenApiOperation.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithConsumesAttributeAndProvidedOpenApiOperation.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithEndpointNameMetadata.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithEndpointNameMetadata.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithEndpointNameMetadata.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithEndpointNameMetadata.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithParameterAndProvidedOpenApiOperation.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithParameterAndProvidedOpenApiOperation.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithParameterAndProvidedOpenApiOperation.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithParameterAndProvidedOpenApiOperation.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithProducesAttributeAndProvidedOpenApiOperation.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithProducesAttributeAndProvidedOpenApiOperation.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithProducesAttributeAndProvidedOpenApiOperation.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithProducesAttributeAndProvidedOpenApiOperation.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithProvidedOpenApiMetadata.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithProvidedOpenApiMetadata.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithProvidedOpenApiMetadata.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithProvidedOpenApiMetadata.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredBodyParameter_action=ActionWithParameterWithBindRequiredAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredBodyParameter_action=ActionWithParameterWithBindRequiredAttribute.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredBodyParameter_action=ActionWithParameterWithBindRequiredAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredBodyParameter_action=ActionWithParameterWithBindRequiredAttribute.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredBodyParameter_action=ActionWithParameterWithRequiredAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredBodyParameter_action=ActionWithParameterWithRequiredAttribute.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredBodyParameter_action=ActionWithParameterWithRequiredAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredBodyParameter_action=ActionWithParameterWithRequiredAttribute.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredMember.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredMember.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredMember.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredMember.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredQueryParameter_action=ActionWithParameterWithBindRequiredAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredQueryParameter_action=ActionWithParameterWithBindRequiredAttribute.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredQueryParameter_action=ActionWithParameterWithBindRequiredAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredQueryParameter_action=ActionWithParameterWithBindRequiredAttribute.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredQueryParameter_action=ActionWithParameterWithRequiredAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredQueryParameter_action=ActionWithParameterWithRequiredAttribute.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredQueryParameter_action=ActionWithParameterWithRequiredAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRequiredQueryParameter_action=ActionWithParameterWithRequiredAttribute.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithReturnValueAndSupportedResponseTypes.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithReturnValueAndSupportedResponseTypes.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithReturnValueAndSupportedResponseTypes.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithReturnValueAndSupportedResponseTypes.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRouteNameMetadata.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRouteNameMetadata.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRouteNameMetadata.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionWithRouteNameMetadata.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithAcceptFromHeaderParameter.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithAcceptFromHeaderParameter.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithAcceptFromHeaderParameter.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithAcceptFromHeaderParameter.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithAuthorizationFromHeaderParameter.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithAuthorizationFromHeaderParameter.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithAuthorizationFromHeaderParameter.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithAuthorizationFromHeaderParameter.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithContentTypeFromHeaderParameter.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithContentTypeFromHeaderParameter.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithContentTypeFromHeaderParameter.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ActionsWithIllegalHeaderParameters_action=ActionWithContentTypeFromHeaderParameter.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiDescriptionsWithMatchingGroupName.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiDescriptionsWithMatchingGroupName.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiDescriptionsWithMatchingGroupName.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiDescriptionsWithMatchingGroupName.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterDescriptionForBodyIsRequired.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterDescriptionForBodyIsRequired.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterDescriptionForBodyIsRequired.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterDescriptionForBodyIsRequired.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterHasNoCorrespondingActionParameter.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterHasNoCorrespondingActionParameter.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterHasNoCorrespondingActionParameter.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterHasNoCorrespondingActionParameter.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterIsBoundToPath.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterIsBoundToPath.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterIsBoundToPath.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParameterIsBoundToPath.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreBoundToForm.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreBoundToForm.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreBoundToForm.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreBoundToForm.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Header.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Header.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Header.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Header.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Path.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Path.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Path.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Path.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Query.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Query.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Query.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=Query.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=null.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=null.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=null.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ApiParametersThatAreNotBoundToBodyOrForm_bindingSourceId=null.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ConflictingActionsResolverIsSpecified.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ConflictingActionsResolverIsSpecified.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ConflictingActionsResolverIsSpecified.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.ConflictingActionsResolverIsSpecified.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasDescriptionAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasDescriptionAttribute.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasDescriptionAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasDescriptionAttribute.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasSummaryAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasSummaryAttribute.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasSummaryAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasSummaryAttribute.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasTags.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasTags.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasTags.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.EndpointMetadataHasTags.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Copies_Description_From_GeneratedSchema.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Copies_Description_From_GeneratedSchema.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Copies_Description_From_GeneratedSchema.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Copies_Description_From_GeneratedSchema.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFile.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFile.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFile.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFile.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFileCollection.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFileCollection.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFileCollection.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithIFormFileCollection.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithSeveralFromForms.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithSeveralFromForms.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithSeveralFromForms.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithSeveralFromForms.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithStringFromForm.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithStringFromForm.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithStringFromForm.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithStringFromForm.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject_AndString.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject_AndString.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject_AndString.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject_AndString.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_TypeIsEnum_AndModelMetadataTypeIsString.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_TypeIsEnum_AndModelMetadataTypeIsString.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_TypeIsEnum_AndModelMetadataTypeIsString.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.GetSwagger_Works_As_Expected_When_TypeIsEnum_AndModelMetadataTypeIsString.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithAcceptFromHeaderParameter.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithAcceptFromHeaderParameter.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithAcceptFromHeaderParameter.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithAcceptFromHeaderParameter.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithAuthorizationFromHeaderParameter.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithAuthorizationFromHeaderParameter.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithAuthorizationFromHeaderParameter.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithAuthorizationFromHeaderParameter.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithContentTypeFromHeaderParameter.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithContentTypeFromHeaderParameter.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithContentTypeFromHeaderParameter.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.IllegalHeaderForOperation_action=ActionWithContentTypeFromHeaderParameter.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.OperationHasSwaggerIgnoreAttribute.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.OperationHasSwaggerIgnoreAttribute.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.OperationHasSwaggerIgnoreAttribute.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.OperationHasSwaggerIgnoreAttribute.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.SortKeySelectorIsSpecified.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.SortKeySelectorIsSpecified.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.SortKeySelectorIsSpecified.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.SortKeySelectorIsSpecified.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.TagSelectorIsSpecified.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.TagSelectorIsSpecified.DotNet8_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.TagSelectorIsSpecified.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/VerifyTests.TagSelectorIsSpecified.DotNet9_0.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test API",
     "version": "V1"

--- a/test/WebSites/CliExample/wwwroot/swagger/v1/swagger_net8.0.json
+++ b/test/WebSites/CliExample/wwwroot/swagger/v1/swagger_net8.0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "CliExample",
     "version": "1.0"

--- a/test/WebSites/CliExample/wwwroot/swagger/v1/swagger_net9.0.json
+++ b/test/WebSites/CliExample/wwwroot/swagger/v1/swagger_net9.0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "CliExample",
     "version": "1.0"

--- a/test/WebSites/CliExampleWithFactory/wwwroot/swagger/v1/swagger_net8.0.json
+++ b/test/WebSites/CliExampleWithFactory/wwwroot/swagger/v1/swagger_net8.0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "CliExampleWithFactory",
     "version": "1.0"

--- a/test/WebSites/CliExampleWithFactory/wwwroot/swagger/v1/swagger_net9.0.json
+++ b/test/WebSites/CliExampleWithFactory/wwwroot/swagger/v1/swagger_net9.0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "CliExampleWithFactory",
     "version": "1.0"

--- a/test/WebSites/NswagClientExample/swagger_net8.0.json
+++ b/test/WebSites/NswagClientExample/swagger_net8.0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "NswagClientExample",
     "version": "1.0"

--- a/test/WebSites/NswagClientExample/swagger_net9.0.json
+++ b/test/WebSites/NswagClientExample/swagger_net9.0.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "NswagClientExample",
     "version": "1.0"

--- a/test/WebSites/TestFirst/wwwroot/swagger/v1-generated/openapi.json
+++ b/test/WebSites/TestFirst/wwwroot/swagger/v1-generated/openapi.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test-first Example API (Generated)",
     "version": "v1"

--- a/test/WebSites/TestFirst/wwwroot/swagger/v1-imported/openapi.json
+++ b/test/WebSites/TestFirst/wwwroot/swagger/v1-imported/openapi.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Test-first Example API (Imported)",
     "version": "v1"


### PR DESCRIPTION
- Update Microsoft.OpenApi to v1.6.23.
- Update ASP.NET Core 2.1 packages to [ASP.NET Core 2.3](https://github.com/dotnet/announcements/issues/331).
