### PR TITLE
Fix culture-insensitive handling of numbers in RangeAttribute

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
@@ -252,12 +252,14 @@ public static class OpenApiSchemaExtensions
 
     private static void ApplyRangeAttribute(OpenApiSchema schema, RangeAttribute rangeAttribute)
     {
-        schema.Maximum = decimal.TryParse(rangeAttribute.Maximum.ToString(), out decimal maximum)
+        const NumberStyles numberStyles = NumberStyles.Number | NumberStyles.Float;
+
+        schema.Maximum = decimal.TryParse(rangeAttribute.Maximum.ToString(), numberStyles, CultureInfo.InvariantCulture, out decimal maximum)
             ? maximum.ToString(CultureInfo.InvariantCulture)
             : schema.Maximum;
 
-        schema.Minimum = decimal.TryParse(rangeAttribute.Minimum.ToString(), out decimal minimum)
-            ? minimum.ToString()
+        schema.Minimum = decimal.TryParse(rangeAttribute.Minimum.ToString(), numberStyles, CultureInfo.InvariantCulture, out decimal minimum)
+            ? minimum.ToString(CultureInfo.InvariantCulture)
             : schema.Minimum;
 
 #if NET


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

Fix for https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/3283#discussion_r2106322231: do not read/write fractional numbers in the current culture, which depends on OS-level settings, potentially resulting in unparsable JSON.

## Details on the issue fix or feature implementation

According to https://json-schema.org/understanding-json-schema/reference/numeric#number, exponents are allowed, which is why I combined the flags:

```c#
[Flags]
public enum NumberStyles
{
    Number = AllowThousands | AllowDecimalPoint | AllowTrailingSign | Integer,
    Float = AllowExponent | AllowDecimalPoint | Integer
}
```