### PR TITLE
Disable Static Web Assets

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,6 +36,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <UseArtifactsOutput>true</UseArtifactsOutput>


### PR DESCRIPTION
Disable static web assets as it can cause file-write conflicts in parallel builds.
