### PR TITLE
Emit annotation for packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ jobs:
     outputs:
       dotnet-sdk-version: ${{ steps.setup-dotnet.outputs.dotnet-version }}
       dotnet-validate-version: ${{ steps.get-dotnet-tools-versions.outputs.dotnet-validate-version }}
+      package-names: ${{ steps.build.outputs.package-names }}
+      package-version: ${{ steps.build.outputs.package-version }}
 
     permissions:
       attestations: write
@@ -68,7 +70,6 @@ jobs:
       uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         dotnet-version: |
-          6.0.x
           8.0.x
           9.0.x
 
@@ -84,6 +85,7 @@ jobs:
         restore-keys: ${{ runner.os }}-nuget-
 
     - name: Build, Package and Test
+      id: build
       shell: pwsh
       run: |
         ./build.ps1
@@ -195,8 +197,11 @@ jobs:
         dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: Push NuGet packages to MyGet.org
-      run: |
-        dotnet nuget push "*.nupkg" --api-key ${{ secrets.MYGET_TOKEN }} --skip-duplicate --source https://www.myget.org/F/domaindrivendev/api/v2
+      env:
+        API_KEY: ${{ secrets.MYGET_TOKEN }}
+        PACKAGE_VERSION: ${{ needs.build.outputs.package-version }}
+        SOURCE: "https://www.myget.org/F/domaindrivendev/api/v2"
+      run: dotnet nuget push "*.nupkg" --api-key "${API_KEY}" --skip-duplicate --source "${SOURCE}" && echo "::notice title=myget.org::Published version ${PACKAGE_VERSION} to MyGet."
 
   publish-nuget:
     needs: [ build, validate-packages ]
@@ -222,5 +227,8 @@ jobs:
         dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: Push NuGet packages to NuGet.org
-      run: |
-        dotnet nuget push "*.nupkg" --api-key ${{ secrets.NUGET_TOKEN }} --skip-duplicate --source https://api.nuget.org/v3/index.json
+      env:
+        API_KEY: ${{ secrets.NUGET_TOKEN }}
+        PACKAGE_VERSION: ${{ needs.build.outputs.package-version }}
+        SOURCE: https://api.nuget.org/v3/index.json
+      run: dotnet nuget push "*.nupkg" --api-key "${API_KEY}" --skip-duplicate --source "${SOURCE}" && echo "::notice title=nuget.org::Published version ${PACKAGE_VERSION} to NuGet.org."

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -62,4 +62,24 @@
     </PropertyGroup>
     <WriteLinesToFileWithRetry Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' AND Exists('$(ReportGeneratorMarkdownSummary)') " ContinueOnError="WarnAndContinue" File="$(GITHUB_STEP_SUMMARY)" Lines="$(_ReportSummaryContent)" />
   </Target>
+  <Target Name="SetNuGetPackageOutputs" AfterTargets="Pack" Condition=" '$(GITHUB_OUTPUT)' != '' ">
+    <PropertyGroup>
+      <_PackageNamesPath>$(ArtifactsPath)\package-names.txt</_PackageNamesPath>
+    </PropertyGroup>
+    <ReadLinesFromFile File="$(_PackageNamesPath)">
+      <Output TaskParameter="Lines" ItemName="_PackageNames" />
+    </ReadLinesFromFile>
+    <ItemGroup>
+      <_PackageNames Include="$(PackageId)" />
+    </ItemGroup>
+    <RemoveDuplicates Inputs="@(_PackageNames)">
+      <Output TaskParameter="Filtered" ItemName="_UniquePackageNames" />
+    </RemoveDuplicates>
+    <PropertyGroup>
+      <_UniquePackageNames>@(_UniquePackageNames->'%(Identity)', ',')</_UniquePackageNames>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(_PackageNamesPath)" Lines="@(_UniquePackageNames)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+    <WriteLinesToFile File="$(GITHUB_OUTPUT)" Lines="package-names=$(_UniquePackageNames)" />
+    <WriteLinesToFile File="$(GITHUB_OUTPUT)" Lines="package-version=$(Version)" />
+  </Target>
 </Project>


### PR DESCRIPTION
- Emit an annotation containing the NuGet package versions when publishing.
- Stop installing the .NET 6 SDK.
