### PR TITLE
Update to fix Lists/Arrays of nullables not getting marked as nullable

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -183,6 +183,8 @@ public class SchemaGenerator(
         if (schema.Reference == null)
         {
             ApplyFilters(schema, modelType, schemaRepository);
+            if (Nullable.GetUnderlyingType(modelType) != null)
+                schema.Nullable = true;
         }
 
         return schema;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -184,7 +184,9 @@ public class SchemaGenerator(
         {
             ApplyFilters(schema, modelType, schemaRepository);
             if (Nullable.GetUnderlyingType(modelType) != null)
+            {
                 schema.Nullable = true;
+            }
         }
 
         return schema;

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -161,13 +161,13 @@ public class JsonSerializerSchemaGeneratorTests
         Assert.Equal(schema.AdditionalProperties.Reference.Id, referenceSchema.Reference.Id); // ref to self
     }
 
-    public static TheoryData<Type, JsonSchemaType, string> EnumerableTypeData => new()
+    public static TheoryData<Type, JsonSchemaType, string, bool> EnumerableTypeData => new()
     {
-        { typeof(int[]), JsonSchemaTypes.Integer, "int32" },
-        { typeof(IEnumerable<string>), JsonSchemaTypes.String, null },
-        { typeof(DateTime?[]), JsonSchemaTypes.String, "date-time" },
-        { typeof(int[][]), JsonSchemaTypes.Array, null },
-        { typeof(IList), null, null },
+        { typeof(int[]), JsonSchemaTypes.Integer, "int32", false },
+        { typeof(IEnumerable<string>), JsonSchemaTypes.String, null, false },
+        { typeof(DateTime?[]), JsonSchemaTypes.String, "date-time", true },
+        { typeof(int[][]), JsonSchemaTypes.Array, null, false },
+        { typeof(IList), null, null, false },
     };
 
     [Theory]
@@ -175,7 +175,8 @@ public class JsonSerializerSchemaGeneratorTests
     public void GenerateSchema_GeneratesArraySchema_IfEnumerableType(
         Type type,
         JsonSchemaType expectedItemsType,
-        string expectedItemsFormat)
+        string expectedItemsFormat,
+        bool expectedItemsNullable)
     {
         var schema = Subject().GenerateSchema(type, new SchemaRepository());
 
@@ -183,6 +184,7 @@ public class JsonSerializerSchemaGeneratorTests
         Assert.NotNull(schema.Items);
         Assert.Equal(expectedItemsType, schema.Items.Type);
         Assert.Equal(expectedItemsFormat, schema.Items.Format);
+        Assert.Equal(expectedItemsNullable, schema.Items.Nullable);
     }
 
     [Theory]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -164,8 +164,12 @@ public class JsonSerializerSchemaGeneratorTests
     public static TheoryData<Type, JsonSchemaType, string, bool> EnumerableTypeData => new()
     {
         { typeof(int[]), JsonSchemaTypes.Integer, "int32", false },
-        { typeof(IEnumerable<string>), JsonSchemaTypes.String, null, false },
+        { typeof(int?[]), JsonSchemaTypes.Integer, "int32", true },
+        { typeof(double[]), JsonSchemaTypes.Number, "double", false },
+        { typeof(double?[]), JsonSchemaTypes.Number, "double", true },
+        { typeof(DateTime[]), JsonSchemaTypes.String, "date-time", false },
         { typeof(DateTime?[]), JsonSchemaTypes.String, "date-time", true },
+        { typeof(IEnumerable<string>), JsonSchemaTypes.String, null, false },
         { typeof(int[][]), JsonSchemaTypes.Array, null, false },
         { typeof(IList), null, null, false },
     };


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

This Pull Request should hopefully address an issue where Arrays/Lists of Nullable types where not getting correctly marked as Nullable in the generated swagger.

Resolves #3284

## Details on the issue fix or feature implementation

In GenerateSchema -> GenerateSchemaForType I added a check to see if the Array underlying type was nullable. If so, it would mark the corresponding section in the schema (in this case items) with nullable = true.
