### PR TITLE
Fix conflicting settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@
 root = true
 
 [*]
-end_of_line = CRLF
+end_of_line = crlf
 insert_final_newline = true
 
 # Visual Studio Spell Checker

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
-# Set the default end-of-line to UNIX
-* text=auto eol=lf
+* text=auto eol=crlf
 *.verified.txt text eol=lf working-tree-encoding=UTF-8
 *.verified.xml text eol=lf working-tree-encoding=UTF-8
 *.verified.json text eol=lf working-tree-encoding=UTF-8


### PR DESCRIPTION
Fix Git and EditorConfig having conflicting line-ending settings and standardise on CRLF (as that was the oldest setting committed to Git).
