### PR TITLE
Using GZip to compress swagger-ui-dist files in embedded resource to reduce the output dll size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-[Oo]bj/
+﻿[Oo]bj/
 [Bb]in/
+[Tt]est[Rr]esult*/
 .vs/
 .idea*
 BenchmarkDotNet.Artifacts*/

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <ItemGroup>
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
@@ -29,6 +29,7 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.4.0" />
     <PackageVersion Include="ReportGenerator" Version="5.4.4" />
+    <PackageVersion Include="ResourceCompressor" Version="1.0.1" />
     <PackageVersion Include="System.Text.Json" Version="4.6.0" />
     <PackageVersion Include="Verify.XunitV3" Version="29.3.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/GZipCompressedEmbeddedFileProvider.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/GZipCompressedEmbeddedFileProvider.cs
@@ -1,0 +1,143 @@
+﻿using System.Buffers;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.IO.Compression;
+using System.Reflection;
+
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Primitives;
+
+namespace Swashbuckle.AspNetCore.SwaggerUI;
+
+/// <summary>
+/// a <see cref="EmbeddedFileProvider"/> wrapper to provider gzip decompressed resource file info
+/// </summary>
+/// <param name="assembly"></param>
+/// <param name="baseNamespace"></param>
+internal sealed class GZipCompressedEmbeddedFileProvider(Assembly assembly, string baseNamespace) : IFileProvider
+{
+    private readonly string _baseNamespace = string.IsNullOrEmpty(baseNamespace) ? string.Empty : baseNamespace + ".";
+
+    private readonly EmbeddedFileProvider _embeddedFileProvider = new(assembly, baseNamespace);
+
+    private readonly ConcurrentDictionary<string, long> _subpathLengthCache = new(StringComparer.Ordinal);
+
+    /// <inheritdoc/>
+    public IDirectoryContents GetDirectoryContents(string subpath)
+    {
+        //logic same as EmbeddedFileProvider
+        return subpath?.Length == 0 || string.Equals(subpath, "/", StringComparison.Ordinal)
+               ? new DecompresDirectoryContents(EnumerateItems().ToList())
+               : new DecompresDirectoryContents([]);
+    }
+
+    /// <inheritdoc/>
+    public IFileInfo GetFileInfo(string subpath) => new GZipDecompresFileInfoWrapper(_embeddedFileProvider.GetFileInfo(subpath), subpath, GetSubpathDecompressedLength);
+
+    /// <inheritdoc/>
+    public IChangeToken Watch(string filter) => _embeddedFileProvider.Watch(filter);
+
+    private static string NormalizeSubPath(string subpath) => string.Join(".", subpath.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries).Where(m => !string.IsNullOrWhiteSpace(m)));
+
+    /// <summary>
+    /// Get the <paramref name="stream"/>'s length by decompress and read it
+    /// </summary>
+    /// <param name="stream"></param>
+    /// <returns></returns>
+    private static long ReadStreamDecompressedLength(Stream stream)
+    {
+        const int BufferSize = 4096;
+
+        long length = 0;
+        var buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
+
+        try
+        {
+            using var gzipStream = new GZipStream(stream, CompressionMode.Decompress, true);
+            var readLength = 0;
+            do
+            {
+                readLength = gzipStream.Read(buffer, 0, BufferSize);
+                length += readLength;
+            } while (readLength != 0);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+        return length;
+    }
+
+    private IEnumerable<IFileInfo> EnumerateItems()
+    {
+        return assembly.GetManifestResourceNames()
+                       .Where(name => name.StartsWith(_baseNamespace))
+                       .Select(name => name.Substring(_baseNamespace.Length))
+                       .Select(subpath => this.GetFileInfo(subpath))
+                       .Where(static fileInfo => fileInfo.Exists);
+    }
+
+    /// <summary>
+    /// Get <paramref name="subpath"/>'s decompressed length and cache it
+    /// </summary>
+    /// <param name="subpath"></param>
+    /// <returns></returns>
+    private long GetSubpathDecompressedLength(string subpath)
+    {
+        if (_subpathLengthCache.TryGetValue(subpath, out var length))
+        {
+            return length;
+        }
+
+        var resourceName = $"{_baseNamespace}{NormalizeSubPath(subpath)}";
+
+        using var stream = assembly.GetManifestResourceStream(resourceName);
+        if (stream == null)
+        {
+            return -1;
+        }
+
+        return _subpathLengthCache.GetOrAdd(subpath, _ => ReadStreamDecompressedLength(stream));
+    }
+
+    private sealed class DecompresDirectoryContents(List<IFileInfo> fileInfos) : IDirectoryContents
+    {
+        /// <inheritdoc/>
+        public bool Exists => fileInfos.Count > 0;
+
+        /// <inheritdoc/>
+        public IEnumerator<IFileInfo> GetEnumerator() => fileInfos.GetEnumerator();
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class GZipDecompresFileInfoWrapper(IFileInfo fileInfo, string subpath, Func<string, long> getSubpathLengthFunc) : IFileInfo
+    {
+        /// <inheritdoc/>
+        public bool Exists => fileInfo.Exists;
+
+        /// <inheritdoc/>
+        public bool IsDirectory => fileInfo.IsDirectory;
+
+        /// <inheritdoc/>
+        public DateTimeOffset LastModified => fileInfo.LastModified;
+
+        /// <inheritdoc/>
+        public long Length => fileInfo.Exists ? getSubpathLengthFunc(subpath) : -1;
+
+        /// <inheritdoc/>
+        public string Name => fileInfo.Name;
+
+        /// <inheritdoc/>
+        public string PhysicalPath => fileInfo.PhysicalPath;
+
+        /// <inheritdoc/>
+        public Stream CreateReadStream()
+        {
+            return fileInfo.CreateReadStream() is { } stream
+                   ? new GZipStream(stream, CompressionMode.Decompress)
+                   : throw new FileNotFoundException(message: null, fileName: fileInfo.Name);
+        }
+    }
+}

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -4,7 +4,6 @@ using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.StaticFiles;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Reflection;
@@ -110,7 +109,7 @@ internal sealed partial class SwaggerUIMiddleware
         var staticFileOptions = new StaticFileOptions
         {
             RequestPath = string.IsNullOrEmpty(options.RoutePrefix) ? string.Empty : $"/{options.RoutePrefix}",
-            FileProvider = new EmbeddedFileProvider(typeof(SwaggerUIMiddleware).Assembly, EmbeddedFileNamespace),
+            FileProvider = new GZipCompressedEmbeddedFileProvider(typeof(SwaggerUIMiddleware).Assembly, EmbeddedFileNamespace),
             OnPrepareResponse = (context) => SetCacheHeaders(context.Context.Response, options),
         };
 

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/Swashbuckle.AspNetCore.SwaggerUI.csproj
@@ -16,7 +16,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="node_modules/swagger-ui-dist/**/*" Exclude="**/*/index.html;**/*/*.map;**/*/*.json;**/*/*.md;**/*/swagger-ui-es-*" />
+    <InternalsVisibleTo Include="Swashbuckle.AspNetCore.IntegrationTests" Key="00240000048000009400000006020000002400005253413100040000010001000b80d002f0437a94c4f6d77dfc29ce54df1040f66374cb7122ec5ddab3907a6dfe609a07ffd49b9aa6731fe3f8de4da7979ddea73e949c86effc4bec3f469cc36e788cf58c42c4be755efd1afd996ccab9f0db3455b834219f6614d00fe0410cc307c4eced320fd65fcc501f135dc537d7d09dcc1d2a572d24f8459a86469ec5" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <CompressedEmbeddedResource Include="node_modules/swagger-ui-dist/**/*" Exclude="**/*/index.html;**/*/*.map;**/*/*.json;**/*/*.md;**/*/swagger-ui-es-*" GeneratedFileSuffix="None" />
     <None Remove="index.html;index.js" />
     <EmbeddedResource Include="index.html;index.js" />
   </ItemGroup>
@@ -34,6 +38,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="All" />
+    <PackageReference Include="ResourceCompressor">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <AdditionalFiles Include="PublicAPI\PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI\PublicAPI.Unshipped.txt" />
   </ItemGroup>

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -1,4 +1,6 @@
 ﻿using System.Net;
+using Microsoft.Extensions.FileProviders;
+using Swashbuckle.AspNetCore.SwaggerUI;
 
 namespace Swashbuckle.AspNetCore.IntegrationTests;
 
@@ -21,6 +23,82 @@ public class SwaggerUIIntegrationTests
 
         Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
         Assert.Equal(expectedRedirectPath, response.Headers.Location.ToString());
+    }
+
+    [Theory]
+    [InlineData("Swashbuckle.AspNetCore.SwaggerUI.node_modules")]
+    [InlineData("Swashbuckle.AspNetCore.SwaggerUI.node_modules.swagger_ui_dist")]
+    public void ResourceRead_CompressedEmbeddedFileProvider(string baseNamespace)
+    {
+        //confirm that GZipCompressedEmbeddedFileProvider is the same as EmbeddedFileProvider
+        var provider = new EmbeddedFileProvider(typeof(SwaggerUIOptions).Assembly, baseNamespace);
+        var compressedProvider = new GZipCompressedEmbeddedFileProvider(typeof(SwaggerUIOptions).Assembly, baseNamespace);
+        var checkSubpaths = new string[]
+        {
+            "/",
+            null,
+            string.Empty,
+            " ",
+            "\t",
+            "\n",
+            "/swagger_ui_dist",
+            "swagger_ui_dist",
+            "/nodir",
+            "nodir"
+        };
+
+        foreach (var subpath in checkSubpaths)
+        {
+            AssertResources(provider, compressedProvider, subpath);
+        }
+
+        var nonExistentFile = Guid.NewGuid().ToString();
+        AssertFileInfo(provider.GetFileInfo(nonExistentFile), compressedProvider.GetFileInfo(nonExistentFile));
+
+        static void AssertResources(IFileProvider expectedProvider, IFileProvider actualProvider, string subpath)
+        {
+            var expectedContents = expectedProvider.GetDirectoryContents(subpath);
+            var actualContents = actualProvider.GetDirectoryContents(subpath);
+
+            Assert.Equal(expectedContents.Exists, actualContents.Exists);
+            Assert.Equal(expectedContents.Count(), actualContents.Count());
+            var actualResourceMap = actualContents.ToDictionary(m => m.Name);
+
+            foreach (var expectedFileInfo in expectedContents)
+            {
+                Assert.True(actualResourceMap.TryGetValue(expectedFileInfo.Name, out var actualFileInfo));
+                Assert.NotNull(actualFileInfo);
+                Assert.True(actualFileInfo.Exists);
+                AssertFileInfo(expectedFileInfo, actualFileInfo);
+                AssertFileInfo(expectedProvider.GetFileInfo(expectedFileInfo.Name), actualProvider.GetFileInfo(expectedFileInfo.Name));
+            }
+        }
+
+        static void AssertFileInfo(IFileInfo expectedFileInfo, IFileInfo actualFileInfo)
+        {
+            Assert.Equal(expectedFileInfo.Exists, actualFileInfo.Exists);
+            Assert.Equal(expectedFileInfo.IsDirectory, actualFileInfo.IsDirectory);
+            Assert.Equal(expectedFileInfo.LastModified, actualFileInfo.LastModified);
+            Assert.Equal(expectedFileInfo.PhysicalPath, actualFileInfo.PhysicalPath);
+
+            if (expectedFileInfo.Exists && !expectedFileInfo.IsDirectory)
+            {
+                Assert.True(actualFileInfo.Length > 0);
+
+                using var stream = actualFileInfo.CreateReadStream();
+                Assert.NotNull(stream);
+                var buffer = new byte[256];
+                var readLength = stream.Read(buffer, 0, buffer.Length);
+                Assert.True(readLength > 0);
+                //we can check for correctness here
+            }
+            else
+            {
+                Assert.Equal(expectedFileInfo.Length, actualFileInfo.Length);
+                Assert.ThrowsAny<FileNotFoundException>(() => expectedFileInfo.CreateReadStream());
+                Assert.ThrowsAny<FileNotFoundException>(() => actualFileInfo.CreateReadStream());
+            }
+        }
     }
 
     [Theory]


### PR DESCRIPTION
Using GZip to compress swagger-ui-dist files in embedded resource to reduce the output dll size

<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

No

## Details on the issue fix or feature implementation

Using gzip to compress the `swagger-ui-dist` at build time. And decompress it before response it.
This change can compress the size of the `Swashbuckle.AspNetCore.SwaggerUI.dll` from 2259k to 682k.
