### PR TITLE
use one of behind a flag instead for nullable enums

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
@@ -32,6 +32,7 @@ internal class ConfigureSchemaGeneratorOptions(
         target.DiscriminatorNameSelector = source.DiscriminatorNameSelector;
         target.DiscriminatorValueSelector = source.DiscriminatorValueSelector;
         target.UseAllOfToExtendReferenceSchemas = source.UseAllOfToExtendReferenceSchemas;
+        target.UseOneOfForNullableEnums = source.UseOneOfForNullableEnums;
         target.SupportNonNullableReferenceTypes = source.SupportNonNullableReferenceTypes;
         target.NonNullableReferenceTypesAsRequired = source.NonNullableReferenceTypesAsRequired;
         target.SchemaFilters = [.. source.SchemaFilters];

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -300,6 +300,15 @@ public static class SwaggerGenOptionsExtensions
     }
 
     /// <summary>
+    /// Extend enum schemas (using the oneOf construct) to allow null when an enum is referenced
+    /// </summary>
+    /// <param name="swaggerGenOptions"></param>
+    public static void UseOneOfForNullableEnums(this SwaggerGenOptions swaggerGenOptions)
+    {
+        swaggerGenOptions.SchemaGeneratorOptions.UseOneOfForNullableEnums = true;
+    }
+
+    /// <summary>
     /// Enable detection of non nullable reference types to set Nullable flag accordingly on schema properties
     /// </summary>
     /// <param name="swaggerGenOptions"></param>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.UseOneOfForNullableEnums(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions) -> void
+Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions.UseOneOfForNullableEnums.get -> bool
+Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions.UseOneOfForNullableEnums.set -> void

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -155,6 +155,13 @@ public class SchemaGenerator(
         ParameterInfo parameterInfo,
         ApiParameterRouteInfo routeInfo)
     {
+        var customAttributes = parameterInfo.GetCustomAttributes();
+
+        if (customAttributes.OfType<RequiredAttribute>().Any())
+        {
+            modelType = Nullable.GetUnderlyingType(modelType) ?? modelType;
+        }
+
         var dataContract = GetDataContractFor(modelType);
 
         var schema = _generatorOptions.UseOneOfForPolymorphism && IsBaseTypeWithKnownTypesDefined(dataContract, out var knownTypesDataContracts)
@@ -169,8 +176,6 @@ public class SchemaGenerator(
 
         if (schema.Reference == null)
         {
-            var customAttributes = parameterInfo.GetCustomAttributes();
-
             var defaultValue = parameterInfo.HasDefaultValue
                 ? parameterInfo.DefaultValue
                 : customAttributes.OfType<DefaultValueAttribute>().FirstOrDefault()?.Value;
@@ -178,6 +183,11 @@ public class SchemaGenerator(
             if (defaultValue != null)
             {
                 schema.Default = GenerateDefaultValue(dataContract, modelType, defaultValue);
+            }
+
+            if (Nullable.GetUnderlyingType(modelType) is not null && !customAttributes.OfType<RequiredAttribute>().Any())
+            {
+                schema.Nullable = true;
             }
 
             schema.ApplyValidationAttributes(customAttributes);
@@ -283,8 +293,8 @@ public class SchemaGenerator(
             case DataType.Number:
             case DataType.String:
                 {
-                    schemaFactory = () => CreatePrimitiveSchema(dataContract);
-                    returnAsReference = (Nullable.GetUnderlyingType(dataContract.UnderlyingType) ?? dataContract.UnderlyingType).IsEnum && !_generatorOptions.UseInlineDefinitionsForEnums;
+                    schemaFactory = () => CreatePrimitiveSchema(dataContract, schemaRepository);
+                    returnAsReference = dataContract.UnderlyingType.IsEnum && !_generatorOptions.UseInlineDefinitionsForEnums;
                     break;
                 }
 
@@ -329,8 +339,31 @@ public class SchemaGenerator(
             (modelType.IsConstructedGenericType && _generatorOptions.CustomTypeMappings.TryGetValue(modelType.GetGenericTypeDefinition(), out schemaFactory));
     }
 
-    private static OpenApiSchema CreatePrimitiveSchema(DataContract dataContract)
+    private OpenApiSchema CreatePrimitiveSchema(DataContract dataContract, SchemaRepository schemaRepository)
     {
+        var underlyingType = Nullable.GetUnderlyingType(dataContract.UnderlyingType) ?? dataContract.UnderlyingType;
+
+        if (underlyingType.IsEnum && dataContract.UnderlyingType != underlyingType)
+        {
+            var enumDataContract = GetDataContractFor(underlyingType);
+
+            var enumSchema = GenerateConcreteSchema(enumDataContract, schemaRepository);
+
+            if (_generatorOptions.UseInlineDefinitionsForEnums)
+            {
+                enumSchema.Enum.Add(null);
+                return enumSchema;
+            }
+
+            if (_generatorOptions.UseOneOfForNullableEnums)
+            {
+                enumSchema.OneOf = [new OpenApiSchema { Reference = enumSchema.Reference }, new OpenApiSchema() { Enum = [null] }];
+                enumSchema.Reference = null;
+            }
+
+            return enumSchema;
+        }
+
         var schema = new OpenApiSchema
         {
             Type = FromDataType(dataContract.DataType),
@@ -350,17 +383,9 @@ public class SchemaGenerator(
         }
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        var underlyingType = Nullable.GetUnderlyingType(dataContract.UnderlyingType) ?? dataContract.UnderlyingType;
-
         if (underlyingType.IsEnum)
         {
             var enumValues = underlyingType.GetEnumValues().Cast<object>();
-
-            if (dataContract.UnderlyingType != underlyingType)
-            {
-                schema.Nullable = true;
-                enumValues = enumValues.Append(null);
-            }
 
             schema.Enum = [.. enumValues
                 .Select(value => dataContract.JsonConverter(value))

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
@@ -40,6 +40,11 @@ public class SchemaGeneratorOptions
 
     public IList<ISchemaFilter> SchemaFilters { get; set; }
 
+    /// <summary>
+    /// Uses oneOf for enums when the value can be null.
+    /// </summary>
+    public bool UseOneOfForNullableEnums { get; set; }
+
     private string DefaultSchemaIdSelector(Type modelType)
     {
         if (!modelType.IsConstructedGenericType)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -598,7 +598,7 @@ public class SwaggerGenerator(
 
         var schema = (type != null)
             ? GenerateSchema(
-                isRequired ? (Nullable.GetUnderlyingType(type) ?? type) : type,
+                Nullable.GetUnderlyingType(type) ?? type,
                 schemaRepository,
                 apiParameter.PropertyInfo(),
                 apiParameter.ParameterInfo(),

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -1491,7 +1491,7 @@
             "$ref": "#/components/schemas/ProductStatus"
           },
           "status2": {
-            "$ref": "#/components/schemas/ProductStatusNullable"
+            "$ref": "#/components/schemas/ProductStatus"
           }
         },
         "additionalProperties": false,
@@ -1510,17 +1510,6 @@
         ],
         "type": "integer",
         "format": "int32"
-      },
-      "ProductStatusNullable": {
-        "enum": [
-          0,
-          1,
-          2,
-          null
-        ],
-        "type": "integer",
-        "format": "int32",
-        "nullable": true
       },
       "Promotion": {
         "type": "object",

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.SwaggerEndpoint_ReturnsValidSwaggerJson_startupType=Basic.Startup_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -1491,7 +1491,7 @@
             "$ref": "#/components/schemas/ProductStatus"
           },
           "status2": {
-            "$ref": "#/components/schemas/ProductStatusNullable"
+            "$ref": "#/components/schemas/ProductStatus"
           }
         },
         "additionalProperties": false,
@@ -1510,17 +1510,6 @@
         ],
         "type": "integer",
         "format": "int32"
-      },
-      "ProductStatusNullable": {
-        "enum": [
-          0,
-          1,
-          2,
-          null
-        ],
-        "type": "integer",
-        "format": "int32",
-        "nullable": true
       },
       "Promotion": {
         "type": "object",

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=MvcWithNullable.Program_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=MvcWithNullable.Program_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -5,7 +5,7 @@
     "version": "1.0"
   },
   "paths": {
-    "/api/Enum": {
+    "/api/Enum/query": {
       "get": {
         "tags": [
           "Enum"
@@ -17,7 +17,7 @@
             "schema": {
               "allOf": [
                 {
-                  "$ref": "#/components/schemas/LogLevelNullable"
+                  "$ref": "#/components/schemas/LogLevel"
                 }
               ],
               "default": 4
@@ -31,15 +31,15 @@
         }
       }
     },
-    "/api/RequiredEnum": {
+    "/api/Enum/path/{logLevel}": {
       "get": {
         "tags": [
-          "RequiredEnum"
+          "Enum"
         ],
         "parameters": [
           {
             "name": "logLevel",
-            "in": "query",
+            "in": "path",
             "required": true,
             "schema": {
               "allOf": [
@@ -51,6 +51,186 @@
             }
           }
         ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/Enum/header": {
+      "get": {
+        "tags": [
+          "Enum"
+        ],
+        "parameters": [
+          {
+            "name": "logLevel",
+            "in": "header",
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LogLevel"
+                }
+              ],
+              "default": 4
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/Enum/enum-body": {
+      "get": {
+        "tags": [
+          "Enum"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LogLevel"
+                  },
+                  {
+                    "enum": [
+                      null
+                    ]
+                  }
+                ],
+                "default": 4,
+                "nullable": true
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LogLevel"
+                  },
+                  {
+                    "enum": [
+                      null
+                    ]
+                  }
+                ],
+                "default": 4,
+                "nullable": true
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LogLevel"
+                  },
+                  {
+                    "enum": [
+                      null
+                    ]
+                  }
+                ],
+                "default": 4,
+                "nullable": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/Enum/type-body": {
+      "get": {
+        "tags": [
+          "Enum"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TypeWithNullable"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TypeWithNullable"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TypeWithNullable"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/RequiredEnum": {
+      "get": {
+        "tags": [
+          "RequiredEnum"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LogLevel"
+                  }
+                ],
+                "default": 4
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LogLevel"
+                  }
+                ],
+                "default": 4
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LogLevel"
+                  }
+                ],
+                "default": 4
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "OK"
@@ -74,20 +254,48 @@
         "type": "integer",
         "format": "int32"
       },
-      "LogLevelNullable": {
-        "enum": [
-          0,
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          null
+      "TypeWithNullable": {
+        "required": [
+          "jsonRequiredLogLevel",
+          "requiredLogLevel"
         ],
-        "type": "integer",
-        "format": "int32",
-        "nullable": true
+        "type": "object",
+        "properties": {
+          "logLevel": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LogLevel"
+              },
+              {
+                "enum": [
+                  null
+                ]
+              }
+            ],
+            "nullable": true
+          },
+          "requiredLogLevel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LogLevel"
+              }
+            ]
+          },
+          "jsonRequiredLogLevel": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LogLevel"
+              },
+              {
+                "enum": [
+                  null
+                ]
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
       }
     }
   }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=MvcWithNullable.Program_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=MvcWithNullable.Program_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -5,7 +5,7 @@
     "version": "1.0"
   },
   "paths": {
-    "/api/Enum": {
+    "/api/Enum/query": {
       "get": {
         "tags": [
           "Enum"
@@ -17,7 +17,7 @@
             "schema": {
               "allOf": [
                 {
-                  "$ref": "#/components/schemas/LogLevelNullable"
+                  "$ref": "#/components/schemas/LogLevel"
                 }
               ],
               "default": 4
@@ -31,15 +31,15 @@
         }
       }
     },
-    "/api/RequiredEnum": {
+    "/api/Enum/path/{logLevel}": {
       "get": {
         "tags": [
-          "RequiredEnum"
+          "Enum"
         ],
         "parameters": [
           {
             "name": "logLevel",
-            "in": "query",
+            "in": "path",
             "required": true,
             "schema": {
               "allOf": [
@@ -51,6 +51,186 @@
             }
           }
         ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/Enum/header": {
+      "get": {
+        "tags": [
+          "Enum"
+        ],
+        "parameters": [
+          {
+            "name": "logLevel",
+            "in": "header",
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/LogLevel"
+                }
+              ],
+              "default": 4
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/Enum/enum-body": {
+      "get": {
+        "tags": [
+          "Enum"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LogLevel"
+                  },
+                  {
+                    "enum": [
+                      null
+                    ]
+                  }
+                ],
+                "default": 4,
+                "nullable": true
+              }
+            },
+            "text/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LogLevel"
+                  },
+                  {
+                    "enum": [
+                      null
+                    ]
+                  }
+                ],
+                "default": 4,
+                "nullable": true
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/LogLevel"
+                  },
+                  {
+                    "enum": [
+                      null
+                    ]
+                  }
+                ],
+                "default": 4,
+                "nullable": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/Enum/type-body": {
+      "get": {
+        "tags": [
+          "Enum"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TypeWithNullable"
+                  }
+                ]
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TypeWithNullable"
+                  }
+                ]
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TypeWithNullable"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/RequiredEnum": {
+      "get": {
+        "tags": [
+          "RequiredEnum"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LogLevel"
+                  }
+                ],
+                "default": 4
+              }
+            },
+            "text/json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LogLevel"
+                  }
+                ],
+                "default": 4
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LogLevel"
+                  }
+                ],
+                "default": 4
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "OK"
@@ -74,20 +254,48 @@
         "type": "integer",
         "format": "int32"
       },
-      "LogLevelNullable": {
-        "enum": [
-          0,
-          1,
-          2,
-          3,
-          4,
-          5,
-          6,
-          null
+      "TypeWithNullable": {
+        "required": [
+          "jsonRequiredLogLevel",
+          "requiredLogLevel"
         ],
-        "type": "integer",
-        "format": "int32",
-        "nullable": true
+        "type": "object",
+        "properties": {
+          "logLevel": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LogLevel"
+              },
+              {
+                "enum": [
+                  null
+                ]
+              }
+            ],
+            "nullable": true
+          },
+          "requiredLogLevel": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LogLevel"
+              }
+            ]
+          },
+          "jsonRequiredLogLevel": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LogLevel"
+              },
+              {
+                "enum": [
+                  null
+                ]
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
       }
     }
   }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.DotNet8_0.verified.txt
@@ -379,7 +379,7 @@
             "name": "paramNine",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/DateTimeKindNullable"
+              "$ref": "#/components/schemas/DateTimeKind"
             }
           },
           {
@@ -946,7 +946,7 @@
             "format": "time"
           },
           "paramNine": {
-            "$ref": "#/components/schemas/DateTimeKindNullable"
+            "$ref": "#/components/schemas/DateTimeKind"
           },
           "paramTen": {
             "$ref": "#/components/schemas/DateTimeKind"
@@ -994,17 +994,6 @@
         ],
         "type": "integer",
         "format": "int32"
-      },
-      "DateTimeKindNullable": {
-        "enum": [
-          0,
-          1,
-          2,
-          null
-        ],
-        "type": "integer",
-        "format": "int32",
-        "nullable": true
       },
       "Fruit": {
         "type": "object",

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.DotNet9_0.verified.txt
@@ -379,7 +379,7 @@
             "name": "paramNine",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/DateTimeKindNullable"
+              "$ref": "#/components/schemas/DateTimeKind"
             }
           },
           {
@@ -946,7 +946,7 @@
             "format": "time"
           },
           "paramNine": {
-            "$ref": "#/components/schemas/DateTimeKindNullable"
+            "$ref": "#/components/schemas/DateTimeKind"
           },
           "paramTen": {
             "$ref": "#/components/schemas/DateTimeKind"
@@ -994,17 +994,6 @@
         ],
         "type": "integer",
         "format": "int32"
-      },
-      "DateTimeKindNullable": {
-        "enum": [
-          0,
-          1,
-          2,
-          null
-        ],
-        "type": "integer",
-        "format": "int32",
-        "nullable": true
       },
       "Fruit": {
         "type": "object",

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.TypesAreRenderedCorrectly.DotNet8_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.TypesAreRenderedCorrectly.DotNet8_0.verified.txt
@@ -379,7 +379,7 @@
             "name": "paramNine",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/DateTimeKindNullable"
+              "$ref": "#/components/schemas/DateTimeKind"
             }
           },
           {
@@ -946,7 +946,7 @@
             "format": "time"
           },
           "paramNine": {
-            "$ref": "#/components/schemas/DateTimeKindNullable"
+            "$ref": "#/components/schemas/DateTimeKind"
           },
           "paramTen": {
             "$ref": "#/components/schemas/DateTimeKind"
@@ -994,17 +994,6 @@
         ],
         "type": "integer",
         "format": "int32"
-      },
-      "DateTimeKindNullable": {
-        "enum": [
-          0,
-          1,
-          2,
-          null
-        ],
-        "type": "integer",
-        "format": "int32",
-        "nullable": true
       },
       "Fruit": {
         "type": "object",

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.TypesAreRenderedCorrectly.DotNet9_0.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/VerifyTests.TypesAreRenderedCorrectly.DotNet9_0.verified.txt
@@ -379,7 +379,7 @@
             "name": "paramNine",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/DateTimeKindNullable"
+              "$ref": "#/components/schemas/DateTimeKind"
             }
           },
           {
@@ -946,7 +946,7 @@
             "format": "time"
           },
           "paramNine": {
-            "$ref": "#/components/schemas/DateTimeKindNullable"
+            "$ref": "#/components/schemas/DateTimeKind"
           },
           "paramTen": {
             "$ref": "#/components/schemas/DateTimeKind"
@@ -994,17 +994,6 @@
         ],
         "type": "integer",
         "format": "int32"
-      },
-      "DateTimeKindNullable": {
-        "enum": [
-          0,
-          1,
-          2,
-          null
-        ],
-        "type": "integer",
-        "format": "int32",
-        "nullable": true
       },
       "Fruit": {
         "type": "object",

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -88,8 +88,8 @@ public class NewtonsoftSchemaGeneratorTests
     {
         { typeof(IntEnum), JsonSchemaTypes.Integer, "int32", 3 },
         { typeof(LongEnum), JsonSchemaTypes.Integer, "int64", 3 },
-        { typeof(IntEnum?), JsonSchemaTypes.Integer, "int32", 4 },
-        { typeof(LongEnum?), JsonSchemaTypes.Integer, "int64", 4 },
+        { typeof(IntEnum?), JsonSchemaTypes.Integer, "int32", 3 },
+        { typeof(LongEnum?), JsonSchemaTypes.Integer, "int64", 3 },
     };
 
     [Theory]
@@ -297,7 +297,24 @@ public class NewtonsoftSchemaGeneratorTests
         var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
         const string propertyName = nameof(TypeWithNullableProperties.NullableIntEnumProperty);
         Assert.False(schema.Properties[propertyName].Nullable);
-        Assert.Equal("IntEnumNullable", schema.Properties[propertyName].Reference.Id);
+        Assert.Equal("IntEnum", schema.Properties[propertyName].Reference.Id);
+    }
+
+    [Fact]
+    public void GenerateSchema_DoesSetNullableFlag_IfReferencedEnumAndOneOfEnabled()
+    {
+        var schemaRepository = new SchemaRepository();
+
+        var referenceSchema = Subject(o => o.UseOneOfForNullableEnums = true).GenerateSchema(typeof(TypeWithNullableProperties), schemaRepository);
+
+        var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
+        const string propertyName = nameof(TypeWithNullableProperties.NullableIntEnumProperty);
+        Assert.True(schema.Properties[propertyName].Nullable);
+        Assert.Null(schema.Properties[propertyName].Reference);
+        Assert.Equal(2, schema.Properties[propertyName].OneOf.Count);
+        Assert.Equal("IntEnum", schema.Properties[propertyName].OneOf[0].Reference.Id);
+        Assert.Single(schema.Properties[propertyName].OneOf[1].Enum);
+        Assert.Null(schema.Properties[propertyName].OneOf[1].Enum[0]);
     }
 
     [Fact]
@@ -309,6 +326,17 @@ public class NewtonsoftSchemaGeneratorTests
 
         var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
         Assert.True(schema.Properties[nameof(TypeWithNullableProperties.NullableIntEnumProperty)].Nullable);
+    }
+
+    [Fact]
+    public void GenerateSchema_AddNullEnumValue_IfInlineEnum()
+    {
+        var schemaRepository = new SchemaRepository();
+
+        var referenceSchema = Subject(o => o.UseInlineDefinitionsForEnums = true).GenerateSchema(typeof(TypeWithNullableProperties), schemaRepository);
+
+        var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
+        Assert.Null(schema.Properties[nameof(TypeWithNullableProperties.NullableIntEnumProperty)].Enum.Last());
     }
 
     [Theory]
@@ -850,8 +878,8 @@ public class NewtonsoftSchemaGeneratorTests
         Assert.False(schema.Properties["IntEnumWithRequiredAllowNull"].Nullable);
         Assert.False(schema.Properties["IntEnumWithRequiredAlways"].Nullable);
         Assert.False(schema.Properties["IntEnumWithRequiredDisallowNull"].Nullable);
-        Assert.Equal("IntEnumNullable", schema.Properties["IntEnumWithRequiredDefault"].Reference.Id);
-        Assert.Equal("IntEnumNullable", schema.Properties["IntEnumWithRequiredAllowNull"].Reference.Id);
+        Assert.Equal("IntEnum", schema.Properties["IntEnumWithRequiredDefault"].Reference.Id);
+        Assert.Equal("IntEnum", schema.Properties["IntEnumWithRequiredAllowNull"].Reference.Id);
         Assert.Equal(nameof(IntEnum), schema.Properties["IntEnumWithRequiredAlways"].Reference.Id);
         Assert.Equal(nameof(IntEnum), schema.Properties["IntEnumWithRequiredDisallowNull"].Reference.Id);
     }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSchemaGeneratorOptionsTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSchemaGeneratorOptionsTests.cs
@@ -16,7 +16,7 @@ public static class ConfigureSchemaGeneratorOptionsTests
 
         // If this assertion fails, it means that a new property has been added
         // to SwaggerGeneratorOptions and ConfigureSchemaGeneratorOptions.DeepCopy() needs to be updated
-        Assert.Equal(13, publicProperties.Length);
+        Assert.Equal(14, publicProperties.Length);
     }
 
     [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -89,14 +89,13 @@ public class JsonSerializerSchemaGeneratorTests
     }
 
     [Theory]
-    [InlineData(typeof(IntEnum), "int32", false, "2", "4", "8")]
-    [InlineData(typeof(LongEnum), "int64", false, "2", "4", "8")]
-    [InlineData(typeof(IntEnum?), "int32", true, "2", "4", "8", "null")]
-    [InlineData(typeof(LongEnum?), "int64", true, "2", "4", "8", "null")]
+    [InlineData(typeof(IntEnum), "int32", "2", "4", "8")]
+    [InlineData(typeof(LongEnum), "int64", "2", "4", "8")]
+    [InlineData(typeof(IntEnum?), "int32", "2", "4", "8")]
+    [InlineData(typeof(LongEnum?), "int64", "2", "4", "8")]
     public void GenerateSchema_GeneratesReferencedEnumSchema_IfEnumOrNullableEnumType(
         Type type,
         string expectedFormat,
-        bool expectedNullable,
         params string[] expectedEnumAsJson)
     {
         var schemaRepository = new SchemaRepository();
@@ -107,7 +106,33 @@ public class JsonSerializerSchemaGeneratorTests
         var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
         Assert.Equal(JsonSchemaTypes.Integer, schema.Type);
         Assert.Equal(expectedFormat, schema.Format);
-        Assert.Equal(expectedNullable, schema.Nullable);
+        Assert.False(schema.Nullable);
+        Assert.NotNull(schema.Enum);
+        Assert.Equal(expectedEnumAsJson, schema.Enum.Select(openApiAny => openApiAny.ToJson()));
+    }
+
+    [Theory]
+    [InlineData(typeof(IntEnum?), "int32", "2", "4", "8")]
+    [InlineData(typeof(LongEnum?), "int64", "2", "4", "8")]
+    public void GenerateSchema_GeneratesReferencedEnumSchemaWithOneOf_IfEnumOrNullableEnumTypeAndOneOfEnabled(
+        Type type,
+        string expectedFormat,
+        params string[] expectedEnumAsJson)
+    {
+        var schemaRepository = new SchemaRepository();
+
+        var referenceSchema = Subject(o => o.UseOneOfForNullableEnums = true).GenerateSchema(type, schemaRepository);
+
+        Assert.Null(referenceSchema.Reference);
+        Assert.True(referenceSchema.Nullable);
+        Assert.Equal(2, referenceSchema.OneOf.Count);
+        Assert.Single(referenceSchema.OneOf[1].Enum);
+        Assert.Null(referenceSchema.OneOf[1].Enum[0]);
+
+        var schema = schemaRepository.Schemas[referenceSchema.OneOf[0].Reference.Id];
+        Assert.Equal(JsonSchemaTypes.Integer, schema.Type);
+        Assert.Equal(expectedFormat, schema.Format);
+        Assert.False(schema.Nullable);
         Assert.NotNull(schema.Enum);
         Assert.Equal(expectedEnumAsJson, schema.Enum.Select(openApiAny => openApiAny.ToJson()));
     }

--- a/test/WebSites/MvcWithNullable/Program.cs
+++ b/test/WebSites/MvcWithNullable/Program.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -8,6 +9,7 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {
+    options.UseOneOfForNullableEnums();
     options.UseAllOfToExtendReferenceSchemas();
 });
 
@@ -28,8 +30,20 @@ app.Run();
 [Route("api/[controller]")]
 public class EnumController : ControllerBase
 {
-    [HttpGet]
-    public IActionResult Get(LogLevel? logLevel = LogLevel.Error) => Ok(new { logLevel });
+    [HttpGet("query")]
+    public IActionResult GetQuery(LogLevel? logLevel = LogLevel.Error) => Ok(new { logLevel });
+
+    [HttpGet("path/{logLevel}")]
+    public IActionResult GetPath(LogLevel? logLevel = LogLevel.Error) => Ok(new { logLevel });
+
+    [HttpGet("header")]
+    public IActionResult GetHeader([FromHeader] LogLevel? logLevel = LogLevel.Error) => Ok(new { logLevel });
+
+    [HttpGet("enum-body")]
+    public IActionResult GetEnumBody([FromBody] LogLevel? logLevel = LogLevel.Error) => Ok(new { logLevel });
+
+    [HttpGet("type-body")]
+    public IActionResult GetTypeBody([FromBody] TypeWithNullable typeWithNullable) => Ok(new { typeWithNullable.LogLevel });
 }
 
 [ApiController]
@@ -37,7 +51,18 @@ public class EnumController : ControllerBase
 public class RequiredEnumController : ControllerBase
 {
     [HttpGet]
-    public IActionResult Get([Required] LogLevel? logLevel = LogLevel.Error) => Ok(new { logLevel });
+    public IActionResult Get([FromBody, Required] LogLevel? logLevel = LogLevel.Error) => Ok(new { logLevel });
+}
+
+public class TypeWithNullable
+{
+    public LogLevel? LogLevel { get; set; } = Microsoft.Extensions.Logging.LogLevel.Error;
+
+    [Required]
+    public LogLevel? RequiredLogLevel { get; set; } = Microsoft.Extensions.Logging.LogLevel.Error;
+
+    [JsonRequired]
+    public LogLevel? JsonRequiredLogLevel { get; set; } = Microsoft.Extensions.Logging.LogLevel.Error;
 }
 
 namespace MvcWithNullable


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

This is to fix https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3425.

<!-- Please include the existing GitHub issue number where relevant, e.g. "Fixes #123" -->

## Details on the issue fix or feature implementation

This changes how the nullable enums work so that instead of creating a reference to a separate type, it uses one of with a reference and a null enum. This is behind a flag `UseOneOfForNullableEnums` which defaults to off.

Also for non body parameters it will always default to non nullable as there is no way of specifying a nullable parameter. 

I've extended the snapshot tests to include more nullable examples. This did uncover another example where if the enum itself is the body of the request it should be marked as nullable.

At the moment I've left inline enums to include null, I'm not sure if this should also behind a flag.

<!-- Information about your changes -->
