### PR TITLE
add --verify-no-changes option

### DIFF
--- a/src/Swashbuckle.AspNetCore.Cli/VerificationException.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/VerificationException.cs
@@ -1,0 +1,4 @@
+﻿
+namespace Swashbuckle.AspNetCore.Cli;
+
+internal class VerificationException : Exception;

--- a/src/Swashbuckle.AspNetCore.Cli/VerifyingWriter.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/VerifyingWriter.cs
@@ -1,0 +1,58 @@
+﻿using System.Buffers;
+using System.Globalization;
+using System.Text;
+
+namespace Swashbuckle.AspNetCore.Cli;
+
+internal class VerifyingWriter(Stream stream) : TextWriter
+{
+    private readonly StreamReader _reader = new(stream);
+
+    public override Encoding Encoding => _reader.CurrentEncoding;
+
+    public override IFormatProvider FormatProvider => CultureInfo.InvariantCulture;
+
+    public override void Write(char value)
+    {
+        var readChar = _reader.Read();
+
+        if (readChar != value)
+        {
+            throw new VerificationException();
+        }
+    }
+
+    public override void Write(char[] buffer, int index, int count)
+    {
+        var array = ArrayPool<char>.Shared.Rent(count);
+
+        try
+        {
+            var bytesRead = _reader.Read(array, 0, count);
+
+            if (bytesRead != count || !buffer.AsSpan(index, count).SequenceEqual(array.AsSpan(0, count)))
+            {
+                throw new VerificationException();
+            }
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(array);
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (MoreBytesToRead())
+        {
+            throw new VerificationException();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private bool MoreBytesToRead()
+    {
+        return _reader.Read() != -1;
+    }
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

Fixes https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3371

<!-- Please include the existing GitHub issue number where relevant, e.g. "Fixes #123" -->

## Details on the issue fix or feature implementation

This adds the --verify-no-changes option to the tofile command.

When --verify-no-changes is added, --output is required, and is used as an input instead of an output, when not specified, this will return exit code 1.

If the output file does not exist or is different from what has already been output this will return exit code 2.

For this purpose, I have introduced a new class called the `VerifyingWriter`, as the file is being "written out", the contents being "written" are compared with the file specified by --output.

<!-- Information about your changes -->
