### PR TITLE
Add cache headers for ReDoc and SwaggerUI

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,7 +39,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseArtifactsOutput>true</UseArtifactsOutput>
-    <VersionPrefix>8.0.1</VersionPrefix>
+    <VersionPrefix>8.1.0</VersionPrefix>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(GITHUB_ACTIONS)' != '' AND '$(DEPENDABOT_JOB_ID)' == '' ">

--- a/src/Swashbuckle.AspNetCore.Cli/Program.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/Program.cs
@@ -247,7 +247,7 @@ internal class Program
             "exec --depsfile {0} --runtimeconfig {1} {2} _{3} {4}", // note the underscore prepended to the command name
             EscapePath(depsFile),
             EscapePath(runtimeConfig),
-            EscapePath(typeof(Program).GetTypeInfo().Assembly.Location),
+            EscapePath(typeof(Program).Assembly.Location),
             commandName,
             string.Join(" ", subProcessArguments.Select(EscapePath))
         );

--- a/src/Swashbuckle.AspNetCore.ReDoc/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.ReDoc/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Swashbuckle.AspNetCore.ReDoc.ReDocOptions.CacheLifetime.get -> System.TimeSpan?
+Swashbuckle.AspNetCore.ReDoc.ReDocOptions.CacheLifetime.set -> void

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
@@ -100,7 +100,7 @@ internal sealed class ReDocMiddleware
         var staticFileOptions = new StaticFileOptions
         {
             RequestPath = string.IsNullOrEmpty(options.RoutePrefix) ? string.Empty : $"/{options.RoutePrefix}",
-            FileProvider = new EmbeddedFileProvider(typeof(ReDocMiddleware).GetTypeInfo().Assembly, EmbeddedFileNamespace),
+            FileProvider = new EmbeddedFileProvider(typeof(ReDocMiddleware).Assembly, EmbeddedFileNamespace),
         };
 
         return new StaticFileMiddleware(next, hostingEnv, Options.Create(staticFileOptions), loggerFactory);

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
@@ -103,7 +103,7 @@ internal sealed class ReDocMiddleware
         {
             RequestPath = string.IsNullOrEmpty(options.RoutePrefix) ? string.Empty : $"/{options.RoutePrefix}",
             FileProvider = new EmbeddedFileProvider(typeof(ReDocMiddleware).Assembly, EmbeddedFileNamespace),
-            OnPrepareResponse = (context) => SetCacheHeaders(context.Context.Response, options)
+            OnPrepareResponse = (context) => SetCacheHeaders(context.Context.Response, options),
         };
 
         return new StaticFileMiddleware(next, hostingEnv, Options.Create(staticFileOptions), loggerFactory);

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
@@ -129,7 +129,15 @@ internal sealed class ReDocMiddleware
             headers.CacheControl = new()
             {
                 MaxAge = maxAge,
-                Public = true,
+                Private = true,
+            };
+        }
+        else
+        {
+            headers.CacheControl = new()
+            {
+                NoCache = true,
+                NoStore = true,
             };
         }
 

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocOptions.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocOptions.cs
@@ -38,4 +38,12 @@ public class ReDocOptions
     /// Gets or sets the optional <see cref="System.Text.Json.JsonSerializerOptions"/> to use.
     /// </summary>
     public JsonSerializerOptions JsonSerializerOptions { get; set; }
+
+    /// <summary>
+    /// Gets or sets the cache lifetime to use for the ReDoc files, if any.
+    /// </summary>
+    /// <remarks>
+    /// The default value is 7 days.
+    /// </remarks>
+    public TimeSpan? CacheLifetime { get; set; } = TimeSpan.FromDays(7);
 }

--- a/src/Swashbuckle.AspNetCore.ReDoc/ResourceHelper.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ResourceHelper.cs
@@ -1,12 +1,10 @@
-﻿using System.Reflection;
-
-namespace Swashbuckle.AspNetCore.ReDoc;
+﻿namespace Swashbuckle.AspNetCore.ReDoc;
 
 internal static class ResourceHelper
 {
     public static Stream GetEmbeddedResource(string fileName)
     {
-        return typeof(ResourceHelper).GetTypeInfo().Assembly
+        return typeof(ResourceHelper).Assembly
             .GetManifestResourceStream($"Swashbuckle.AspNetCore.ReDoc.{fileName}");
     }
 }

--- a/src/Swashbuckle.AspNetCore.ReDoc/Swashbuckle.AspNetCore.ReDoc.csproj
+++ b/src/Swashbuckle.AspNetCore.ReDoc/Swashbuckle.AspNetCore.ReDoc.csproj
@@ -58,4 +58,28 @@
     <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js/npm is required to build this project." />
   </Target>
 
+  <!-- Embed the ReDoc version into the [AssemblyMetadata] attributes -->
+  <UsingTask TaskName="GetReDocVersion" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <PackageJsonPath ParameterType="System.String" Required="true" />
+      <ReDocVersion ParameterType="System.String" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Code Type="Fragment" Language="cs"><![CDATA[
+        var packageJson = System.IO.File.ReadAllText(PackageJsonPath);
+        var pattern = @"""redoc"":\s*""([^""]+)""";
+        var match = System.Text.RegularExpressions.Regex.Match(packageJson, pattern);
+        ReDocVersion = match.Groups[1].Value;
+   ]]></Code>
+    </Task>
+  </UsingTask>
+  <Target Name="AddCustomAssemblyMetadata" BeforeTargets="GetAssemblyAttributes">
+    <GetReDocVersion PackageJsonPath="$(MSBuildThisFileDirectory)\package.json">
+      <Output TaskParameter="ReDocVersion" PropertyName="ReDocVersion" />
+    </GetReDocVersion>
+    <ItemGroup>
+      <AssemblyMetadata Include="ReDocVersion" Value="$(ReDocVersion)" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIOptions.CacheLifetime.get -> System.TimeSpan?
+Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIOptions.CacheLifetime.set -> void

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/ResourceHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/ResourceHelper.cs
@@ -1,12 +1,10 @@
-﻿using System.Reflection;
-
-namespace Swashbuckle.AspNetCore.SwaggerUI;
+﻿namespace Swashbuckle.AspNetCore.SwaggerUI;
 
 internal static class ResourceHelper
 {
     public static Stream GetEmbeddedResource(string fileName)
     {
-        return typeof(ResourceHelper).GetTypeInfo().Assembly
+        return typeof(ResourceHelper).Assembly
             .GetManifestResourceStream($"Swashbuckle.AspNetCore.SwaggerUI.{fileName}");
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -136,7 +136,15 @@ internal sealed partial class SwaggerUIMiddleware
             headers.CacheControl = new()
             {
                 MaxAge = maxAge,
-                Public = true,
+                Private = true,
+            };
+        }
+        else
+        {
+            headers.CacheControl = new()
+            {
+                NoCache = true,
+                NoStore = true,
             };
         }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -106,7 +106,7 @@ internal sealed partial class SwaggerUIMiddleware
         var staticFileOptions = new StaticFileOptions
         {
             RequestPath = string.IsNullOrEmpty(options.RoutePrefix) ? string.Empty : $"/{options.RoutePrefix}",
-            FileProvider = new EmbeddedFileProvider(typeof(SwaggerUIMiddleware).GetTypeInfo().Assembly, EmbeddedFileNamespace),
+            FileProvider = new EmbeddedFileProvider(typeof(SwaggerUIMiddleware).Assembly, EmbeddedFileNamespace),
         };
 
         return new StaticFileMiddleware(next, hostingEnv, Options.Create(staticFileOptions), loggerFactory);

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptions.cs
@@ -70,4 +70,12 @@ public class SwaggerUIOptions
     /// Gets or sets the relative URL path to the route that exposes the values of the configured <see cref="ConfigObject.Urls"/> values.
     /// </summary>
     public string SwaggerDocumentUrlsPath { get; set; } = "documentUrls";
+
+    /// <summary>
+    /// Gets or sets the cache lifetime to use for the SwaggerUI files, if any.
+    /// </summary>
+    /// <remarks>
+    /// The default value is 7 days.
+    /// </remarks>
+    public TimeSpan? CacheLifetime { get; set; } = TimeSpan.FromDays(7);
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
@@ -52,4 +52,28 @@
     <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js/npm is required to build this project." />
   </Target>
 
+  <!-- Embed the swagger-ui version into the [AssemblyMetadata] attributes -->
+  <UsingTask TaskName="GetSwaggerUIVersion" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <PackageJsonPath ParameterType="System.String" Required="true" />
+      <SwaggerUIVersion ParameterType="System.String" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Code Type="Fragment" Language="cs"><![CDATA[
+        var packageJson = System.IO.File.ReadAllText(PackageJsonPath);
+        var pattern = @"""swagger-ui-dist"":\s*""([^""]+)""";
+        var match = System.Text.RegularExpressions.Regex.Match(packageJson, pattern);
+        SwaggerUIVersion = match.Groups[1].Value;
+   ]]></Code>
+    </Task>
+  </UsingTask>
+  <Target Name="AddCustomAssemblyMetadata" BeforeTargets="GetAssemblyAttributes">
+    <GetSwaggerUIVersion PackageJsonPath="$(MSBuildThisFileDirectory)\package.json">
+      <Output TaskParameter="SwaggerUIVersion" PropertyName="SwaggerUIVersion" />
+    </GetSwaggerUIVersion>
+    <ItemGroup>
+      <AssemblyMetadata Include="SwaggerUIVersion" Value="$(SwaggerUIVersion)" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
@@ -41,7 +41,7 @@ public class ReDocIntegrationTests
             Assert.True(response.Headers.ETag.IsWeak);
             Assert.NotEmpty(response.Headers.ETag.Tag);
             Assert.NotNull(response.Headers.CacheControl);
-            Assert.True(response.Headers.CacheControl.Public);
+            Assert.True(response.Headers.CacheControl.Private);
             Assert.Equal(TimeSpan.FromDays(7), response.Headers.CacheControl.MaxAge);
         }
     }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
@@ -11,9 +11,10 @@ public class ReDocIntegrationTests
     [Fact]
     public async Task RoutePrefix_RedirectsToIndexUrl()
     {
-        var client = new TestSite(typeof(ReDocApp.Startup)).BuildClient();
+        var site = new TestSite(typeof(ReDocApp.Startup));
+        using var client = site.BuildClient();
 
-        var response = await client.GetAsync("/api-docs");
+        using var response = await client.GetAsync("/api-docs");
 
         Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
         Assert.Equal("api-docs/index.html", response.Headers.Location.ToString());
@@ -22,47 +23,36 @@ public class ReDocIntegrationTests
     [Fact]
     public async Task IndexUrl_ReturnsEmbeddedVersionOfTheRedocUI()
     {
-        var client = new TestSite(typeof(ReDocApp.Startup)).BuildClient();
+        var site = new TestSite(typeof(ReDocApp.Startup));
+        using var client = site.BuildClient();
 
-        var htmlResponse = await client.GetAsync("/api-docs/index.html");
-        var cssResponse = await client.GetAsync("/api-docs/index.css");
-        var jsResponse = await client.GetAsync("/api-docs/redoc.standalone.js");
+        using var htmlResponse = await client.GetAsync("/api-docs/index.html");
+        using var cssResponse = await client.GetAsync("/api-docs/index.css");
+        using var jsResponse = await client.GetAsync("/api-docs/redoc.standalone.js");
 
-        Assert.Equal(HttpStatusCode.OK, htmlResponse.StatusCode);
-        Assert.Equal(HttpStatusCode.OK, cssResponse.StatusCode);
-        Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
+        AssertResource(htmlResponse);
+        AssertResource(cssResponse);
+        AssertResource(jsResponse);
 
-        Assert.NotNull(htmlResponse.Headers.ETag);
-        Assert.NotNull(cssResponse.Headers.ETag);
-        Assert.NotNull(jsResponse.Headers.ETag);
-
-        Assert.True(htmlResponse.Headers.ETag.IsWeak);
-        Assert.True(cssResponse.Headers.ETag.IsWeak);
-        Assert.True(jsResponse.Headers.ETag.IsWeak);
-
-        Assert.NotEmpty(htmlResponse.Headers.ETag.Tag);
-        Assert.NotEmpty(cssResponse.Headers.ETag.Tag);
-        Assert.NotEmpty(jsResponse.Headers.ETag.Tag);
-
-        Assert.NotNull(htmlResponse.Headers.CacheControl);
-        Assert.NotNull(cssResponse.Headers.CacheControl);
-        Assert.NotNull(jsResponse.Headers.CacheControl);
-
-        Assert.True(htmlResponse.Headers.CacheControl.Public);
-        Assert.True(cssResponse.Headers.CacheControl.Public);
-        Assert.True(jsResponse.Headers.CacheControl.Public);
-
-        Assert.Equal(TimeSpan.FromDays(7), htmlResponse.Headers.CacheControl.MaxAge);
-        Assert.Equal(TimeSpan.FromDays(7), cssResponse.Headers.CacheControl.MaxAge);
-        Assert.Equal(TimeSpan.FromDays(7), jsResponse.Headers.CacheControl.MaxAge);
+        static void AssertResource(HttpResponseMessage response)
+        {
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Headers.ETag);
+            Assert.True(response.Headers.ETag.IsWeak);
+            Assert.NotEmpty(response.Headers.ETag.Tag);
+            Assert.NotNull(response.Headers.CacheControl);
+            Assert.True(response.Headers.CacheControl.Public);
+            Assert.Equal(TimeSpan.FromDays(7), response.Headers.CacheControl.MaxAge);
+        }
     }
 
     [Fact]
     public async Task RedocMiddleware_ReturnsInitializerScript()
     {
-        var client = new TestSite(typeof(ReDocApp.Startup)).BuildClient();
+        var site = new TestSite(typeof(ReDocApp.Startup));
+        using var client = site.BuildClient();
 
-        var response = await client.GetAsync("/api-docs/index.js");
+        using var response = await client.GetAsync("/api-docs/index.js");
         var content = await response.Content.ReadAsStringAsync();
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -76,12 +66,13 @@ public class ReDocIntegrationTests
     [Fact]
     public async Task IndexUrl_IgnoresUrlCase()
     {
-        var client = new TestSite(typeof(ReDocApp.Startup)).BuildClient();
+        var site = new TestSite(typeof(ReDocApp.Startup));
+        using var client = site.BuildClient();
 
-        var htmlResponse = await client.GetAsync("/Api-Docs/index.html");
-        var cssResponse = await client.GetAsync("/Api-Docs/index.css");
-        var jsInitResponse = await client.GetAsync("/Api-Docs/index.js");
-        var jsRedocResponse = await client.GetAsync("/Api-Docs/redoc.standalone.js");
+        using var htmlResponse = await client.GetAsync("/Api-Docs/index.html");
+        using var cssResponse = await client.GetAsync("/Api-Docs/index.css");
+        using var jsInitResponse = await client.GetAsync("/Api-Docs/index.js");
+        using var jsRedocResponse = await client.GetAsync("/Api-Docs/redoc.standalone.js");
 
         Assert.Equal(HttpStatusCode.OK, htmlResponse.StatusCode);
         Assert.Equal(HttpStatusCode.OK, cssResponse.StatusCode);
@@ -94,10 +85,11 @@ public class ReDocIntegrationTests
     [InlineData("/redoc/2.0/index.html", "/redoc/2.0/index.js", "/swagger/2.0/swagger.json")]
     public async Task RedocMiddleware_CanBeConfiguredMultipleTimes(string htmlUrl, string jsUrl, string swaggerPath)
     {
-        var client = new TestSite(typeof(MultipleVersions.Startup)).BuildClient();
+        var site = new TestSite(typeof(MultipleVersions.Startup));
+        using var client = site.BuildClient();
 
-        var htmlResponse = await client.GetAsync(htmlUrl);
-        var jsResponse = await client.GetAsync(jsUrl);
+        using var htmlResponse = await client.GetAsync(htmlUrl);
+        using var jsResponse = await client.GetAsync(jsUrl);
         var content = await jsResponse.Content.ReadAsStringAsync();
 
         Assert.Equal(HttpStatusCode.OK, htmlResponse.StatusCode);

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
@@ -31,6 +31,30 @@ public class ReDocIntegrationTests
         Assert.Equal(HttpStatusCode.OK, htmlResponse.StatusCode);
         Assert.Equal(HttpStatusCode.OK, cssResponse.StatusCode);
         Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
+
+        Assert.NotNull(htmlResponse.Headers.ETag);
+        Assert.NotNull(cssResponse.Headers.ETag);
+        Assert.NotNull(jsResponse.Headers.ETag);
+
+        Assert.True(htmlResponse.Headers.ETag.IsWeak);
+        Assert.True(cssResponse.Headers.ETag.IsWeak);
+        Assert.True(jsResponse.Headers.ETag.IsWeak);
+
+        Assert.NotEmpty(htmlResponse.Headers.ETag.Tag);
+        Assert.NotEmpty(cssResponse.Headers.ETag.Tag);
+        Assert.NotEmpty(jsResponse.Headers.ETag.Tag);
+
+        Assert.NotNull(htmlResponse.Headers.CacheControl);
+        Assert.NotNull(cssResponse.Headers.CacheControl);
+        Assert.NotNull(jsResponse.Headers.CacheControl);
+
+        Assert.True(htmlResponse.Headers.CacheControl.Public);
+        Assert.True(cssResponse.Headers.CacheControl.Public);
+        Assert.True(jsResponse.Headers.CacheControl.Public);
+
+        Assert.Equal(TimeSpan.FromDays(7), htmlResponse.Headers.CacheControl.MaxAge);
+        Assert.Equal(TimeSpan.FromDays(7), cssResponse.Headers.CacheControl.MaxAge);
+        Assert.Equal(TimeSpan.FromDays(7), jsResponse.Headers.CacheControl.MaxAge);
     }
 
     [Fact]

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -14,9 +14,10 @@ public class SwaggerUIIntegrationTests
         string requestPath,
         string expectedRedirectPath)
     {
-        var client = new TestSite(startupType).BuildClient();
+        var site = new TestSite(startupType);
+        using var client = site.BuildClient();
 
-        var response = await client.GetAsync(requestPath);
+        using var response = await client.GetAsync(requestPath);
 
         Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
         Assert.Equal(expectedRedirectPath, response.Headers.Location.ToString());
@@ -32,19 +33,31 @@ public class SwaggerUIIntegrationTests
         string indexCssPath,
         string swaggerUiCssPath)
     {
-        var client = new TestSite(startupType).BuildClient();
+        var site = new TestSite(startupType);
+        using var client = site.BuildClient();
 
-        var htmlResponse = await client.GetAsync(htmlPath);
-        Assert.Equal(HttpStatusCode.OK, htmlResponse.StatusCode);
+        using var htmlResponse = await client.GetAsync(htmlPath);
+        AssertResource(htmlResponse);
 
-        var jsResponse = await client.GetAsync(swaggerUijsPath);
-        Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
+        using var jsResponse = await client.GetAsync(swaggerUijsPath);
+        AssertResource(jsResponse);
 
-        var cssResponse = await client.GetAsync(indexCssPath);
-        Assert.Equal(HttpStatusCode.OK, cssResponse.StatusCode);
+        using var indexCss = await client.GetAsync(indexCssPath);
+        AssertResource(indexCss);
 
-        cssResponse = await client.GetAsync(swaggerUiCssPath);
-        Assert.Equal(HttpStatusCode.OK, cssResponse.StatusCode);
+        using var cssResponse = await client.GetAsync(swaggerUiCssPath);
+        AssertResource(cssResponse);
+
+        static void AssertResource(HttpResponseMessage response)
+        {
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(response.Headers.ETag);
+            Assert.True(response.Headers.ETag.IsWeak);
+            Assert.NotEmpty(response.Headers.ETag.Tag);
+            Assert.NotNull(response.Headers.CacheControl);
+            Assert.True(response.Headers.CacheControl.Public);
+            Assert.Equal(TimeSpan.FromDays(7), response.Headers.CacheControl.MaxAge);
+        }
     }
 
     [Theory]
@@ -54,9 +67,10 @@ public class SwaggerUIIntegrationTests
         Type startupType,
         string indexJsPath)
     {
-        var client = new TestSite(startupType).BuildClient();
+        var site = new TestSite(startupType);
+        using var client = site.BuildClient();
 
-        var jsResponse = await client.GetAsync(indexJsPath);
+        using var jsResponse = await client.GetAsync(indexJsPath);
         Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
 
         var jsContent = await jsResponse.Content.ReadAsStringAsync();
@@ -74,9 +88,10 @@ public class SwaggerUIIntegrationTests
     [Fact]
     public async Task IndexUrl_DefinesPlugins()
     {
-        var client = new TestSite(typeof(CustomUIConfig.Startup)).BuildClient();
+        var site = new TestSite(typeof(CustomUIConfig.Startup));
+        using var client = site.BuildClient();
 
-        var jsResponse = await client.GetAsync("/swagger/index.js");
+        using var jsResponse = await client.GetAsync("/swagger/index.js");
         Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
 
         var jsContent = await jsResponse.Content.ReadAsStringAsync();
@@ -86,9 +101,10 @@ public class SwaggerUIIntegrationTests
     [Fact]
     public async Task IndexUrl_DoesntDefinePlugins()
     {
-        var client = new TestSite(typeof(Basic.Startup)).BuildClient();
+        var site = new TestSite(typeof(Basic.Startup));
+        using var client = site.BuildClient();
 
-        var jsResponse = await client.GetAsync("/index.js");
+        using var jsResponse = await client.GetAsync("/index.js");
         Assert.Equal(HttpStatusCode.OK, jsResponse.StatusCode);
         var jsContent = await jsResponse.Content.ReadAsStringAsync();
         Assert.DoesNotContain("\"plugins\"", jsContent);
@@ -97,9 +113,10 @@ public class SwaggerUIIntegrationTests
     [Fact]
     public async Task IndexUrl_ReturnsCustomPageTitleAndStylesheets_IfConfigured()
     {
-        var client = new TestSite(typeof(CustomUIConfig.Startup)).BuildClient();
+        var site = new TestSite(typeof(CustomUIConfig.Startup));
+        using var client = site.BuildClient();
 
-        var response = await client.GetAsync("/swagger/index.html");
+        using var response = await client.GetAsync("/swagger/index.html");
         var content = await response.Content.ReadAsStringAsync();
 
         Assert.Contains("<title>CustomUIConfig</title>", content);
@@ -109,9 +126,10 @@ public class SwaggerUIIntegrationTests
     [Fact]
     public async Task IndexUrl_ReturnsCustomIndexHtml_IfConfigured()
     {
-        var client = new TestSite(typeof(CustomUIIndex.Startup)).BuildClient();
+        var site = new TestSite(typeof(CustomUIIndex.Startup));
+        using var client = site.BuildClient();
 
-        var response = await client.GetAsync("/swagger/index.html");
+        using var response = await client.GetAsync("/swagger/index.html");
         var content = await response.Content.ReadAsStringAsync();
 
         Assert.Contains("Example.com", content);
@@ -120,9 +138,10 @@ public class SwaggerUIIntegrationTests
     [Fact]
     public async Task IndexUrl_ReturnsInterceptors_IfConfigured()
     {
-        var client = new TestSite(typeof(CustomUIConfig.Startup)).BuildClient();
+        var site = new TestSite(typeof(CustomUIConfig.Startup));
+        using var client = site.BuildClient();
 
-        var response = await client.GetAsync("/swagger/index.js");
+        using var response = await client.GetAsync("/swagger/index.js");
         var content = await response.Content.ReadAsStringAsync();
 
         Assert.Contains("\"RequestInterceptorFunction\":", content);
@@ -135,10 +154,11 @@ public class SwaggerUIIntegrationTests
     [InlineData("/swagger/2.0/index.html", "/swagger/2.0/index.js", new[] { "Version 2.0" })]
     public async Task SwaggerUIMiddleware_CanBeConfiguredMultipleTimes(string htmlUrl, string jsUrl, string[] versions)
     {
-        var client = new TestSite(typeof(MultipleVersions.Startup)).BuildClient();
+        var site = new TestSite(typeof(MultipleVersions.Startup));
+        using var client = site.BuildClient();
 
-        var htmlResponse = await client.GetAsync(htmlUrl);
-        var jsResponse = await client.GetAsync(jsUrl);
+        using var htmlResponse = await client.GetAsync(htmlUrl);
+        using var jsResponse = await client.GetAsync(jsUrl);
         var content = await jsResponse.Content.ReadAsStringAsync();
 
         Assert.Equal(HttpStatusCode.OK, htmlResponse.StatusCode);
@@ -159,9 +179,10 @@ public class SwaggerUIIntegrationTests
         string scriptBundlePath,
         string scriptPresetsPath)
     {
-        var client = new TestSite(startupType).BuildClient();
+        var site = new TestSite(startupType);
+        using var client = site.BuildClient();
 
-        var htmlResponse = await client.GetAsync(htmlPath);
+        using var htmlResponse = await client.GetAsync(htmlPath);
         Assert.Equal(HttpStatusCode.OK, htmlResponse.StatusCode);
 
         var content = await htmlResponse.Content.ReadAsStringAsync();

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -55,7 +55,7 @@ public class SwaggerUIIntegrationTests
             Assert.True(response.Headers.ETag.IsWeak);
             Assert.NotEmpty(response.Headers.ETag.Tag);
             Assert.NotNull(response.Headers.CacheControl);
-            Assert.True(response.Headers.CacheControl.Public);
+            Assert.True(response.Headers.CacheControl.Private);
             Assert.Equal(TimeSpan.FromDays(7), response.Headers.CacheControl.MaxAge);
         }
     }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/TestSite.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/TestSite.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 
 namespace Swashbuckle.AspNetCore.IntegrationTests;
@@ -15,7 +14,7 @@ public class TestSite
 
     public TestServer BuildServer()
     {
-        var startupAssembly = _startupType.GetTypeInfo().Assembly;
+        var startupAssembly = _startupType.Assembly;
         var applicationName = startupAssembly.GetName().Name;
 
         var builder = new WebHostBuilder()

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/TestSiteAutofaq.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/TestSiteAutofaq.cs
@@ -16,7 +16,7 @@ public class TestSiteAutofaq
 
     public TestServer BuildServer()
     {
-        var startupAssembly = _startupType.GetTypeInfo().Assembly;
+        var startupAssembly = _startupType.Assembly;
         var applicationName = startupAssembly.GetName().Name;
 
         var hostBuilder = new WebHostBuilder()


### PR DESCRIPTION
- Embed the versions of redoc and swagger-ui-dist into their respective assemblies as `[AssemblyMetdata]` attributes.
- Remove redundant `GetTypeInfo()` calls.
- Add cache headers to ReDoc and SwaggerUI static files.

Resolves #3336.
