### PR TITLE
fix schema for nullable enums

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
@@ -49,7 +49,7 @@ public class JsonSerializerDataContractResolver(JsonSerializerOptions serializer
             primitiveTypeAndFormat = PrimitiveTypesAndFormats[exampleType];
 
             return DataContract.ForPrimitive(
-                underlyingType: effectiveType,
+                underlyingType: type,
                 dataType: primitiveTypeAndFormat.Item1,
                 dataFormat: primitiveTypeAndFormat.Item2,
                 jsonConverter: (value) => JsonConverterFunc(value, type));

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -54,6 +54,18 @@ public class SchemaGenerator(
         MemberInfo memberInfo,
         DataProperty dataProperty = null)
     {
+        if (dataProperty != null)
+        {
+            var customAttributes = memberInfo.GetInlineAndMetadataAttributes();
+
+            var requiredAttribute = customAttributes.OfType<RequiredAttribute>().FirstOrDefault();
+
+            if (!IsNullable(customAttributes, requiredAttribute, dataProperty, memberInfo))
+            {
+                modelType = Nullable.GetUnderlyingType(modelType) ?? modelType;
+            }
+        }
+
         var dataContract = GetDataContractFor(modelType);
 
         var schema = _generatorOptions.UseOneOfForPolymorphism && IsBaseTypeWithKnownTypesDefined(dataContract, out var knownTypesDataContracts)
@@ -75,11 +87,7 @@ public class SchemaGenerator(
             {
                 var requiredAttribute = customAttributes.OfType<RequiredAttribute>().FirstOrDefault();
 
-                var nullable = _generatorOptions.SupportNonNullableReferenceTypes
-                    ? dataProperty.IsNullable && requiredAttribute == null && !memberInfo.IsNonNullableReferenceType()
-                    : dataProperty.IsNullable && requiredAttribute == null;
-
-                schema.Nullable = nullable;
+                schema.Nullable = IsNullable(customAttributes, requiredAttribute, dataProperty, memberInfo);
 
                 schema.ReadOnly = dataProperty.IsReadOnly;
                 schema.WriteOnly = dataProperty.IsWriteOnly;
@@ -127,6 +135,13 @@ public class SchemaGenerator(
         }
 
         return schema;
+    }
+
+    private bool IsNullable(IEnumerable<object> customAttributes, RequiredAttribute requiredAttribute, DataProperty dataProperty, MemberInfo memberInfo)
+    {
+        return _generatorOptions.SupportNonNullableReferenceTypes
+            ? dataProperty.IsNullable && requiredAttribute == null && !memberInfo.IsNonNullableReferenceType()
+            : dataProperty.IsNullable && requiredAttribute == null;
     }
 
     private OpenApiSchema GenerateSchemaForParameter(
@@ -264,7 +279,7 @@ public class SchemaGenerator(
             case DataType.String:
                 {
                     schemaFactory = () => CreatePrimitiveSchema(dataContract);
-                    returnAsReference = dataContract.UnderlyingType.IsEnum && !_generatorOptions.UseInlineDefinitionsForEnums;
+                    returnAsReference = (Nullable.GetUnderlyingType(dataContract.UnderlyingType) ?? dataContract.UnderlyingType).IsEnum && !_generatorOptions.UseInlineDefinitionsForEnums;
                     break;
                 }
 
@@ -330,10 +345,19 @@ public class SchemaGenerator(
         }
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        if (dataContract.UnderlyingType.IsEnum)
+        var underlyingType = Nullable.GetUnderlyingType(dataContract.UnderlyingType) ?? dataContract.UnderlyingType;
+
+        if (underlyingType.IsEnum)
         {
-            schema.Enum = [.. dataContract.UnderlyingType.GetEnumValues()
-                .Cast<object>()
+            var enumValues = underlyingType.GetEnumValues().Cast<object>();
+
+            if (dataContract.UnderlyingType != underlyingType)
+            {
+                schema.Nullable = true;
+                enumValues = enumValues.Append(null);
+            }
+
+            schema.Enum = [.. enumValues
                 .Select(value => dataContract.JsonConverter(value))
                 .Distinct()
                 .Select(JsonModelFactory.CreateFromJson)];
@@ -440,9 +464,11 @@ public class SchemaGenerator(
                 continue;
             }
 
+            var memberType = dataProperty.IsNullable ? dataProperty.MemberType : (Nullable.GetUnderlyingType(dataProperty.MemberType) ?? dataProperty.MemberType);
+
             schema.Properties[dataProperty.Name] = (dataProperty.MemberInfo != null)
-                ? GenerateSchemaForMember(dataProperty.MemberType, schemaRepository, dataProperty.MemberInfo, dataProperty)
-                : GenerateSchemaForType(dataProperty.MemberType, schemaRepository);
+                ? GenerateSchemaForMember(memberType, schemaRepository, dataProperty.MemberInfo, dataProperty)
+                : GenerateSchemaForType(memberType, schemaRepository);
 
             var markNonNullableTypeAsRequired =
                 _generatorOptions.NonNullableReferenceTypesAsRequired &&

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -598,7 +598,7 @@ public class SwaggerGenerator(
 
         var schema = (type != null)
             ? GenerateSchema(
-                type,
+                isRequired ? (Nullable.GetUnderlyingType(type) ?? type) : type,
                 schemaRepository,
                 apiParameter.PropertyInfo(),
                 apiParameter.ParameterInfo(),

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -1491,7 +1491,7 @@
             "$ref": "#/components/schemas/ProductStatus"
           },
           "status2": {
-            "$ref": "#/components/schemas/ProductStatus"
+            "$ref": "#/components/schemas/ProductStatusNullable"
           }
         },
         "additionalProperties": false,
@@ -1510,6 +1510,17 @@
         ],
         "type": "integer",
         "format": "int32"
+      },
+      "ProductStatusNullable": {
+        "enum": [
+          0,
+          1,
+          2,
+          null
+        ],
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
       },
       "Promotion": {
         "type": "object",

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -1491,7 +1491,7 @@
             "$ref": "#/components/schemas/ProductStatus"
           },
           "status2": {
-            "$ref": "#/components/schemas/ProductStatus"
+            "$ref": "#/components/schemas/ProductStatusNullable"
           }
         },
         "additionalProperties": false,
@@ -1510,6 +1510,17 @@
         ],
         "type": "integer",
         "format": "int32"
+      },
+      "ProductStatusNullable": {
+        "enum": [
+          0,
+          1,
+          2,
+          null
+        ],
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
       },
       "Promotion": {
         "type": "object",

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=MvcWithNullable.Program_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=MvcWithNullable.Program_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -17,6 +17,33 @@
             "schema": {
               "allOf": [
                 {
+                  "$ref": "#/components/schemas/LogLevelNullable"
+                }
+              ],
+              "default": 4
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/RequiredEnum": {
+      "get": {
+        "tags": [
+          "RequiredEnum"
+        ],
+        "parameters": [
+          {
+            "name": "logLevel",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "allOf": [
+                {
                   "$ref": "#/components/schemas/LogLevel"
                 }
               ],
@@ -46,6 +73,21 @@
         ],
         "type": "integer",
         "format": "int32"
+      },
+      "LogLevelNullable": {
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          null
+        ],
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
       }
     }
   }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=MvcWithNullable.Program_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=MvcWithNullable.Program_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -17,6 +17,33 @@
             "schema": {
               "allOf": [
                 {
+                  "$ref": "#/components/schemas/LogLevelNullable"
+                }
+              ],
+              "default": 4
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/RequiredEnum": {
+      "get": {
+        "tags": [
+          "RequiredEnum"
+        ],
+        "parameters": [
+          {
+            "name": "logLevel",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "allOf": [
+                {
                   "$ref": "#/components/schemas/LogLevel"
                 }
               ],
@@ -46,6 +73,21 @@
         ],
         "type": "integer",
         "format": "int32"
+      },
+      "LogLevelNullable": {
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          null
+        ],
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
       }
     }
   }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -379,7 +379,7 @@
             "name": "paramNine",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/DateTimeKind"
+              "$ref": "#/components/schemas/DateTimeKindNullable"
             }
           },
           {
@@ -946,7 +946,7 @@
             "format": "time"
           },
           "paramNine": {
-            "$ref": "#/components/schemas/DateTimeKind"
+            "$ref": "#/components/schemas/DateTimeKindNullable"
           },
           "paramTen": {
             "$ref": "#/components/schemas/DateTimeKind"
@@ -994,6 +994,17 @@
         ],
         "type": "integer",
         "format": "int32"
+      },
+      "DateTimeKindNullable": {
+        "enum": [
+          0,
+          1,
+          2,
+          null
+        ],
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
       },
       "Fruit": {
         "type": "object",

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -379,7 +379,7 @@
             "name": "paramNine",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/DateTimeKind"
+              "$ref": "#/components/schemas/DateTimeKindNullable"
             }
           },
           {
@@ -946,7 +946,7 @@
             "format": "time"
           },
           "paramNine": {
-            "$ref": "#/components/schemas/DateTimeKind"
+            "$ref": "#/components/schemas/DateTimeKindNullable"
           },
           "paramTen": {
             "$ref": "#/components/schemas/DateTimeKind"
@@ -994,6 +994,17 @@
         ],
         "type": "integer",
         "format": "int32"
+      },
+      "DateTimeKindNullable": {
+        "enum": [
+          0,
+          1,
+          2,
+          null
+        ],
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
       },
       "Fruit": {
         "type": "object",

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.TypesAreRenderedCorrectly.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.TypesAreRenderedCorrectly.DotNet8_0.verified.txt
@@ -379,7 +379,7 @@
             "name": "paramNine",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/DateTimeKind"
+              "$ref": "#/components/schemas/DateTimeKindNullable"
             }
           },
           {
@@ -946,7 +946,7 @@
             "format": "time"
           },
           "paramNine": {
-            "$ref": "#/components/schemas/DateTimeKind"
+            "$ref": "#/components/schemas/DateTimeKindNullable"
           },
           "paramTen": {
             "$ref": "#/components/schemas/DateTimeKind"
@@ -994,6 +994,17 @@
         ],
         "type": "integer",
         "format": "int32"
+      },
+      "DateTimeKindNullable": {
+        "enum": [
+          0,
+          1,
+          2,
+          null
+        ],
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
       },
       "Fruit": {
         "type": "object",

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.TypesAreRenderedCorrectly.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.TypesAreRenderedCorrectly.DotNet9_0.verified.txt
@@ -379,7 +379,7 @@
             "name": "paramNine",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/DateTimeKind"
+              "$ref": "#/components/schemas/DateTimeKindNullable"
             }
           },
           {
@@ -946,7 +946,7 @@
             "format": "time"
           },
           "paramNine": {
-            "$ref": "#/components/schemas/DateTimeKind"
+            "$ref": "#/components/schemas/DateTimeKindNullable"
           },
           "paramTen": {
             "$ref": "#/components/schemas/DateTimeKind"
@@ -994,6 +994,17 @@
         ],
         "type": "integer",
         "format": "int32"
+      },
+      "DateTimeKindNullable": {
+        "enum": [
+          0,
+          1,
+          2,
+          null
+        ],
+        "type": "integer",
+        "format": "int32",
+        "nullable": true
       },
       "Fruit": {
         "type": "object",

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/JsonPropertyAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/JsonPropertyAnnotatedType.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.Serialization;
 using Newtonsoft.Json;
+using Swashbuckle.AspNetCore.TestSupport;
 
 namespace Swashbuckle.AspNetCore.Newtonsoft.Test;
 
@@ -31,4 +32,16 @@ public class JsonPropertyAnnotatedType
     [DataMember(IsRequired = true)] //As the support for DataMember has been implemented later, JsonProperty.Required should take precedence
     [JsonProperty(Required = Required.Default)]
     public string StringWithRequiredDefaultButConflictingDataMember { get; set; }
+
+    [JsonProperty(Required = Required.Default)]
+    public IntEnum? IntEnumWithRequiredDefault { get; set; }
+
+    [JsonProperty(Required = Required.DisallowNull)]
+    public IntEnum? IntEnumWithRequiredDisallowNull { get; set; }
+
+    [JsonProperty(Required = Required.Always)]
+    public IntEnum? IntEnumWithRequiredAlways { get; set; }
+
+    [JsonProperty(Required = Required.AllowNull)]
+    public IntEnum? IntEnumWithRequiredAllowNull { get; set; }
 }

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/JsonRequiredAnnotatedType.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/Fixtures/JsonRequiredAnnotatedType.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.Serialization;
 using Newtonsoft.Json;
+using Swashbuckle.AspNetCore.TestSupport;
 
 namespace Swashbuckle.AspNetCore.Newtonsoft.Test;
 
@@ -12,4 +13,10 @@ public class JsonRequiredAnnotatedType
     [DataMember(IsRequired = false)] //As the support for DataMember has been implemented later, JsonRequired should take precedence
     [JsonRequired]
     public string StringWithConflictingRequired { get; set; }
+
+    [JsonRequired]
+    public IntEnum IntEnumWithRequired { get; set; }
+
+    [JsonRequired]
+    public IntEnum? NullableIntEnumWithRequired { get; set; }
 }

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -287,35 +287,28 @@ public class NewtonsoftSchemaGeneratorTests
         Assert.Equal(expectedNullable, schema.Properties[propertyName].Nullable);
     }
 
-    [Theory]
-    [InlineData(typeof(TypeWithNullableProperties), nameof(TypeWithNullableProperties.NullableIntEnumProperty), false)]
-    public void GenerateSchema_DoesNotSetNullableFlag_IfReferencedEnum(
-        Type declaringType,
-        string propertyName,
-        bool expectedNullable)
+    [Fact]
+    public void GenerateSchema_DoesNotSetNullableFlag_IfReferencedEnum()
     {
         var schemaRepository = new SchemaRepository();
 
-        var referenceSchema = Subject().GenerateSchema(declaringType, schemaRepository);
+        var referenceSchema = Subject().GenerateSchema(typeof(TypeWithNullableProperties), schemaRepository);
 
         var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-        Assert.Equal(expectedNullable, schema.Properties[propertyName].Nullable);
+        const string propertyName = nameof(TypeWithNullableProperties.NullableIntEnumProperty);
+        Assert.False(schema.Properties[propertyName].Nullable);
         Assert.Equal("IntEnumNullable", schema.Properties[propertyName].Reference.Id);
     }
 
-    [Theory]
-    [InlineData(typeof(TypeWithNullableProperties), nameof(TypeWithNullableProperties.NullableIntEnumProperty), true)]
-    public void GenerateSchema_SetNullableFlag_IfInlineEnum(
-        Type declaringType,
-        string propertyName,
-        bool expectedNullable)
+    [Fact]
+    public void GenerateSchema_SetNullableFlag_IfInlineEnum()
     {
         var schemaRepository = new SchemaRepository();
 
-        var referenceSchema = Subject(o => o.UseInlineDefinitionsForEnums = true).GenerateSchema(declaringType, schemaRepository);
+        var referenceSchema = Subject(o => o.UseInlineDefinitionsForEnums = true).GenerateSchema(typeof(TypeWithNullableProperties), schemaRepository);
 
         var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
-        Assert.Equal(expectedNullable, schema.Properties[propertyName].Nullable);
+        Assert.True(schema.Properties[nameof(TypeWithNullableProperties.NullableIntEnumProperty)].Nullable);
     }
 
     [Theory]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -89,13 +89,14 @@ public class JsonSerializerSchemaGeneratorTests
     }
 
     [Theory]
-    [InlineData(typeof(IntEnum), "int32", "2", "4", "8")]
-    [InlineData(typeof(LongEnum), "int64", "2", "4", "8")]
-    [InlineData(typeof(IntEnum?), "int32", "2", "4", "8")]
-    [InlineData(typeof(LongEnum?), "int64", "2", "4", "8")]
+    [InlineData(typeof(IntEnum), "int32", false, "2", "4", "8")]
+    [InlineData(typeof(LongEnum), "int64", false, "2", "4", "8")]
+    [InlineData(typeof(IntEnum?), "int32", true, "2", "4", "8", "null")]
+    [InlineData(typeof(LongEnum?), "int64", true, "2", "4", "8", "null")]
     public void GenerateSchema_GeneratesReferencedEnumSchema_IfEnumOrNullableEnumType(
         Type type,
         string expectedFormat,
+        bool expectedNullable,
         params string[] expectedEnumAsJson)
     {
         var schemaRepository = new SchemaRepository();
@@ -106,6 +107,7 @@ public class JsonSerializerSchemaGeneratorTests
         var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
         Assert.Equal(JsonSchemaTypes.Integer, schema.Type);
         Assert.Equal(expectedFormat, schema.Format);
+        Assert.Equal(expectedNullable, schema.Nullable);
         Assert.NotNull(schema.Enum);
         Assert.Equal(expectedEnumAsJson, schema.Enum.Select(openApiAny => openApiAny.ToJson()));
     }
@@ -387,7 +389,7 @@ public class JsonSerializerSchemaGeneratorTests
         Assert.False(schema.Properties["StringWithRequired"].Nullable);
         Assert.False(schema.Properties["StringWithRequiredAllowEmptyTrue"].Nullable);
         Assert.Null(schema.Properties["StringWithRequiredAllowEmptyTrue"].MinLength);
-        Assert.Equal(["StringWithRequired", "StringWithRequiredAllowEmptyTrue"], schema.Required);
+        Assert.Equal(["NullableIntEnumWithRequired", "StringWithRequired", "StringWithRequiredAllowEmptyTrue"], schema.Required);
         Assert.Equal("Description", schema.Properties[nameof(TypeWithValidationAttributes.StringWithDescription)].Description);
         Assert.True(schema.Properties[nameof(TypeWithValidationAttributes.StringWithReadOnly)].ReadOnly);
     }

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableProperties.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithNullableProperties.cs
@@ -7,4 +7,6 @@ public class TypeWithNullableProperties
     public string StringProperty { get; set; }
 
     public int? NullableIntProperty { get; set; }
+
+    public IntEnum? NullableIntEnumProperty { get; set; }
 }

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributes.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributes.cs
@@ -50,4 +50,7 @@ public class TypeWithValidationAttributes
 
     [ReadOnly(true)]
     public string StringWithReadOnly { get; set; }
+
+    [Required]
+    public IntEnum? NullableIntEnumWithRequired { get; set; }
 }

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributesViaMetadataType.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributesViaMetadataType.cs
@@ -38,6 +38,8 @@ public class TypeWithValidationAttributesViaMetadataType
     public string StringWithDescription { get; set; }
 
     public string StringWithReadOnly { get; set; }
+
+    public IntEnum? NullableIntEnumWithRequired { get; set; }
 }
 
 public class MetadataType
@@ -87,4 +89,7 @@ public class MetadataType
 
     [ReadOnly(true)]
     public string StringWithReadOnly { get; set; }
+
+    [Required]
+    public IntEnum? NullableIntEnumWithRequired { get; set; }
 }

--- a/test/WebSites/MvcWithNullable/Program.cs
+++ b/test/WebSites/MvcWithNullable/Program.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -29,6 +30,14 @@ public class EnumController : ControllerBase
 {
     [HttpGet]
     public IActionResult Get(LogLevel? logLevel = LogLevel.Error) => Ok(new { logLevel });
+}
+
+[ApiController]
+[Route("api/[controller]")]
+public class RequiredEnumController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get([Required] LogLevel? logLevel = LogLevel.Error) => Ok(new { logLevel });
 }
 
 namespace MvcWithNullable


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

Fixes https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3225

<!-- Please include the existing GitHub issue number where relevant, e.g. "Fixes #123" -->

## Details on the issue fix or feature implementation

This makes changes to the data contract resolvers so that the nullability of enums comes through with the type information.

From there we can ensure that we can set nullable to true and append null as a possible value.

As the values are different there are two different schemas that get built, one which contains the null value, and one that doesn't.

This does mean however that other sections of code now also need to handle nullable types.

Anywhere that does checks if a type is an enum.
Checking for properties that are nullable but have either `Required`, `JsonRequired` or `JsonProperty` with required set.
Checking for required parameters.

<!-- Information about your changes -->
