### PR TITLE
Add dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,24 @@
+name: dependency-review
+
+on:
+  pull_request:
+    branches: [ master, dotnet-vnext ]
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Review dependencies
+        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
+        with:
+          allow-licenses: '(MPL-2.0 OR Apache-2.0),0BSD,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,MIT,Python-2.0'


### PR DESCRIPTION
Add a GitHub Actions workflow that checks the licenses of our dependencies.

Allow list derived from running Syft on the repository as of 79f634218fdf4fdfe7a23f886d1b8c8072981952 using a custom build of https://github.com/anchore/syft/pull/3946 with some fixes.

```pwsh
.\syft.exe "{repo clone path after running dotnet build --configuration Release}" --enrich "all" --output syft-json | ConvertFrom-Json | `
  Select-Object -ExpandProperty artifacts | `
  Select-Object -ExpandProperty licenses | `
  Select-Object -ExpandProperty spdxExpression | `
  Where-Object { $_ } | Sort-Object -Unique
```
