### PR TITLE
Add build timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
 
     outputs:
       dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}


### PR DESCRIPTION
Timeout the build after 15 minutes.

Otherwise it will potentially run for up to [6 hours](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/actions/runs/14441736699/job/40493209997)(!) if something goes wrong.
