### PR TITLE
[Docs] Improve the formatting of documentation files

### DIFF
--- a/docs/configure-and-customize-annotations.md
+++ b/docs/configure-and-customize-annotations.md
@@ -12,11 +12,10 @@
 2. In the `ConfigureServices` method of `Startup.cs`, enable annotations within in the Swagger config block:
 
     ```csharp
-    services.AddSwaggerGen(c =>
+    services.AddSwaggerGen(options =>
     {
-       ...
-
-       c.EnableAnnotations();
+        ...
+        options.EnableAnnotations();
     });
     ```
 
@@ -26,7 +25,6 @@ Once annotations have been enabled, you can enrich the generated Operation metad
 
 ```csharp
 [HttpPost]
-
 [SwaggerOperation(
     Summary = "Creates a new product",
     Description = "Requires admin privileges",
@@ -38,7 +36,7 @@ public IActionResult Create([FromBody]Product product)
 
 ## Enrich Response Metadata
 
-ASP.NET Core provides the `ProducesResponseTypeAttribute` for listing the different responses that can be returned by an action. These attributes can be combined with XML comments, as described [above](#include-descriptions-from-xml-comments), to include human friendly descriptions with each response in the generated Swagger. If you'd prefer to do all of this with a single attribute, and avoid the use of XML comments, you can use `SwaggerResponseAttribute`s instead:
+ASP.NET Core provides the `ProducesResponseTypeAttribute` for listing the different responses that can be returned by an action. These attributes can be combined with XML comments, as described [here](configure-and-customize-swaggergen.md#include-descriptions-from-xml-comments), to include human friendly descriptions with each response in the generated Swagger. If you'd prefer to do all of this with a single attribute, and avoid the use of XML comments, you can use `SwaggerResponseAttribute`s instead:
 
 ```csharp
 [HttpPost]
@@ -86,21 +84,24 @@ public class Product
 }
 ```
 
-_NOTE: In Swagger / OpenAPI, serialized objects AND contained properties are represented as `Schema` instances, hence why this annotation can be applied to both classes and properties. Also worth noting, "required" properties are specified as an array of property names on the top-level schema as opposed to a flag on each individual property._
+> [!NOTE]
+> In Swagger / OpenAPI, serialized objects AND contained properties are represented as `Schema` instances, hence why this annotation can be applied to both classes and properties. Also worth noting, "required" properties are specified as an array of property names on the top-level schema as opposed to a flag on each individual property.
 
 ## Apply Schema Filters to Specific Types
 
-The `SwaggerGen` package provides several extension points, including Schema Filters ([described here](#extend-generator-with-operation-schema--document-filter)) for customizing ALL generated Schemas. However, there may be cases where it's preferable to apply a filter to a specific Schema. For example, if you'd like to include an example for a specific type in your API. This can be done by decorating the type with a `SwaggerSchemaFilterAttribute`:
+The `SwaggerGen` package provides several extension points, including Schema Filters (described [here](configure-and-customize-swaggergen.md#extend-generator-with-operation-schema--document-filter)) for customizing ALL generated Schemas. However, there may be cases where it's preferable to apply a filter to a specific Schema. For example, if you'd like to include an example for a specific type in your API. This can be done by decorating the type with a `SwaggerSchemaFilterAttribute`:
 
+Product.cs
 ```csharp
-// Product.cs
 [SwaggerSchemaFilter(typeof(ProductSchemaFilter))]
 public class Product
 {
     ...
 }
+```
 
-// ProductSchemaFilter.cs
+ProductSchemaFilter.cs
+```csharp
 public class ProductSchemaFilter : ISchemaFilter
 {
     public void Apply(OpenApiSchema schema, SchemaFilterContext context)
@@ -126,21 +127,23 @@ public class ProductsController
 }
 ```
 
-_NOTE: This will add the above description specifically to the tag named "Products". Therefore, you should avoid using this attribute if you're tagging Operations with something other than controller name - e.g. if you're customizing the tagging behavior with `TagActionsBy`._
+> [!NOTE] 
+> This will add the above description specifically to the tag named "Products". Therefore, you should avoid using this attribute if you're tagging Operations with something other than controller name - e.g. if you're customizing the tagging behavior with `TagActionsBy`.
 
 ## List Known Subtypes for Inheritance and Polymorphism
 
-If you want to use Swashbuckle's [inheritance and/or polymorphism behavior](#inheritance-and-polymorphism), you can use annotations to _explicitly_ indicate the "known" subtypes for a given base type. This will override the default selector function, which selects _all_ subtypes in the same assembly as the base type, and therefore needs to be explicitly enabled when you enable Annotations:
+If you want to use Swashbuckle's [inheritance and/or polymorphism behavior](configure-and-customize-swaggergen.md#inheritance-and-polymorphism), you can use annotations to _explicitly_ indicate the "known" subtypes for a given base type. This will override the default selector function, which selects _all_ subtypes in the same assembly as the base type, and therefore needs to be explicitly enabled when you enable Annotations:
 
+Startup.cs
 ```csharp
-// Startup.cs
-services.AddSwaggerGen(c =>
+services.AddSwaggerGen(options =>
 {
-    c.EnableAnnotations(enableAnnotationsForInheritance: true, enableAnnotationsForPolymorphism: true);
+    options.EnableAnnotations(enableAnnotationsForInheritance: true, enableAnnotationsForPolymorphism: true);
 });
+```
 
-// Shape.cs
-
+Shape.cs
+```csharp
 // .NET 7 or later
 [JsonDerivedType(typeof(Rectangle))]
 [JsonDerivedType(typeof(Circle))]
@@ -160,16 +163,16 @@ public abstract class Shape
 
 If you're using annotations to _explicitly_ indicate the "known" subtypes for a polymorphic base type, you can combine the `JsonPolymorphicAttribute` with the `JsonDerivedTypeAttribute` to provide additional metadata about the "discriminator" property, which will then be incorporated into the generated schema definition:
 
-
+Startup.cs
 ```csharp
-// Startup.cs
-services.AddSwaggerGen(c =>
+services.AddSwaggerGen(options =>
 {
-    c.EnableAnnotations(enableAnnotationsForInheritance: true, enableAnnotationsForPolymorphism: true);
+    options.EnableAnnotations(enableAnnotationsForInheritance: true, enableAnnotationsForPolymorphism: true);
 });
+```
 
-// Shape.cs
-
+Shape.cs
+```csharp
 // .NET 7 or later
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "shapeType")]
 [JsonDerivedType(typeof(Rectangle), "rectangle")]
@@ -200,7 +203,7 @@ public enum ShapeType
 
 This indicates that the corresponding payload will have a "shapeType" property to discriminate between subtypes, and that property will have a value of "rectangle" if the payload represents a `Rectangle` type and a value of "circle" if it represents a `Circle` type. This detail will be described in the generated schema definition as follows:
 
-```
+```yaml
 schema: {
   oneOf: [
     {

--- a/docs/configure-and-customize-annotations.md
+++ b/docs/configure-and-customize-annotations.md
@@ -14,7 +14,7 @@
     ```csharp
     services.AddSwaggerGen(options =>
     {
-        ...
+        //...
         options.EnableAnnotations();
     });
     ```
@@ -91,16 +91,16 @@ public class Product
 
 The `SwaggerGen` package provides several extension points, including Schema Filters (described [here](configure-and-customize-swaggergen.md#extend-generator-with-operation-schema--document-filter)) for customizing ALL generated Schemas. However, there may be cases where it's preferable to apply a filter to a specific Schema. For example, if you'd like to include an example for a specific type in your API. This can be done by decorating the type with a `SwaggerSchemaFilterAttribute`:
 
-Product.cs
+📝 `Product.cs`
 ```csharp
 [SwaggerSchemaFilter(typeof(ProductSchemaFilter))]
 public class Product
 {
-    ...
+    //...
 }
 ```
 
-ProductSchemaFilter.cs
+📝 `ProductSchemaFilter.cs`
 ```csharp
 public class ProductSchemaFilter : ISchemaFilter
 {
@@ -123,7 +123,7 @@ By default, the Swagger generator will tag all operations with the controller na
 [SwaggerTag("Create, read, update and delete Products")]
 public class ProductsController
 {
-    ...
+    //...
 }
 ```
 
@@ -134,7 +134,7 @@ public class ProductsController
 
 If you want to use Swashbuckle's [inheritance and/or polymorphism behavior](configure-and-customize-swaggergen.md#inheritance-and-polymorphism), you can use annotations to _explicitly_ indicate the "known" subtypes for a given base type. This will override the default selector function, which selects _all_ subtypes in the same assembly as the base type, and therefore needs to be explicitly enabled when you enable Annotations:
 
-Startup.cs
+📝 `Startup.cs`
 ```csharp
 services.AddSwaggerGen(options =>
 {
@@ -142,7 +142,7 @@ services.AddSwaggerGen(options =>
 });
 ```
 
-Shape.cs
+📝 `Shape.cs`
 ```csharp
 // .NET 7 or later
 [JsonDerivedType(typeof(Rectangle))]
@@ -163,7 +163,7 @@ public abstract class Shape
 
 If you're using annotations to _explicitly_ indicate the "known" subtypes for a polymorphic base type, you can combine the `JsonPolymorphicAttribute` with the `JsonDerivedTypeAttribute` to provide additional metadata about the "discriminator" property, which will then be incorporated into the generated schema definition:
 
-Startup.cs
+📝 `Startup.cs`
 ```csharp
 services.AddSwaggerGen(options =>
 {
@@ -171,7 +171,7 @@ services.AddSwaggerGen(options =>
 });
 ```
 
-Shape.cs
+📝 `Shape.cs`
 ```csharp
 // .NET 7 or later
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "shapeType")]

--- a/docs/configure-and-customize-annotations.md
+++ b/docs/configure-and-customize-annotations.md
@@ -89,7 +89,7 @@ public class Product
 
 ## Apply Schema Filters to Specific Types
 
-The `SwaggerGen` package provides several extension points, including Schema Filters (described [here](configure-and-customize-swaggergen.md#extend-generator-with-operation-schema--document-filter)) for customizing ALL generated Schemas. However, there may be cases where it's preferable to apply a filter to a specific Schema. For example, if you'd like to include an example for a specific type in your API. This can be done by decorating the type with a `SwaggerSchemaFilterAttribute`:
+The `SwaggerGen` package provides several extension points, including Schema Filters (described [here](configure-and-customize-swaggergen.md#extend-generator-with-operation-schema--document-filter)) for customizing **all** generated Schemas. However, there may be cases where it's preferable to apply a filter to a specific Schema. For example, if you'd like to include an example for a specific type in your API. This can be done by decorating the type with a `SwaggerSchemaFilterAttribute`:
 
 📝 `Product.cs`
 ```csharp

--- a/docs/configure-and-customize-cli.md
+++ b/docs/configure-and-customize-cli.md
@@ -2,11 +2,12 @@
 
 ## Retrieve Swagger Directly from a Startup Assembly 
 
-Once your application has been setup with Swashbuckle (see [Getting Started](#getting-started)), you can use the Swashbuckle CLI tool to retrieve Swagger / OpenAPI JSON directly from your application's startup assembly, and write it to file. This can be useful if you want to incorporate Swagger generation into a CI/CD process, or if you want to serve it from static file at run-time.
+Once your application has been setup with Swashbuckle (see [Getting Started](../README.md#getting-started)), you can use the Swashbuckle CLI tool to retrieve Swagger / OpenAPI JSON directly from your application's startup assembly, and write it to file. This can be useful if you want to incorporate Swagger generation into a CI/CD process, or if you want to serve it from static file at run-time.
 
 It's packaged as a [.NET Tool](https://learn.microsoft.com/dotnet/core/tools/global-tools) that can be installed and used via the dotnet SDK.
 
-> :warning: The tool needs to load your Startup DLL and its dependencies at runtime. Therefore, you should use a version of the `dotnet` SDK that is compatible with your application. For example, if your app targets `net8.0`, then you should use version 8.0.xxx of the SDK to run the CLI tool. If it targets `net9.0`, then you should use version 9.0.xxx of the SDK and so on.
+> [!WARNING] 
+> The tool needs to load your Startup DLL and its dependencies at runtime. Therefore, you should use a version of the `dotnet` SDK that is compatible with your application. For example, if your app targets `net8.0`, then you should use version 8.0.xxx of the SDK to run the CLI tool. If it targets `net9.0`, then you should use version 9.0.xxx of the SDK and so on.
 
 ### Using the tool with the .NET SDK
 
@@ -28,10 +29,10 @@ It's packaged as a [.NET Tool](https://learn.microsoft.com/dotnet/core/tools/glo
     swagger tofile --output [output] [startupassembly] [swaggerdoc]
     ```
 
-    Where ...
-    * [output] is the relative path where the Swagger JSON will be output to
-    * [startupassembly] is the relative path to your application's startup assembly
-    * [swaggerdoc] is the name of the swagger document you want to retrieve, as configured in your startup class
+    Placeholders and their meaning:
+    * `[output]`: the relative path where the Swagger JSON will be output to
+    * `[startupassembly]`: the relative path to your application's startup assembly
+    * `[swaggerdoc]`: the name of the swagger document you want to retrieve, as configured in your startup class
 
 ### Using the tool with the .NET 6.0 SDK or later
 
@@ -59,10 +60,10 @@ It's packaged as a [.NET Tool](https://learn.microsoft.com/dotnet/core/tools/glo
     dotnet swagger tofile --output [output] [startupassembly] [swaggerdoc]
     ```
 
-    Where ...
-    * [output] is the relative path where the Swagger JSON will be output to
-    * [startupassembly] is the relative path to your application's startup assembly
-    * [swaggerdoc] is the name of the swagger document you want to retrieve, as configured in your startup class
+    Placeholders and their meaning:
+    * `[output]`: the relative path where the Swagger JSON will be output to
+    * `[startupassembly]`: the relative path to your application's startup assembly
+    * `[swaggerdoc]`: the name of the swagger document you want to retrieve, as configured in your startup class
 
 ## Use the CLI Tool with a Custom Host Configuration
 

--- a/docs/configure-and-customize-redoc.md
+++ b/docs/configure-and-customize-redoc.md
@@ -2,13 +2,13 @@
 
 ## Change Relative Path to the UI
 
-By default, the Redoc UI will be exposed at "/api-docs". If necessary, you can alter this when enabling the Redoc middleware:
+By default, the Redoc UI will be exposed at `"/api-docs"`. If necessary, you can alter this when enabling the Redoc middleware:
 
 ```csharp
-app.UseReDoc(c =>
+app.UseReDoc(options =>
 {
-    c.RoutePrefix = "docs"
-    ...
+    options.RoutePrefix = "docs"
+    //...
 }
 ```
 
@@ -17,71 +17,73 @@ app.UseReDoc(c =>
 By default, the Redoc UI will have a generic document title. You can alter this when enabling the Redoc middleware:
 
 ```csharp
-app.UseReDoc(c =>
+app.UseReDoc(options =>
 {
-    c.DocumentTitle = "My API Docs";
-    ...
+    options.DocumentTitle = "My API Docs";
+    //...
 }
 ```
 
 ## Apply Redoc Parameters
 
-Redoc ships with its own set of configuration parameters, all described here https://github.com/Rebilly/redoc/blob/main/README.md#redoc-options-object. In Swashbuckle, most of these are surfaced through the Redoc middleware options:
+Redoc ships with its own set of configuration parameters, all described [here](https://github.com/Rebilly/redoc/blob/main/README.md#redoc-options-object). In Swashbuckle, most of these are surfaced through the Redoc middleware options:
 
 ```csharp
-app.UseReDoc(c =>
+app.UseReDoc(options =>
 {
-    c.SpecUrl("/v1/swagger.json");
-    c.EnableUntrustedSpec();
-    c.ScrollYOffset(10);
-    c.HideHostname();
-    c.HideDownloadButton();
-    c.ExpandResponses("200,201");
-    c.RequiredPropsFirst();
-    c.NoAutoAuth();
-    c.PathInMiddlePanel();
-    c.HideLoading();
-    c.NativeScrollbars();
-    c.DisableSearch();
-    c.OnlyRequiredInSamples();
-    c.SortPropsAlphabetically();
+    options.SpecUrl("/v1/swagger.json");
+    options.EnableUntrustedSpec();
+    options.ScrollYOffset(10);
+    options.HideHostname();
+    options.HideDownloadButton();
+    options.ExpandResponses("200,201");
+    options.RequiredPropsFirst();
+    options.NoAutoAuth();
+    options.PathInMiddlePanel();
+    options.HideLoading();
+    options.NativeScrollbars();
+    options.DisableSearch();
+    options.OnlyRequiredInSamples();
+    options.SortPropsAlphabetically();
 });
 ```
 
-_Using `c.SpecUrl("/v1/swagger.json")` multiple times within the same `UseReDoc(...)` will not add multiple urls._
+> [!NOTE]
+> Using `options.SpecUrl("/v1/swagger.json")` multiple times within the same `UseReDoc(...)` will not add multiple urls.
 
 ## Inject Custom CSS
 
 To tweak the look and feel, you can inject additional CSS stylesheets by adding them to your `wwwroot` folder and specifying the relative paths in the middleware options:
 
 ```csharp
-app.UseReDoc(c =>
+app.UseReDoc(options =>
 {
-    ...
-    c.InjectStylesheet("/redoc/custom.css");
+    //...
+    options.InjectStylesheet("/redoc/custom.css");
 }
 ```
 
-It is also possible to modify the theme by using the `AdditionalItems` property, see https://github.com/Rebilly/redoc/blob/main/README.md#redoc-options-object for more information.
+It is also possible to modify the theme by using the `AdditionalItems` property, more information can be found [here](https://github.com/Rebilly/redoc/blob/main/README.md#redoc-options-object).
 
 ```csharp
-app.UseReDoc(c =>
+app.UseReDoc(options =>
 {
-    ...
-    c.ConfigObject.AdditionalItems = ...
+    //...
+    options.ConfigObject.AdditionalItems = ...
 }
 ```
 
 ## Customize index.html
 
-To customize the UI beyond the basic options listed above, you can provide your own version of the Redoc index.html page:
+To customize the UI beyond the basic options listed above, you can provide your own version of the Redoc `index.html` page:
 
 ```csharp
-app.UseReDoc(c =>
+app.UseReDoc(options =>
 {
-    c.IndexStream = () => GetType().Assembly
+    options.IndexStream = () => GetType().Assembly
         .GetManifestResourceStream("CustomIndex.ReDoc.index.html"); // requires file to be added as an embedded resource
 });
 ```
 
-_To get started, you should base your custom index.html on the [default version](src/Swashbuckle.AspNetCore.ReDoc/index.html)_
+> [!TIP]
+> To get started, you should base your custom `index.html` on the [default version](../src/Swashbuckle.AspNetCore.ReDoc/index.html)

--- a/docs/configure-and-customize-redoc.md
+++ b/docs/configure-and-customize-redoc.md
@@ -49,7 +49,7 @@ app.UseReDoc(options =>
 ```
 
 > [!NOTE]
-> Using `options.SpecUrl("/v1/swagger.json")` multiple times within the same `UseReDoc(...)` will not add multiple urls.
+> Using `options.SpecUrl("/v1/swagger.json")` multiple times within the same `UseReDoc(...)` will not add multiple URL.
 
 ## Inject Custom CSS
 
@@ -86,4 +86,4 @@ app.UseReDoc(options =>
 ```
 
 > [!TIP]
-> To get started, you should base your custom `index.html` on the [default version](../src/Swashbuckle.AspNetCore.ReDoc/index.html)
+> To get started, you should base your custom `index.html` on the [default version](../src/Swashbuckle.AspNetCore.ReDoc/index.html).

--- a/docs/configure-and-customize-redoc.md
+++ b/docs/configure-and-customize-redoc.md
@@ -9,7 +9,7 @@ app.UseReDoc(options =>
 {
     options.RoutePrefix = "docs"
     //...
-}
+});
 ```
 
 ## Change Document Title
@@ -21,7 +21,7 @@ app.UseReDoc(options =>
 {
     options.DocumentTitle = "My API Docs";
     //...
-}
+});
 ```
 
 ## Apply Redoc Parameters
@@ -60,7 +60,7 @@ app.UseReDoc(options =>
 {
     //...
     options.InjectStylesheet("/redoc/custom.css");
-}
+});
 ```
 
 It is also possible to modify the theme by using the `AdditionalItems` property, more information can be found [here](https://github.com/Rebilly/redoc/blob/main/README.md#redoc-options-object).
@@ -70,7 +70,7 @@ app.UseReDoc(options =>
 {
     //...
     options.ConfigObject.AdditionalItems = ...
-}
+});
 ```
 
 ## Customize index.html

--- a/docs/configure-and-customize-swagger.md
+++ b/docs/configure-and-customize-swagger.md
@@ -5,7 +5,7 @@
 By default, Swagger JSON will be exposed at the following route - `"/swagger/{documentName}/swagger.json"`. If necessary, you can change this when enabling the Swagger middleware. 
 
 > [!IMPORTANT]
-> Custom routes MUST include the `{documentName}` parameter.
+> Custom routes **must** include the `{documentName}` parameter.
 
 ```csharp
 app.UseSwagger(options =>

--- a/docs/configure-and-customize-swagger.md
+++ b/docs/configure-and-customize-swagger.md
@@ -11,7 +11,7 @@ By default, Swagger JSON will be exposed at the following route - `"/swagger/{do
 app.UseSwagger(options =>
 {
     options.RouteTemplate = "api-docs/{documentName}/swagger.json";
-})
+});
 ```
 
 > [!NOTE] 
@@ -21,7 +21,7 @@ app.UseSwagger(options =>
 > app.UseSwaggerUI(options =>
 > {
 >     options.SwaggerEndpoint("/api-docs/v1/swagger.json", "My API V1");
-> })
+> });
 > ```
 >
 > If you also need to update the relative path that the UI itself is available on, you'll need to follow the instructions found in [Change Relative Path to the UI](configure-and-customize-swaggerui.md#change-relative-path-to-the-ui).
@@ -82,7 +82,7 @@ it is possible to create a custom document serializer that implements the `ISwag
 services.ConfigureSwagger(options =>
 {
     option.SetCustomDocumentSerializer<CustomDocumentSerializer>();
-})
+});
 ```
 
 When the command line tool is not used, it can also be done on the application host:
@@ -91,5 +91,5 @@ When the command line tool is not used, it can also be done on the application h
 app.UseSwagger(options =>
 {
     options.SetCustomDocumentSerializer<CustomDocumentSerializer>();
-})
+});
 ```

--- a/docs/configure-and-customize-swagger.md
+++ b/docs/configure-and-customize-swagger.md
@@ -68,7 +68,7 @@ app.UseSwaggerUI(options =>
 ```
 
 > [!NOTE] 
-> In previous versions of the docs, you may have seen this expressed as a root-relative link (e.g. `/swagger/v1/swagger.json`). This won't work if your app is hosted on an IIS virtual directory or behind a proxy that trims the request path before forwarding. If you switch to the *page-relative* syntax shown above, it should work in all cases._
+> In previous versions of the docs, you may have seen this expressed as a root-relative link (e.g. `/swagger/v1/swagger.json`). This won't work if your app is hosted on an IIS virtual directory or behind a proxy that trims the request path before forwarding. If you switch to the *page-relative* syntax shown above, it should work in all cases.
 
 ## Customizing how the OpenAPI document is serialized
 

--- a/docs/configure-and-customize-swagger.md
+++ b/docs/configure-and-customize-swagger.md
@@ -2,34 +2,38 @@
 
 ## Change the Path for Swagger JSON Endpoints
 
-By default, Swagger JSON will be exposed at the following route - "/swagger/{documentName}/swagger.json". If necessary, you can change this when enabling the Swagger middleware. Custom routes MUST include the `{documentName}` parameter.
+By default, Swagger JSON will be exposed at the following route - `"/swagger/{documentName}/swagger.json"`. If necessary, you can change this when enabling the Swagger middleware. 
+
+> [!IMPORTANT]
+> Custom routes MUST include the `{documentName}` parameter.
 
 ```csharp
-app.UseSwagger(c =>
+app.UseSwagger(options =>
 {
-    c.RouteTemplate = "api-docs/{documentName}/swagger.json";
+    options.RouteTemplate = "api-docs/{documentName}/swagger.json";
 })
 ```
 
-_NOTE: If you're using the SwaggerUI middleware, you'll also need to update its configuration to reflect the new endpoints:_
-
-```csharp
-app.UseSwaggerUI(c =>
-{
-    c.SwaggerEndpoint("/api-docs/v1/swagger.json", "My API V1");
-})
-```
-
-_NOTE: If you also need to update the relative path that the UI itself is available on, you'll need to follow the instructions found in [Change Relative Path to the UI](#change-relative-path-to-the-ui)._
+> [!NOTE] 
+> If you're using the SwaggerUI middleware, you'll also need to update its configuration to reflect the new endpoints:
+>
+> ```csharp
+> app.UseSwaggerUI(options =>
+> {
+>     options.SwaggerEndpoint("/api-docs/v1/swagger.json", "My API V1");
+> })
+> ```
+>
+> If you also need to update the relative path that the UI itself is available on, you'll need to follow the instructions found in [Change Relative Path to the UI](configure-and-customize-swaggerui.md#change-relative-path-to-the-ui).
 
 ## Modify Swagger with Request Context
 
 If you need to set some Swagger metadata based on the current request, you can configure a filter that's executed prior to serializing the document.
 
 ```csharp
-app.UseSwagger(c =>
+app.UseSwagger(options =>
 {
-    c.PreSerializeFilters.Add((swagger, httpReq) =>
+    options.PreSerializeFilters.Add((swagger, httpReq) =>
     {
         swagger.Servers = new List<OpenApiServer> { new OpenApiServer { Url = $"{httpReq.Scheme}://{httpReq.Host.Value}" } };
     });
@@ -43,9 +47,9 @@ The `OpenApiDocument` and the current `HttpRequest` are both passed to the filte
 By default, Swashbuckle will generate and expose Swagger JSON in version 3.0 of the specification, officially called the OpenAPI Specification. However, to support backwards compatibility, you can opt to continue exposing it in the 2.0 format with the following option:
 
 ```csharp
-app.UseSwagger(c =>
+app.UseSwagger(options =>
 {
-    c.OpenApiVersion = Microsoft.OpenApi.OpenApiSpecVersion.OpenApi2_0;
+    options.OpenApiVersion = Microsoft.OpenApi.OpenApiSpecVersion.OpenApi2_0;
 });
 ```
 
@@ -56,14 +60,15 @@ Virtual directories and reverse proxies can cause issues for applications that g
 For example, to wire up the SwaggerUI middleware, you provide the URL to one or more OpenAPI/Swagger documents. This is the URL that the swagger-ui, a client-side application, will call to retrieve your API metadata. To ensure this works behind virtual directories and reverse proxies, you should express this relative to the `RoutePrefix` of the swagger-ui itself:
 
 ```csharp
-app.UseSwaggerUI(c =>
+app.UseSwaggerUI(options =>
 {
-    c.RoutePrefix = "swagger";
-    c.SwaggerEndpoint("v1/swagger.json", "My API V1");
+    options.RoutePrefix = "swagger";
+    options.SwaggerEndpoint("v1/swagger.json", "My API V1");
 });
 ```
 
-_NOTE: In previous versions of the docs, you may have seen this expressed as a root-relative link (e.g. `/swagger/v1/swagger.json`). This won't work if your app is hosted on an IIS virtual directory or behind a proxy that trims the request path before forwarding. If you switch to the *page-relative* syntax shown above, it should work in all cases._
+> [!NOTE] 
+> In previous versions of the docs, you may have seen this expressed as a root-relative link (e.g. `/swagger/v1/swagger.json`). This won't work if your app is hosted on an IIS virtual directory or behind a proxy that trims the request path before forwarding. If you switch to the *page-relative* syntax shown above, it should work in all cases._
 
 ## Customizing how the OpenAPI document is serialized
 

--- a/docs/configure-and-customize-swaggergen.md
+++ b/docs/configure-and-customize-swaggergen.md
@@ -6,38 +6,41 @@ In Swagger, operations MAY be assigned an `operationId`. This ID MUST be unique 
 
 Auto-generating an ID that matches these requirements, while also providing a name that would be meaningful in client libraries is a non-trivial task and so, Swashbuckle omits the `operationId` by default. However, if necessary, you can assign `operationIds` by decorating individual routes OR by providing a custom strategy.
 
-__Option 1) Decorate routes with a `Name` property__
+### Option 1: Decorate routes with a `Name` property
 
 ```csharp
 [HttpGet("{id}", Name = "GetProductById")]
 public IActionResult Get(int id) // operationId = "GetProductById"
 ```
 
-__Option 2) Provide a custom strategy__
+### Option 2: Provide a custom strategy
 
+📝 `Startup.cs`
 ```csharp
-// Startup.cs
-services.AddSwaggerGen(c =>
+services.AddSwaggerGen(options =>
 {
-    ...
+    //...
     
     // Use method name as operationId
-    c.CustomOperationIds(apiDesc =>
+    options.CustomOperationIds(apiDesc =>
     {
         return apiDesc.TryGetMethodInfo(out MethodInfo methodInfo) ? methodInfo.Name : null;
     });
-})
+});
+```
 
-// ProductsController.cs
+📝 `ProductsController.cs`
+```csharp
 [HttpGet("{id}")]
 public IActionResult GetProductById(int id) // operationId = "GetProductById"
 ```
 
-_NOTE: With either approach, API authors are responsible for ensuring the uniqueness of `operationIds` across all Operations_
+> [!NOTE] 
+> With either approach, API authors are responsible for ensuring the uniqueness of `operationIds` across all Operations
 
 ## List Operation Responses
 
-By default, Swashbuckle will generate a "200" response for each operation. If the action returns a response DTO, then this will be used to generate a schema for the response body. For example ...
+By default, Swashbuckle will generate a `"200"` response for each operation. If the action returns a response DTO, then this will be used to generate a schema for the response body. For example:
 
 ```csharp
 [HttpPost("{id}")]
@@ -46,7 +49,7 @@ public Product GetById(int id)
 
 Will produce the following response metadata:
 
-```
+```yaml
 responses: {
   200: {
     description: "OK",
@@ -63,7 +66,7 @@ responses: {
 
 ### Explicit Responses
 
-If you need to specify a different status code and/or additional responses, or your actions return `IActionResult` instead of a response DTO, you can explicitly describe responses with the `ProducesResponseTypeAttribute` that ships with ASP.NET Core. For example ...
+If you need to specify a different status code and/or additional responses, or your actions return `IActionResult` instead of a response DTO, you can explicitly describe responses with the `ProducesResponseTypeAttribute` that ships with ASP.NET Core. For example:
 
 ```csharp
 [HttpPost("{id}")]
@@ -75,7 +78,7 @@ public IActionResult GetById(int id)
 
 Will produce the following response metadata:
 
-```
+```yaml
 responses: {
   200: {
     description: "OK",
@@ -111,16 +114,18 @@ responses: {
 
 In a Swagger document, you can flag parameters and schema properties that are required for a request. If a parameter (top-level or property-based) is decorated with the `BindRequiredAttribute` or `RequiredAttribute`, then Swashbuckle will automatically flag it as a "required" parameter in the generated Swagger:
 
+📝 `ProductsController.cs`
 ```csharp
-// ProductsController.cs
 public IActionResult Search([FromQuery, BindRequired]string keywords, [FromQuery]PagingParams pagingParams)
 {
     if (!ModelState.IsValid)
         return BadRequest(ModelState);
-    ...
+    //...
 }
+```
 
-// SearchParams.cs
+📝 `SearchParams.cs`
+```csharp
 public class PagingParams
 {
     [Required]
@@ -132,16 +137,18 @@ public class PagingParams
 
 In addition to parameters, Swashbuckle will also honor the `RequiredAttribute` when used in a model that's bound to the request body. In this case, the decorated properties will be flagged as "required" properties in the body description:
 
+📝 `ProductsController.cs`
 ```csharp
-// ProductsController.cs
 public IActionResult Create([FromBody]Product product)
 {
     if (!ModelState.IsValid)
         return BadRequest(ModelState);
-    ...
+    //...
 }
+```
 
-// Product.cs
+📝 `Product.cs`
+```csharp
 public class Product
 {
     [Required]
@@ -160,11 +167,13 @@ This controller will accept two form field values and one named file upload from
 public void UploadFile([FromForm]string description, [FromForm]DateTime clientDate, IFormFile file)
 ```
 
-> Important note: As per the [ASP.NET Core docs](https://learn.microsoft.com/aspnet/core/mvc/models/file-uploads), you're not supposed to decorate `IFormFile` parameters with the `[FromForm]` attribute as the binding source is automatically inferred from the type. In fact, the inferred value is `BindingSource.FormFile` and if you apply the attribute it will be set to `BindingSource.Form` instead, which screws up `ApiExplorer`, the metadata component that ships with ASP.NET Core and is heavily relied on by Swashbuckle. One particular issue here is that SwaggerUI will not treat the parameter as a file and so will not display a file upload button, if you do mistakenly include this attribute.
+> [!IMPORTANT]
+> As per the [ASP.NET Core docs](https://learn.microsoft.com/aspnet/core/mvc/models/file-uploads), you're not supposed to decorate `IFormFile` parameters with the `[FromForm]` attribute as the binding source is automatically inferred from the type. In fact, the inferred value is `BindingSource.FormFile` and if you apply the attribute it will be set to `BindingSource.Form` instead, which screws up `ApiExplorer`, the metadata component that ships with ASP.NET Core and is heavily relied on by Swashbuckle. One particular issue here is that SwaggerUI will not treat the parameter as a file and so will not display a file upload button, if you do mistakenly include this attribute.
 
 ## Handle File Downloads
 
-`ApiExplorer` (the ASP.NET Core metadata component that Swashbuckle is built on) *DOES NOT* surface the `FileResult` types by default and so you need to explicitly tell it to with the `ProducesResponseType` attribute (or `Produces` on .NET 5 or older):
+>[!IMPORTANT]
+> `ApiExplorer` (the ASP.NET Core metadata component that Swashbuckle is built on) *DOES NOT* surface the `FileResult` types by default and so you need to explicitly tell it to with the `ProducesResponseType` attribute (or `Produces` on .NET 5 or older):
 ```csharp
 [HttpGet("{fileName}")]
 [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status200OK, "image/jpeg")]
@@ -177,14 +186,14 @@ To enhance the generated docs with human-friendly descriptions, you can annotate
 
 1. Open the Properties dialog for your project, click the "Build" tab and ensure that "XML documentation file" is checked, or add `<GenerateDocumentationFile>true</GenerateDocumentationFile>` element to the `<PropertyGroup>` section of your .csproj project file. This will produce a file containing all XML comments at build-time.
 
-    _At this point, any classes or methods that are NOT annotated with XML comments will trigger a build warning. To suppress this, enter the warning code "1591" into the "Suppress warnings" field in the properties dialog or add `<NoWarn>1591</NoWarn>` to the `<PropertyGroup>` section of your .csproj project file._
+    > At this point, any classes or methods that are NOT annotated with XML comments will trigger a build warning. To suppress this, enter the warning code "1591" into the "Suppress warnings" field in the properties dialog or add `<NoWarn>1591</NoWarn>` to the `<PropertyGroup>` section of your .csproj project file.
 
 2. Configure Swashbuckle to incorporate the XML comments on file into the generated Swagger JSON:
 
     ```csharp
-    services.AddSwaggerGen(c =>
+    services.AddSwaggerGen(options =>
     {
-        c.SwaggerDoc("v1",
+        options.SwaggerDoc("v1",
             new OpenApiInfo
             {
                 Title = "My API - V1",
@@ -192,9 +201,9 @@ To enhance the generated docs with human-friendly descriptions, you can annotate
             }
          );
 
-         c.IncludeXmlComments(Assembly.GetExecutingAssembly());
-         // or c.IncludeXmlComments(typeof(MyController).Assembly));
-    }
+         options.IncludeXmlComments(Assembly.GetExecutingAssembly());
+         // or options.IncludeXmlComments(typeof(MyController).Assembly));
+    });
     ```
 
 3. Annotate your actions with summary, remarks, param and response tags:
@@ -242,14 +251,15 @@ To enhance the generated docs with human-friendly descriptions, you can annotate
 
 5. Rebuild your project to update the XML Comments file and navigate to the Swagger JSON endpoint. Note how the descriptions are mapped onto corresponding Swagger fields.
 
-_NOTE: You can also provide Swagger Schema descriptions by annotating your API models and their properties with summary tags. If you have multiple XML comments files (e.g. separate libraries for controllers and models), you can invoke the IncludeXmlComments method multiple times and they will all be merged into the outputted Swagger JSON._
+> [!NOTE] 
+> You can also provide Swagger Schema descriptions by annotating your API models and their properties with summary tags. If you have multiple XML comments files (e.g. separate libraries for controllers and models), you can invoke the `IncludeXmlComments` method multiple times and they will all be merged into the outputted Swagger JSON.
 
 ## Provide Global API Metadata
 
-In addition to "PathItems", "Operations" and "Responses", which Swashbuckle generates for you, Swagger also supports global metadata (see https://swagger.io/specification/#oasObject). For example, you can provide a full description for your API, terms of service or even contact and licensing information:
+In addition to `"PathItems"`, `"Operations"` and `"Responses"`, which Swashbuckle generates for you, Swagger also supports [global metadata](https://swagger.io/specification/#oasObject). For example, you can provide a full description for your API, terms of service or even contact and licensing information:
 
 ```csharp
-c.SwaggerDoc("v1",
+options.SwaggerDoc("v1",
     new OpenApiInfo
     {
         Title = "My API - V1",
@@ -270,21 +280,23 @@ c.SwaggerDoc("v1",
 );
 ```
 
-_TIP: Use IntelliSense to see what other fields are available._
+> [!TIP] 
+> Use IntelliSense to see what other fields are available.
 
 ## Generate Multiple Swagger Documents
 
 With the setup described above, the generator will include all API operations in a single Swagger document. However, you can create multiple documents if necessary. For example, you may want a separate document for each version of your API. To do this, start by defining multiple Swagger docs in `Startup.cs`:
 
 ```csharp
-services.AddSwaggerGen(c =>
+services.AddSwaggerGen(options =>
 {
-    c.SwaggerDoc("v1", new OpenApiInfo { Title = "My API - V1", Version = "v1" });
-    c.SwaggerDoc("v2", new OpenApiInfo { Title = "My API - V2", Version = "v2" });
-})
+    options.SwaggerDoc("v1", new OpenApiInfo { Title = "My API - V1", Version = "v1" });
+    options.SwaggerDoc("v2", new OpenApiInfo { Title = "My API - V2", Version = "v2" });
+});
 ```
 
-_Take note of the first argument to SwaggerDoc. It MUST be a URI-friendly name that uniquely identifies the document. It's subsequently used to make up the path for requesting the corresponding Swagger JSON. For example, with the default routing, the above documents will be available at "/swagger/v1/swagger.json" and "/swagger/v2/swagger.json"._
+> [!NOTE]
+> Take note of the first argument to SwaggerDoc. It MUST be a URI-friendly name that uniquely identifies the document. It's subsequently used to make up the path for requesting the corresponding Swagger JSON. For example, with the default routing, the above documents will be available at `"/swagger/v1/swagger.json"` and `"/swagger/v2/swagger.json"`.
 
 Next, you'll need to inform Swashbuckle which actions to include in each document. Although this can be customized (see below), by default, the generator will use the `ApiDescription.GroupName` property, part of the built-in metadata layer that ships with ASP.NET Core, to make this distinction. You can set this by decorating individual actions OR by applying an application wide convention.
 
@@ -302,8 +314,8 @@ public void Post([FromBody]Product product)
 
 To group by convention instead of decorating every action, you can apply a custom controller or action convention. For example, you could wire up the following convention to assign actions to documents based on the controller namespace.
 
+📝 `ApiExplorerGroupPerVersionConvention.cs`
 ```csharp
-// ApiExplorerGroupPerVersionConvention.cs
 public class ApiExplorerGroupPerVersionConvention : IControllerModelConvention
 {
     public void Apply(ControllerModel controller)
@@ -314,24 +326,26 @@ public class ApiExplorerGroupPerVersionConvention : IControllerModelConvention
         controller.ApiExplorer.GroupName = apiVersion;
     }
 }
+```
 
-// Startup.cs
+📝 `Startup.cs`
+```csharp
 public void ConfigureServices(IServiceCollection services)
 {
-    services.AddMvc(c =>
-        c.Conventions.Add(new ApiExplorerGroupPerVersionConvention())
+    services.AddMvc(options =>
+        options.Conventions.Add(new ApiExplorerGroupPerVersionConvention())
     );
 
-    ...
+    //...
 }
 ```
 
 ### Customize the Action Selection Process
 
-When selecting actions for a given Swagger document, the generator invokes a `DocInclusionPredicate` against every `ApiDescription` that's surfaced by the framework. The default implementation inspects `ApiDescription.GroupName` and returns true if the value is either null OR equal to the requested document name. However, you can also provide a custom inclusion predicate. For example, if you're using an attribute-based approach to implement API versioning (e.g. Microsoft.AspNetCore.Mvc.Versioning), you could configure a custom predicate that leverages the versioning attributes instead:
+When selecting actions for a given Swagger document, the generator invokes a `DocInclusionPredicate` against every `ApiDescription` that's surfaced by the framework. The default implementation inspects `ApiDescription.GroupName` and returns true if the value is either null OR equal to the requested document name. However, you can also provide a custom inclusion predicate. For example, if you're using an attribute-based approach to implement API versioning (e.g. `Microsoft.AspNetCore.Mvc.Versioning`), you could configure a custom predicate that leverages the versioning attributes instead:
 
 ```csharp
-c.DocInclusionPredicate((docName, apiDesc) =>
+options.DocInclusionPredicate((docName, apiDesc) =>
 {
     if (!apiDesc.TryGetMethodInfo(out MethodInfo methodInfo)) return false;
 
@@ -346,28 +360,28 @@ c.DocInclusionPredicate((docName, apiDesc) =>
 
 ### Exposing Multiple Documents through the UI
 
-If you're using the `SwaggerUI` middleware, you'll need to specify any additional Swagger endpoints you want to expose. See [List Multiple Swagger Documents](#list-multiple-swagger-documents) for more.
+If you're using the `SwaggerUI` middleware, you'll need to specify any additional Swagger endpoints you want to expose. See [List Multiple Swagger Documents](configure-and-customize-swaggerui.md#list-multiple-swagger-documents) for more.
 
 ## Omit Obsolete Operations and/or Schema Properties
 
 The [Swagger spec](https://swagger.io/specification/) includes a `deprecated` flag for indicating that an operation is deprecated and should be refrained from use. The Swagger generator will automatically set this flag if the corresponding action is decorated with the `ObsoleteAttribute`. However, instead of setting a flag, you can configure the generator to ignore obsolete actions altogether:
 
 ```csharp
-services.AddSwaggerGen(c =>
+services.AddSwaggerGen(options =>
 {
-    ...
-    c.IgnoreObsoleteActions();
-};
+    //...
+    options.IgnoreObsoleteActions();
+});
 ```
 
 A similar approach can also be used to omit obsolete properties from Schemas in the Swagger output. That is, you can decorate model properties with the `ObsoleteAttribute` and configure Swashbuckle to omit those properties when generating JSON Schemas:
 
 ```csharp
-services.AddSwaggerGen(c =>
+services.AddSwaggerGen(options =>
 {
-    ...
-    c.IgnoreObsoleteProperties();
-};
+    //...
+    options.IgnoreObsoleteProperties();
+});
 ```
 
 ## Omit Arbitrary Operations
@@ -388,8 +402,8 @@ public Product GetById(int id)
 
 To omit actions by convention instead of decorating them individually, you can apply a custom action convention. For example, you could wire up the following convention to only document GET operations:
 
+📝 `ApiExplorerGetsOnlyConvention.cs`
 ```csharp
-// ApiExplorerGetsOnlyConvention.cs
 public class ApiExplorerGetsOnlyConvention : IActionModelConvention
 {
     public void Apply(ActionModel action)
@@ -397,15 +411,17 @@ public class ApiExplorerGetsOnlyConvention : IActionModelConvention
         action.ApiExplorer.IsVisible = action.Attributes.OfType<HttpGetAttribute>().Any();
     }
 }
+```
 
-// Startup.cs
+📝 `Startup.cs`
+```csharp
 public void ConfigureServices(IServiceCollection services)
 {
-    services.AddMvc(c =>
-        c.Conventions.Add(new ApiExplorerGetsOnlyConvention())
+    services.AddMvc(options =>
+        options.Conventions.Add(new ApiExplorerGetsOnlyConvention())
     );
 
-    ...
+    //...
 }
 ```
 
@@ -416,11 +432,11 @@ The [Swagger spec](https://swagger.io/specification/) allows one or more "tags" 
 You can override the default tag by providing a function that applies tags by convention. For example, the following configuration will tag, and therefore group operations in the UI, by HTTP method:
 
 ```csharp
-services.AddSwaggerGen(c =>
+services.AddSwaggerGen(options =>
 {
-    ...
-    c.TagActionsBy(api => api.HttpMethod);
-};
+    //...
+    options.TagActionsBy(api => api.HttpMethod);
+});
 ```
 
 ## Change Operation Sort Order (e.g. for UI Sorting)
@@ -428,20 +444,21 @@ services.AddSwaggerGen(c =>
 By default, actions are ordered by assigned tag (see above) before they're grouped into the path-centric, nested structure of the [Swagger spec](https://swagger.io/specification). But, you can change the default ordering of actions with a custom sorting strategy:
 
 ```csharp
-services.AddSwaggerGen(c =>
+services.AddSwaggerGen(options =>
 {
-    ...
-    c.OrderActionsBy((apiDesc) => $"{apiDesc.ActionDescriptor.RouteValues["controller"]}_{apiDesc.HttpMethod}");
-};
+    //...
+    options.OrderActionsBy((apiDesc) => $"{apiDesc.ActionDescriptor.RouteValues["controller"]}_{apiDesc.HttpMethod}");
+});
 ```
 
-_NOTE: This dictates the sort order BEFORE actions are grouped and transformed into the Swagger format. So, it affects the ordering of groups (i.e. Swagger "PathItems"), AND the ordering of operations within a group, in the Swagger output._
+> [!NOTE]
+> This dictates the sort order BEFORE actions are grouped and transformed into the Swagger format. So, it affects the ordering of groups (i.e. Swagger "PathItems"), AND the ordering of operations within a group, in the Swagger output.
 
 ## Customize Schema Id's
 
 If the generator encounters complex parameter or response types, it will generate a corresponding JSON Schema, add it to the global `components/schemas` dictionary, and reference it from the operation description by unique Id. For example, if you have an action that returns a `Product` type, then the generated schema will be referenced as follows:
 
-```
+```yaml
 responses: {
   200: {
     description: "OK",
@@ -459,14 +476,14 @@ responses: {
 However, if it encounters multiple types with the same name but different namespaces (e.g. `RequestModels.Product` & `ResponseModels.Product`), then Swashbuckle will raise an exception due to "Conflicting schemaIds". In this case, you'll need to provide a custom Id strategy that further qualifies the name:
 
 ```csharp
-services.AddSwaggerGen(c =>
+services.AddSwaggerGen(options =>
 {
-    ...
-    c.CustomSchemaIds((type) => type.FullName);
-};
+    //...
+    options.CustomSchemaIds((type) => type.FullName);
+});
 ```
-
-See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2703 for support for nested types.
+> [!NOTE]
+> See [this github issue](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2703) for support for nested types.
 
 ## Override Schema for Specific Types
 
@@ -474,8 +491,8 @@ Out-of-the-box, Swashbuckle does a decent job at generating JSON Schemas that ac
 
 For example, you might have a class with multiple properties that you want to represent in JSON as a comma-separated string. To do this you would probably implement a custom `JsonConverter`. In this case, Swashbuckle doesn't know how the converter is implemented and so you would need to provide it with a Schema that accurately describes the type:
 
+📝 `PhoneNumber.cs`
 ```csharp
-// PhoneNumber.cs
 public class PhoneNumber
 {
     public string CountryCode { get; set; }
@@ -484,13 +501,15 @@ public class PhoneNumber
 
     public string SubscriberId { get; set; }
 }
+```
 
-// Startup.cs
-services.AddSwaggerGen(c =>
+📝 `Startup.cs`
+```csharp
+services.AddSwaggerGen(options =>
 {
-    ...
-    c.MapType<PhoneNumber>(() => new OpenApiSchema { Type = "string" });
-};
+    //...
+    options.MapType<PhoneNumber>(() => new OpenApiSchema { Type = "string" });
+});
 ```
 
 ## Extend Generator with Operation, Schema & Document Filters
@@ -503,8 +522,8 @@ Swashbuckle retrieves an `ApiDescription`, part of ASP.NET Core, for every actio
 
 In a typical filter implementation, you would inspect the `ApiDescription` for relevant information (e.g. route info, action attributes etc.) and then update the `OpenApiOperation` accordingly. For example, the following filter lists an additional "401" response for all actions that are decorated with the `AuthorizeAttribute`:
 
+📝 `AuthResponsesOperationFilter.cs`
 ```csharp
-// AuthResponsesOperationFilter.cs
 public class AuthResponsesOperationFilter : IOperationFilter
 {
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
@@ -517,25 +536,28 @@ public class AuthResponsesOperationFilter : IOperationFilter
             operation.Responses.Add("401", new OpenApiResponse { Description = "Unauthorized" });
     }
 }
-
-// Startup.cs
-services.AddSwaggerGen(c =>
-{
-    ...
-    c.OperationFilter<AuthResponsesOperationFilter>();
-};
 ```
 
-_NOTE: Filter pipelines are DI-aware. That is, you can create filters with constructor parameters and if the parameter types are registered with the DI framework, they'll be automatically injected when the filters are instantiated_
+📝 `Startup.cs`
+```csharp
+services.AddSwaggerGen(options =>
+{
+    //...
+    options.OperationFilter<AuthResponsesOperationFilter>();
+});
+```
+
+> [!NOTE] 
+> Filter pipelines are DI-aware. That is, you can create filters with constructor parameters and if the parameter types are registered with the DI framework, they'll be automatically injected when the filters are instantiated.
 
 ### Schema Filters
 
 Swashbuckle generates a Swagger-flavored [JSONSchema](https://swagger.io/specification/#schemaObject) for every parameter, response and property type that's exposed by your controller actions. Once generated, it passes the schema and type through the list of configured Schema Filters.
 
-The example below adds an AutoRest vendor extension (see https://github.com/Azure/autorest/blob/master/docs/extensions/readme.md#x-ms-enum) to inform the AutoRest tool how enums should be modelled when it generates the API client.
+The example below adds an [AutoRest vendor extension](https://github.com/Azure/autorest/blob/master/docs/extensions/readme.md#x-ms-enum) to inform the AutoRest tool how enums should be modelled when it generates the API client.
 
+📝 `AutoRestSchemaFilter.cs`
 ```csharp
-// AutoRestSchemaFilter.cs
 public class AutoRestSchemaFilter : ISchemaFilter
 {
     public void Apply(OpenApiSchema schema, SchemaFilterContext context)
@@ -551,24 +573,26 @@ public class AutoRestSchemaFilter : ISchemaFilter
                     ["modelAsString"] = new OpenApiBoolean(true)
                 }
             );
-        };
+        }
     }
 }
+```
 
-// Startup.cs
-services.AddSwaggerGen(c =>
+📝 `Startup.cs`
+```csharp
+services.AddSwaggerGen(options =>
 {
-    ...
-    c.SchemaFilter<AutoRestSchemaFilter>();
-};
+    //...
+    options.SchemaFilter<AutoRestSchemaFilter>();
+});
 ```
 
 The example below allows for automatic schema generation of generic `Dictionary<Enum, TValue>` objects.
 Note that this only generates the swagger; `System.Text.Json` is not able to parse dictionary enums by default,
 so you will need [a special JsonConverter, like in the .NET docs](https://learn.microsoft.com/dotnet/standard/serialization/system-text-json/converters-how-to#sample-factory-pattern-converter)
 
+📝 `DictionaryTKeyEnumTValueSchemaFilter.cs`
 ```csharp
-// DictionaryTKeyEnumTValueSchemaFilter.cs
 public class DictionaryTKeyEnumTValueSchemaFilter : ISchemaFilter
 {
   public void Apply(OpenApiSchema schema, SchemaFilterContext context)
@@ -576,7 +600,7 @@ public class DictionaryTKeyEnumTValueSchemaFilter : ISchemaFilter
     // Only run for fields that are a Dictionary<Enum, TValue>
     if (!context.Type.IsGenericType || !context.Type.GetGenericTypeDefinition().IsAssignableFrom(typeof(Dictionary<,>)))
     {
-return;
+      return;
     }
 
     var keyType = context.Type.GetGenericArguments()[0];
@@ -584,7 +608,7 @@ return;
 
     if (!keyType.IsEnum)
     {
-return;
+      return;
     }
 
     schema.Type = "object";
@@ -593,17 +617,18 @@ name => context.SchemaGenerator.GenerateSchema(valueType,
   context.SchemaRepository));
   }
 }
+```
 
-// Startup.cs
-services.AddSwaggerGen(c =>
+📝 `Startup.cs`
+```csharp
+services.AddSwaggerGen(options =>
 {
-    ...
+    //...
     // These will be replaced by DictionaryTKeyEnumTValueSchemaFilter, but are needed to avoid an error.
     // You will need one for every kind of Dictionary<,> you have.
-    c.MapType<Dictionary<MyEnum, List<string>>>(() => new OpenApiSchema());
-    c.SchemaFilter<DictionaryTKeyEnumTValueSchemaFilter>();
-};
-    
+    options.MapType<Dictionary<MyEnum, List<string>>>(() => new OpenApiSchema());
+    options.SchemaFilter<DictionaryTKeyEnumTValueSchemaFilter>();
+});  
 ```
 
 ### Document Filters
@@ -625,22 +650,23 @@ public class TagDescriptionsDocumentFilter : IDocumentFilter
 }
 ```
 
-_NOTE: If you're using the `SwaggerUI` middleware, the `TagDescriptionsDocumentFilter` demonstrated above could be used to display additional descriptions beside each group of Operations._
+> [!NOTE] 
+> If you're using the `SwaggerUI` middleware, the `TagDescriptionsDocumentFilter` demonstrated above could be used to display additional descriptions beside each group of Operations.
 
 ## Add Security Definitions and Requirements
 
-In Swagger, you can describe how your API is secured by defining one or more security schemes (e.g basic, api key, oauth2 etc.) and declaring which of those schemes are applicable globally OR for specific operations. For more details, take a look at the [Security Requirement Object in the Swagger spec.](https://swagger.io/specification/#securityRequirementObject).
+In Swagger, you can describe how your API is secured by defining one or more security schemes (e.g basic, api key, oauth2 etc.) and declaring which of those schemes are applicable globally OR for specific operations. For more details, take a look at the [Security Requirement Object in the Swagger spec](https://swagger.io/specification/#securityRequirementObject).
 
 In Swashbuckle, you can define schemes by invoking the `AddSecurityDefinition` method, providing a name and an instance of `OpenApiSecurityScheme`. For example you can define an [OAuth 2.0 - implicit flow](https://oauth.net/2/) as follows:
 
+📝 `Startup.cs`
 ```csharp
-// Startup.cs
-services.AddSwaggerGen(c =>
+services.AddSwaggerGen(options =>
 {
-    ...
+    //...
 
     // Define the OAuth2.0 scheme that's in use (i.e. Implicit Flow)
-    c.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
+    options.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
     {
         Type = SecuritySchemeType.OAuth2,
         Flows = new OpenApiOAuthFlows
@@ -656,17 +682,19 @@ services.AddSwaggerGen(c =>
             }
         }
     });
-};
+});
 ```
 
-_NOTE: In addition to defining a scheme, you also need to indicate which operations that scheme is applicable to. You can apply schemes globally (i.e. to ALL operations) through the `AddSecurityRequirement` method. The example below indicates that the scheme called "oauth2" should be applied to all operations, and that the "readAccess" and "writeAccess" scopes are required. When applying schemes of type other than "oauth2", the array of scopes MUST be empty._
+> [!NOTE] 
+> In addition to defining a scheme, you also need to indicate which operations that scheme is applicable to. You can apply schemes globally (i.e. to ALL operations) through the `AddSecurityRequirement` method. The example below indicates that the scheme called "oauth2" should be applied to all operations, and that the `"readAccess"` and `"writeAccess"` scopes are required. When applying schemes of type other than `"oauth2"`, the array of scopes MUST be empty.
 
+📝 `Startup.cs`
 ```csharp
-c.AddSwaggerGen(c =>
+services.AddSwaggerGen(options =>
 {
-    ...
+    //...
 
-    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    options.AddSecurityRequirement(new OpenApiSecurityRequirement
     {
         {
             new OpenApiSecurityScheme
@@ -676,13 +704,13 @@ c.AddSwaggerGen(c =>
             new[] { "readAccess", "writeAccess" }
         }
     });
-})
+});
 ```
 
 If you have schemes that are only applicable for certain operations, you can apply them through an Operation filter. For example, the following filter adds OAuth2 requirements based on the presence of the `AuthorizeAttribute`:
 
+📝 `SecurityRequirementsOperationFilter.cs`
 ```csharp
-// SecurityRequirementsOperationFilter.cs
 public class SecurityRequirementsOperationFilter : IOperationFilter
 {
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
@@ -716,21 +744,22 @@ public class SecurityRequirementsOperationFilter : IOperationFilter
 }
 ```
 
-_NOTE: If you're using the `SwaggerUI` middleware, you can enable interactive OAuth2.0 flows that are powered by the emitted security metadata. See [Enabling OAuth2.0 Flows](#enable-oauth20-flows) for more details._
+> [!NOTE] 
+> If you're using the `SwaggerUI` middleware, you can enable interactive OAuth2.0 flows that are powered by the emitted security metadata. See [Enabling OAuth2.0 Flows](configure-and-customize-swaggerui.md#enable-oauth20-flows) for more details.
 
 ## Add Security Definitions and Requirements for Bearer auth
 
 ```csharp
-services.AddSwaggerGen(c =>
+services.AddSwaggerGen(options =>
 {
-    c.AddSecurityDefinition("bearerAuth", new OpenApiSecurityScheme
+    options.AddSecurityDefinition("bearerAuth", new OpenApiSecurityScheme
     {
         Type = SecuritySchemeType.Http,
         Scheme = "bearer",
         BearerFormat = "JWT",
         Description = "JWT Authorization header using the Bearer scheme."
     });
-    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    options.AddSecurityRequirement(new OpenApiSecurityRequirement
     {
         {
             new OpenApiSecurityScheme
@@ -751,7 +780,7 @@ Swagger / OpenAPI defines the `allOf` and `oneOf` keywords for describing [inher
 
 By default, Swashbuckle flattens inheritance hierarchies. That is, for derived models, the inherited properties are combined and listed alongside the declared properties. This can cause a lot of duplication in the generated Swagger, particularly when there's multiple subtypes. It's also problematic if you're using a client generator (e.g. NSwag) and would like to maintain the inheritance hierarchy in the generated client models. To work around this, you can apply the `UseAllOfForInheritance` setting, and this will leverage the `allOf` keyword to incorporate inherited properties by reference in the generated Swagger:
 
-```
+```yaml
 Circle: {
   type: "object",
   allOf: [
@@ -781,19 +810,20 @@ Shape: {
 
 If your serializer supports polymorphic serialization/deserialization and you would like to list the possible subtypes for an action that accepts/returns abstract base types, you can apply the `UseOneOfForPolymorphism` setting. As a result, the generated request/response schemas will reference a collection of "possible" schemas instead of just the base class schema:
 
-```
+```yaml
 requestBody: {
   content: {
     application/json: {
       schema: {
-      oneOf: [
-        {
-          $ref: "#/components/schemas/Rectangle"
-        },
-        {
-          $ref: "#/components/schemas/Circle"
-        },
-      ],
+        oneOf: [
+          {
+            $ref: "#/components/schemas/Rectangle"
+          },
+          {
+            $ref: "#/components/schemas/Circle"
+          },
+        ],
+      }
     }
   }
 }
@@ -804,13 +834,13 @@ requestBody: {
 As inheritance and polymorphism relationships can often become quite complex, not just in your own models but also within the .NET class library, Swashbuckle is selective about which hierarchies it does and doesn't expose in the generated Swagger. By default, it will pick up any subtypes that are defined in the same assembly as a given base type. If you'd like to override this behavior, you can provide a custom selector function:
 
 ```csharp
-services.AddSwaggerGen(c =>
+services.AddSwaggerGen(options =>
 {
-    ...
+    //...
 
-    c.UseAllOfForInheritance();
+    options.UseAllOfForInheritance();
 
-    c.SelectSubTypesUsing(baseType =>
+    options.SelectSubTypesUsing(baseType =>
     {
         return typeof(Startup).Assembly.GetTypes().Where(type => type.IsSubclassOf(baseType));
     })
@@ -818,7 +848,7 @@ services.AddSwaggerGen(c =>
 ```
 
 > [!NOTE]
-> If you're using the [Swashbuckle Annotations library](#swashbuckleaspnetcoreannotations), it contains a custom selector that's based on the presence of `[JsonDerivedType]` (or `[SwaggerSubType]` for .NET 6 or earlier) attributes on base class definitions. This way, you can use simple attributes to explicitly list the inheritance and/or polymorphism relationships you want to expose. To enable this behavior, check out the [Annotations docs](#list-known-subtypes-for-inheritance-and-polymorphism).
+> If you're using the [Swashbuckle Annotations library](configure-and-customize-annotations.md#configuration--customization-of-swashbuckleaspnetcoreannotations), it contains a custom selector that's based on the presence of `[JsonDerivedType]` (or `[SwaggerSubType]` for .NET 6 or earlier) attributes on base class definitions. This way, you can use simple attributes to explicitly list the inheritance and/or polymorphism relationships you want to expose. To enable this behavior, check out the [Annotations docs](configure-and-customize-annotations.md#list-known-subtypes-for-inheritance-and-polymorphism).
 
 ### Describing Discriminators
 
@@ -826,7 +856,7 @@ In conjunction with the `oneOf` and/or `allOf` keywords, Swagger / OpenAPI suppo
 
 For example, the Newtonsoft serializer supports polymorphic serialization/deserialization by emitting/accepting a "$type" property on JSON instances. The value of this property will be the [assembly qualified type name](https://learn.microsoft.com/dotnet/api/system.type.assemblyqualifiedname) of the type represented by a given JSON instance. So, to explicitly describe this behavior in Swagger, the corresponding request/response schema could be defined as follows:
 
-```
+```yaml
 components: {
   schemas: {
     Shape: {
@@ -837,12 +867,13 @@ components: {
       properties: {
         $type: {
           type": "string"
-      },
-      discriminator: {
-        propertyName: "$type",
-        mapping: {
-          Rectangle: "#/components/schemas/Rectangle",
-          Circle: "#/components/schemas/Circle"
+        },
+        discriminator: {
+          propertyName: "$type",
+          mapping: {
+            Rectangle: "#/components/schemas/Rectangle",
+            Circle: "#/components/schemas/Circle"
+          }
         }
       }
     },
@@ -873,16 +904,16 @@ If `UseAllOfForInheritance` or `UseOneOfForPolymorphism` is enabled, and your se
 Alternatively, if you've customized your serializer to support polymorphic serialization/deserialization, you can provide some custom selector functions to determine the discriminator name and corresponding mapping:
 
 ```csharp
-services.AddSwaggerGen(c =>
+services.AddSwaggerGen(options =>
 {
-    ...
+    //...
 
-    c.UseOneOfForInheritance();
+    options.UseOneOfForInheritance();
 
-    c.SelectDiscriminatorNameUsing((baseType) => "TypeName");
-    c.SelectDiscriminatorValueUsing((subType) => subType.Name);
+    options.SelectDiscriminatorNameUsing((baseType) => "TypeName");
+    options.SelectDiscriminatorValueUsing((subType) => subType.Name);
 });
 ```
 
 > [!NOTE]
-> If you're using the [Swashbuckle Annotations library](#swashbuckleaspnetcoreannotations), it contains custom selector functions that are based on the presence of `[JsonPolymorphic]` (or `[SwaggerDiscriminator]` for .NET 6 or earlier) and `[JsonDerivedType]` (or `[SwaggerSubType]` for .NET 6 or earlier) attributes on base class definitions. This way, you can use simple attributes to explicitly provide discriminator metadata. To enable this behavior, check out the [Annotations docs](#enrich-polymorphic-base-classes-with-discriminator-metadata).
+> If you're using the [Swashbuckle Annotations library](configure-and-customize-annotations.md#configuration--customization-of-swashbuckleaspnetcoreannotations), it contains custom selector functions that are based on the presence of `[JsonPolymorphic]` (or `[SwaggerDiscriminator]` for .NET 6 or earlier) and `[JsonDerivedType]` (or `[SwaggerSubType]` for .NET 6 or earlier) attributes on base class definitions. This way, you can use simple attributes to explicitly provide discriminator metadata. To enable this behavior, check out the [Annotations docs](configure-and-customize-annotations.md#enrich-polymorphic-base-classes-with-discriminator-metadata).

--- a/docs/configure-and-customize-swaggergen.md
+++ b/docs/configure-and-customize-swaggergen.md
@@ -281,7 +281,7 @@ options.SwaggerDoc("v1",
 ```
 
 > [!TIP] 
-> Use IntelliSense to see what other fields are available.
+> Use IntelliSense to see what other members are available.
 
 ## Generate Multiple Swagger Documents
 
@@ -296,7 +296,7 @@ services.AddSwaggerGen(options =>
 ```
 
 > [!NOTE]
-> Take note of the first argument to SwaggerDoc. It MUST be a URI-friendly name that uniquely identifies the document. It's subsequently used to make up the path for requesting the corresponding Swagger JSON. For example, with the default routing, the above documents will be available at `"/swagger/v1/swagger.json"` and `"/swagger/v2/swagger.json"`.
+> Take note of the first argument to SwaggerDoc. It **must** be a URI-friendly name that uniquely identifies the document. It's subsequently used to make up the path for requesting the corresponding Swagger JSON. For example, with the default routing, the above documents will be available at `"/swagger/v1/swagger.json"` and `"/swagger/v2/swagger.json"`.
 
 Next, you'll need to inform Swashbuckle which actions to include in each document. Although this can be customized (see below), by default, the generator will use the `ApiDescription.GroupName` property, part of the built-in metadata layer that ships with ASP.NET Core, to make this distinction. You can set this by decorating individual actions OR by applying an application wide convention.
 
@@ -452,7 +452,7 @@ services.AddSwaggerGen(options =>
 ```
 
 > [!NOTE]
-> This dictates the sort order BEFORE actions are grouped and transformed into the Swagger format. So, it affects the ordering of groups (i.e. Swagger "PathItems"), AND the ordering of operations within a group, in the Swagger output.
+> This dictates the sort order BEFORE actions are grouped and transformed into the Swagger format. So, it affects the ordering of groups (i.e. Swagger "PathItems"), **and** the ordering of operations within a group, in the Swagger output.
 
 ## Customize Schema Id's
 
@@ -483,7 +483,7 @@ services.AddSwaggerGen(options =>
 });
 ```
 > [!NOTE]
-> See [this github issue](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2703) for support for nested types.
+> See [this GitHub issue](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2703) for support for nested types.
 
 ## Override Schema for Specific Types
 
@@ -655,7 +655,7 @@ public class TagDescriptionsDocumentFilter : IDocumentFilter
 
 ## Add Security Definitions and Requirements
 
-In Swagger, you can describe how your API is secured by defining one or more security schemes (e.g basic, api key, oauth2 etc.) and declaring which of those schemes are applicable globally OR for specific operations. For more details, take a look at the [Security Requirement Object in the Swagger spec](https://swagger.io/specification/#securityRequirementObject).
+In Swagger, you can describe how your API is secured by defining one or more security schemes (e.g. Basic, API key, OAuth2 etc.) and declaring which of those schemes are applicable globally OR for specific operations. For more details, take a look at the [Security Requirement Object in the Swagger spec](https://swagger.io/specification/#securityRequirementObject).
 
 In Swashbuckle, you can define schemes by invoking the `AddSecurityDefinition` method, providing a name and an instance of `OpenApiSecurityScheme`. For example you can define an [OAuth 2.0 - implicit flow](https://oauth.net/2/) as follows:
 
@@ -686,7 +686,7 @@ services.AddSwaggerGen(options =>
 ```
 
 > [!NOTE] 
-> In addition to defining a scheme, you also need to indicate which operations that scheme is applicable to. You can apply schemes globally (i.e. to ALL operations) through the `AddSecurityRequirement` method. The example below indicates that the scheme called "oauth2" should be applied to all operations, and that the `"readAccess"` and `"writeAccess"` scopes are required. When applying schemes of type other than `"oauth2"`, the array of scopes MUST be empty.
+> In addition to defining a scheme, you also need to indicate which operations that scheme is applicable to. You can apply schemes globally (i.e. to **all** operations) through the `AddSecurityRequirement` method. The example below indicates that the scheme called `"oauth2"` should be applied to all operations, and that the `"readAccess"` and `"writeAccess"` scopes are required. When applying schemes of type other than `"oauth2"`, the array of scopes **must** be empty.
 
 📝 `Startup.cs`
 ```csharp
@@ -848,7 +848,7 @@ services.AddSwaggerGen(options =>
 ```
 
 > [!NOTE]
-> If you're using the [Swashbuckle Annotations library](configure-and-customize-annotations.md#configuration--customization-of-swashbuckleaspnetcoreannotations), it contains a custom selector that's based on the presence of `[JsonDerivedType]` (or `[SwaggerSubType]` for .NET 6 or earlier) attributes on base class definitions. This way, you can use simple attributes to explicitly list the inheritance and/or polymorphism relationships you want to expose. To enable this behavior, check out the [Annotations docs](configure-and-customize-annotations.md#list-known-subtypes-for-inheritance-and-polymorphism).
+> If you're using the [Swashbuckle Annotations library](configure-and-customize-annotations.md#configuration--customization-of-swashbuckleaspnetcoreannotations), it contains a custom selector that's based on the presence of `[JsonDerivedType]` attributes on base class definitions. This way, you can use simple attributes to explicitly list the inheritance and/or polymorphism relationships you want to expose. To enable this behavior, check out the [Annotations docs](configure-and-customize-annotations.md#list-known-subtypes-for-inheritance-and-polymorphism).
 
 ### Describing Discriminators
 
@@ -916,4 +916,4 @@ services.AddSwaggerGen(options =>
 ```
 
 > [!NOTE]
-> If you're using the [Swashbuckle Annotations library](configure-and-customize-annotations.md#configuration--customization-of-swashbuckleaspnetcoreannotations), it contains custom selector functions that are based on the presence of `[JsonPolymorphic]` (or `[SwaggerDiscriminator]` for .NET 6 or earlier) and `[JsonDerivedType]` (or `[SwaggerSubType]` for .NET 6 or earlier) attributes on base class definitions. This way, you can use simple attributes to explicitly provide discriminator metadata. To enable this behavior, check out the [Annotations docs](configure-and-customize-annotations.md#enrich-polymorphic-base-classes-with-discriminator-metadata).
+> If you're using the [Swashbuckle Annotations library](configure-and-customize-annotations.md#configuration--customization-of-swashbuckleaspnetcoreannotations), it contains custom selector functions that are based on the presence of `[JsonPolymorphic]` and `[JsonDerivedType]` attributes on base class definitions. This way, you can use simple attributes to explicitly provide discriminator metadata. To enable this behavior, check out the [Annotations docs](configure-and-customize-annotations.md#enrich-polymorphic-base-classes-with-discriminator-metadata).

--- a/docs/configure-and-customize-swaggerui.md
+++ b/docs/configure-and-customize-swaggerui.md
@@ -8,7 +8,7 @@ By default, the Swagger UI will be exposed at `"/swagger"`. If necessary, you ca
 app.UseSwaggerUI(options =>
 {
     options.RoutePrefix = "api-docs"
-}
+});
 ```
 
 ## Change Document Title
@@ -19,7 +19,7 @@ By default, the Swagger UI will have a generic document title. When you have mul
 app.UseSwaggerUI(options =>
 {
     options.DocumentTitle = "My Swagger UI";
-}
+});
 ```
 
 ## Change CSS or JS Paths
@@ -32,7 +32,7 @@ app.UseSwaggerUI(options =>
     options.StylesPath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.10/swagger-ui.min.css";
     options.ScriptBundlePath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.10/swagger-ui-bundle.min.js";
     options.ScriptPresetsPath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.10/swagger-ui-standalone-preset.min.js";
-}
+});
 ```
 
 ## List Multiple Swagger Documents
@@ -44,7 +44,7 @@ app.UseSwaggerUI(options =>
 {
     options.SwaggerEndpoint("/swagger/v1/swagger.json", "V1 Docs");
     options.SwaggerEndpoint("/swagger/v2/swagger.json", "V2 Docs");
-}
+});
 ```
 
 ## Apply swagger-ui Parameters
@@ -86,7 +86,7 @@ To tweak the behavior, you can inject additional JavaScript files by adding them
 app.UseSwaggerUI(options =>
 {
     options.InjectJavascript("/swagger-ui/custom.js");
-}
+});
 ```
 
 > [!NOTE] 
@@ -103,7 +103,7 @@ To tweak the look and feel, you can inject additional CSS stylesheets by adding 
 app.UseSwaggerUI(options =>
 {
     options.InjectStylesheet("/swagger-ui/custom.css");
-}
+});
 ```
 
 ## Customize index.html

--- a/docs/configure-and-customize-swaggerui.md
+++ b/docs/configure-and-customize-swaggerui.md
@@ -2,12 +2,12 @@
 
 ## Change Relative Path to the UI
 
-By default, the Swagger UI will be exposed at "/swagger". If necessary, you can alter this when enabling the SwaggerUI middleware:
+By default, the Swagger UI will be exposed at `"/swagger"`. If necessary, you can alter this when enabling the SwaggerUI middleware:
 
 ```csharp
-app.UseSwaggerUI(c =>
+app.UseSwaggerUI(options =>
 {
-    c.RoutePrefix = "api-docs"
+    options.RoutePrefix = "api-docs"
 }
 ```
 
@@ -16,9 +16,9 @@ app.UseSwaggerUI(c =>
 By default, the Swagger UI will have a generic document title. When you have multiple Swagger pages open, it can be difficult to tell them apart. You can alter this when enabling the SwaggerUI middleware:
 
 ```csharp
-app.UseSwaggerUI(c =>
+app.UseSwaggerUI(options =>
 {
-    c.DocumentTitle = "My Swagger UI";
+    options.DocumentTitle = "My Swagger UI";
 }
 ```
 
@@ -27,11 +27,11 @@ app.UseSwaggerUI(c =>
 By default, the Swagger UI include default CSS and JS, but if you wish to change the path or URL (for example to use a CDN):
 
 ```csharp
-app.UseSwaggerUI(c =>
+app.UseSwaggerUI(options =>
 {
-    c.StylesPath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.10/swagger-ui.min.css";
-    c.ScriptBundlePath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.10/swagger-ui-bundle.min.js";
-    c.ScriptPresetsPath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.10/swagger-ui-standalone-preset.min.js";
+    options.StylesPath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.10/swagger-ui.min.css";
+    options.ScriptBundlePath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.10/swagger-ui-bundle.min.js";
+    options.ScriptPresetsPath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.10/swagger-ui-standalone-preset.min.js";
 }
 ```
 
@@ -40,10 +40,10 @@ app.UseSwaggerUI(c =>
 When enabling the middleware, you're required to specify one or more Swagger endpoints (fully qualified or relative to the UI page) to power the UI. If you provide multiple endpoints, they'll be listed in the top right corner of the page, allowing users to toggle between the different documents. For example, the following configuration could be used to document different versions of an API.
 
 ```csharp
-app.UseSwaggerUI(c =>
+app.UseSwaggerUI(options =>
 {
-    c.SwaggerEndpoint("/swagger/v1/swagger.json", "V1 Docs");
-    c.SwaggerEndpoint("/swagger/v2/swagger.json", "V2 Docs");
+    options.SwaggerEndpoint("/swagger/v1/swagger.json", "V1 Docs");
+    options.SwaggerEndpoint("/swagger/v2/swagger.json", "V2 Docs");
 }
 ```
 
@@ -52,26 +52,26 @@ app.UseSwaggerUI(c =>
 The swagger-ui ships with its own set of configuration parameters, all described [here](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md#display). In Swashbuckle, most of these are surfaced through the SwaggerUI middleware options:
 
 ```csharp
-app.UseSwaggerUI(c =>
+app.UseSwaggerUI(options =>
 {
-    c.DefaultModelExpandDepth(2);
-    c.DefaultModelRendering(ModelRendering.Model);
-    c.DefaultModelsExpandDepth(-1);
-    c.DisplayOperationId();
-    c.DisplayRequestDuration();
-    c.DocExpansion(DocExpansion.None);
-    c.EnableDeepLinking();
-    c.EnableFilter();
-    c.EnablePersistAuthorization();
-    c.EnableTryItOutByDefault();
-    c.MaxDisplayedTags(5);
-    c.ShowExtensions();
-    c.ShowCommonExtensions();
-    c.Plugins = ["myCustomPlugin"];
-    c.EnableValidator();
-    c.SupportedSubmitMethods(SubmitMethod.Get, SubmitMethod.Head);
-    c.UseRequestInterceptor("(request) => { return request; }");
-    c.UseResponseInterceptor("(response) => { return response; }");
+    options.DefaultModelExpandDepth(2);
+    options.DefaultModelRendering(ModelRendering.Model);
+    options.DefaultModelsExpandDepth(-1);
+    options.DisplayOperationId();
+    options.DisplayRequestDuration();
+    options.DocExpansion(DocExpansion.None);
+    options.EnableDeepLinking();
+    options.EnableFilter();
+    options.EnablePersistAuthorization();
+    options.EnableTryItOutByDefault();
+    options.MaxDisplayedTags(5);
+    options.ShowExtensions();
+    options.ShowCommonExtensions();
+    options.Plugins = ["myCustomPlugin"];
+    options.EnableValidator();
+    options.SupportedSubmitMethods(SubmitMethod.Get, SubmitMethod.Head);
+    options.UseRequestInterceptor("(request) => { return request; }");
+    options.UseResponseInterceptor("(response) => { return response; }");
 });
 ```
 
@@ -83,24 +83,26 @@ app.UseSwaggerUI(c =>
 To tweak the behavior, you can inject additional JavaScript files by adding them to your `wwwroot` folder and specifying the relative paths in the middleware options:
 
 ```csharp
-app.UseSwaggerUI(c =>
+app.UseSwaggerUI(options =>
 {
-    c.InjectJavascript("/swagger-ui/custom.js");
+    options.InjectJavascript("/swagger-ui/custom.js");
 }
 ```
 
-_NOTE: The `InjectOnCompleteJavaScript` and `InjectOnFailureJavaScript` options have been removed because the latest version of swagger-ui doesn't expose the necessary hooks. Instead, it provides a [flexible customization system](https://github.com/swagger-api/swagger-ui/blob/master/docs/customization/overview.md) based on concepts and patterns from React and Redux. To leverage this, you'll need to provide a custom version of index.html as described [below](#customize-indexhtml)._
+> [!NOTE] 
+> The `InjectOnCompleteJavaScript` and `InjectOnFailureJavaScript` options have been removed because the latest version of swagger-ui doesn't expose the necessary hooks. Instead, it provides a [flexible customization system](https://github.com/swagger-api/swagger-ui/blob/master/docs/customization/overview.md) based on concepts and patterns from React and Redux. To leverage this, you'll need to provide a custom version of index.html as described [below](#customize-indexhtml).
 
-The [custom index sample app](test/WebSites/CustomUIIndex/Swagger/index.html) demonstrates this approach, using the swagger-ui plugin system provide a custom topbar, and to hide the info component.
+> [!TIP]
+> The [custom index sample app](../test/WebSites/CustomUIIndex/Swagger/index.html) demonstrates this approach, using the swagger-ui plugin system provide a custom topbar, and to hide the info component.
 
 ## Inject Custom CSS
 
 To tweak the look and feel, you can inject additional CSS stylesheets by adding them to your `wwwroot` folder and specifying the relative paths in the middleware options:
 
 ```csharp
-app.UseSwaggerUI(c =>
+app.UseSwaggerUI(options =>
 {
-    c.InjectStylesheet("/swagger-ui/custom.css");
+    options.InjectStylesheet("/swagger-ui/custom.css");
 }
 ```
 
@@ -109,35 +111,36 @@ app.UseSwaggerUI(c =>
 To customize the UI beyond the basic options listed above, you can provide your own version of the swagger-ui index.html page:
 
 ```csharp
-app.UseSwaggerUI(c =>
+app.UseSwaggerUI(options =>
 {
-    c.IndexStream = () => GetType().Assembly
+    options.IndexStream = () => GetType().Assembly
         .GetManifestResourceStream("CustomUIIndex.Swagger.index.html"); // requires file to be added as an embedded resource
 });
 ```
 
-_To get started, you should base your custom index.html on the [default version](src/Swashbuckle.AspNetCore.SwaggerUI/index.html)_
+> [!TIP]
+> To get started, you should base your custom `index.html` on the [default version](../src/Swashbuckle.AspNetCore.SwaggerUI/index.html)
 
 ## Enable OAuth2.0 Flows
 
-The swagger-ui has built-in support to participate in OAuth2.0 authorization flows. It interacts with authorization and/or token endpoints, as specified in the Swagger JSON, to obtain access tokens for subsequent API calls. See [Adding Security Definitions and Requirements](#add-security-definitions-and-requirements) for an example of adding OAuth2.0 metadata to the generated Swagger.
+The swagger-ui has built-in support to participate in OAuth2.0 authorization flows. It interacts with authorization and/or token endpoints, as specified in the Swagger JSON, to obtain access tokens for subsequent API calls. See [Adding Security Definitions and Requirements](configure-and-customize-swaggergen.md#add-security-definitions-and-requirements) for an example of adding OAuth2.0 metadata to the generated Swagger.
 
 If your Swagger endpoint includes the appropriate security metadata, the UI interaction should be automatically enabled. However, you can further customize OAuth support in the UI with the following settings below. See [Swagger-UI documentation](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/oauth2.md) for more info:
 
 ```csharp
-app.UseSwaggerUI(c =>
+app.UseSwaggerUI(options =>
 {
-    c.OAuthClientId("test-id");
-    c.OAuthClientSecret("test-secret");
-    c.OAuthUsername("test-user");
-    c.OAuthRealm("test-realm");
-    c.OAuthAppName("test-app");
-    c.OAuth2RedirectUrl("url");
-    c.OAuthScopeSeparator(" ");
-    c.OAuthScopes("scope1", "scope2");
-    c.OAuthAdditionalQueryStringParams(new Dictionary<string, string> { { "foo", "bar" }}); 
-    c.OAuthUseBasicAuthenticationWithAccessCodeGrant();
-    c.OAuthUsePkce();
+    options.OAuthClientId("test-id");
+    options.OAuthClientSecret("test-secret");
+    options.OAuthUsername("test-user");
+    options.OAuthRealm("test-realm");
+    options.OAuthAppName("test-app");
+    options.OAuth2RedirectUrl("url");
+    options.OAuthScopeSeparator(" ");
+    options.OAuthScopes("scope1", "scope2");
+    options.OAuthAdditionalQueryStringParams(new Dictionary<string, string> { { "foo", "bar" }}); 
+    options.OAuthUseBasicAuthenticationWithAccessCodeGrant();
+    options.OAuthUsePkce();
 });
 ```
 
@@ -146,18 +149,18 @@ app.UseSwaggerUI(c =>
 To use custom interceptors on requests and responses going through swagger-ui you can define them as javascript functions in the configuration:
 
 ```csharp
-app.UseSwaggerUI(c =>
+app.UseSwaggerUI(options =>
 {
-    c.UseRequestInterceptor("(req) => { req.headers['x-my-custom-header'] = 'MyCustomValue'; return req; }");
-    c.UseResponseInterceptor("(res) => { console.log('Custom interceptor intercepted response from:', res.url); return res; }");
+    options.UseRequestInterceptor("(req) => { req.headers['x-my-custom-header'] = 'MyCustomValue'; return req; }");
+    options.UseResponseInterceptor("(res) => { console.log('Custom interceptor intercepted response from:', res.url); return res; }");
 });
 ```
 
 This can be useful in a range of scenarios where you might want to append local xsrf tokens to all requests for example:
 
 ```csharp
-app.UseSwaggerUI(c =>
+app.UseSwaggerUI(options =>
 {
-    c.UseRequestInterceptor("(req) => { req.headers['X-XSRF-Token'] = localStorage.getItem('xsrf-token'); return req; }");
+    options.UseRequestInterceptor("(req) => { req.headers['X-XSRF-Token'] = localStorage.getItem('xsrf-token'); return req; }");
 });
 ```

--- a/docs/configure-and-customize-swaggerui.md
+++ b/docs/configure-and-customize-swaggerui.md
@@ -29,9 +29,9 @@ By default, the Swagger UI include default CSS and JS, but if you wish to change
 ```csharp
 app.UseSwaggerUI(options =>
 {
-    options.StylesPath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.10/swagger-ui.min.css";
-    options.ScriptBundlePath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.10/swagger-ui-bundle.min.js";
-    options.ScriptPresetsPath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.10/swagger-ui-standalone-preset.min.js";
+    options.StylesPath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.21.0/swagger-ui.min.css";
+    options.ScriptBundlePath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.21.0/swagger-ui-bundle.min.js";
+    options.ScriptPresetsPath = "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.21.0/swagger-ui-standalone-preset.min.js";
 });
 ```
 


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

- #3365
- #3405 

## Details on the issue fix or feature implementation

### Improvements
- Update broken links
- Use [github's markdown alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) syntax for Note sections
- Replace lambda functions' parameter names to more meaningful
- Split those code blocks that contains code fragments for multiple files
- Add syntax highlight for missing code blocks
- Make the code blocks copy-paste ready

### Done
- Annotations: [Preview](https://github.com/peter-csala/Swashbuckle.AspNetCore/blob/3365-improve-formatting-of-the-documentation/docs/configure-and-customize-annotations.md)
- CLI: [Preview](https://github.com/peter-csala/Swashbuckle.AspNetCore/blob/3365-improve-formatting-of-the-documentation/docs/configure-and-customize-cli.md)
- ReDoc: [Preview](https://github.com/peter-csala/Swashbuckle.AspNetCore/blob/3365-improve-formatting-of-the-documentation/docs/configure-and-customize-redoc.md)
- Swagger: [Preview](https://github.com/peter-csala/Swashbuckle.AspNetCore/blob/3365-improve-formatting-of-the-documentation/docs/configure-and-customize-swagger.md)
- SwaggerUI: [Preview](https://github.com/peter-csala/Swashbuckle.AspNetCore/blob/3365-improve-formatting-of-the-documentation/docs/configure-and-customize-swaggerui.md)
- SwaggerGen: [Preview](https://github.com/peter-csala/Swashbuckle.AspNetCore/blob/3365-improve-formatting-of-the-documentation/docs/configure-and-customize-swaggergen.md)
