### PR TITLE
Fix RangeAttribute behaviour

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
@@ -242,12 +242,22 @@ public static class OpenApiSchemaExtensions
             // Use the appropriate culture as the user may have specified a culture-specific format for the numbers
             // if they specified the value as a string. By default RangeAttribute uses the current culture, but it
             // can be set to use the invariant culture.
-            var targetCulture = rangeAttribute.ParseLimitsInInvariantCulture
+            var targetCulture = rangeAttribute.ParseLimitsInInvariantCulture || rangeAttribute.Minimum is double
                 ? CultureInfo.InvariantCulture
                 : CultureInfo.CurrentCulture;
 
-            schema.Maximum = Convert.ToDecimal(rangeAttribute.Maximum, targetCulture);
-            schema.Minimum = Convert.ToDecimal(rangeAttribute.Minimum, targetCulture);
+            var maxString = Convert.ToString(rangeAttribute.Maximum, targetCulture);
+            var minString = Convert.ToString(rangeAttribute.Minimum, targetCulture);
+
+            if (decimal.TryParse(maxString, NumberStyles.Any, targetCulture, out var value))
+            {
+                schema.Maximum = value;
+            }
+
+            if (decimal.TryParse(minString, NumberStyles.Any, targetCulture, out value))
+            {
+                schema.Minimum = value;
+            }
         }
 
 #if NET

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/OpenApiSchemaExtensionsTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/OpenApiSchemaExtensionsTests.cs
@@ -56,7 +56,6 @@ public static class OpenApiSchemaExtensionsTests
             foreach (var exclusive in isExclusive)
             {
                 testCases.Add(culture, exclusive, new(1, 1234) { MaximumIsExclusive = exclusive, MinimumIsExclusive = exclusive }, "1", "1234");
-                testCases.Add(culture, exclusive, new(1, 1234) { MaximumIsExclusive = exclusive, MinimumIsExclusive = exclusive }, "1", "1234");
                 testCases.Add(culture, exclusive, new(1d, 1234d) { MaximumIsExclusive = exclusive, MinimumIsExclusive = exclusive }, "1", "1234");
                 testCases.Add(culture, exclusive, new(1.23, 4.56) { MaximumIsExclusive = exclusive, MinimumIsExclusive = exclusive }, "1.23", "4.56");
 
@@ -109,6 +108,23 @@ public static class OpenApiSchemaExtensionsTests
         Assert.Equal(isExclusive ? true : null, schema.ExclusiveMaximum);
         Assert.Equal(minimum, schema.Minimum);
         Assert.Equal(maximum, schema.Maximum);
+    }
+
+    [Fact]
+    public static void ApplyValidationAttributes_Handles_Invalid_RangeAttribute_Values()
+    {
+        // Arrange
+        var rangeAttribute = new RangeAttribute(typeof(int), "foo", "bar");
+        var schema = new OpenApiSchema();
+
+        // Act
+        schema.ApplyValidationAttributes([rangeAttribute]);
+
+        // Assert
+        Assert.Null(schema.ExclusiveMinimum);
+        Assert.Null(schema.ExclusiveMaximum);
+        Assert.Null(schema.Minimum);
+        Assert.Null(schema.Maximum);
     }
 
     private sealed class CultureSwitcher : IDisposable


### PR DESCRIPTION
- Use invariant culture when values are `double`.
- Use `decimal.TryParse()` not `Convert.ToDecimal()` so that invalid values are just ignored like they were before.
- Remove duplicate test case.
