### PR TITLE
Remove redundant StaticWebAssetsEnabled props

### DIFF
--- a/test/WebSites/CustomUIConfig/CustomUIConfig.csproj
+++ b/test/WebSites/CustomUIConfig/CustomUIConfig.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/test/WebSites/CustomUIIndex/CustomUIIndex.csproj
+++ b/test/WebSites/CustomUIIndex/CustomUIIndex.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
     <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
Remove redundant setting of `StaticWebAssetsEnabled=false` in specific project files.
