### PR TITLE
Fix incorrect Content-Length for swagger-ui and Redoc static assets

### DIFF
--- a/src/Shared/EmbeddedResourceProvider.cs
+++ b/src/Shared/EmbeddedResourceProvider.cs
@@ -151,7 +151,7 @@ internal sealed class EmbeddedResourceProvider(
             var hash = SHA1.HashData(content);
 
             entry.CompressedLength = compressed.Length;
-            entry.DecompressedLength = content.Length;
+            entry.DecompressedLength = decompressed.Length;
             entry.ETag = $"\"{Convert.ToBase64String(hash)}\"";
         }
 

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
@@ -212,6 +212,8 @@ public class ReDocIntegrationTests(ITestOutputHelper outputHelper)
         Assert.NotNull(response.Headers.CacheControl);
         Assert.True(response.Headers.CacheControl.Private);
         Assert.Equal(TimeSpan.FromDays(7), response.Headers.CacheControl.MaxAge);
+
+        Assert.Equal(response.Content.Headers.ContentLength, actual.Length);
     }
 
     [Fact]
@@ -262,5 +264,7 @@ public class ReDocIntegrationTests(ITestOutputHelper outputHelper)
         Assert.NotNull(response.Headers.CacheControl);
         Assert.True(response.Headers.CacheControl.Private);
         Assert.Equal(TimeSpan.FromDays(7), response.Headers.CacheControl.MaxAge);
+
+        Assert.Equal(response.Content.Headers.ContentLength, actual.Length);
     }
 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -276,6 +276,8 @@ public class SwaggerUIIntegrationTests(ITestOutputHelper outputHelper)
         Assert.NotNull(response.Headers.CacheControl);
         Assert.True(response.Headers.CacheControl.Private);
         Assert.Equal(TimeSpan.FromDays(7), response.Headers.CacheControl.MaxAge);
+
+        Assert.Equal(response.Content.Headers.ContentLength, actual.Length);
     }
 
     [Theory]
@@ -332,6 +334,8 @@ public class SwaggerUIIntegrationTests(ITestOutputHelper outputHelper)
         Assert.NotNull(response.Headers.CacheControl);
         Assert.True(response.Headers.CacheControl.Private);
         Assert.Equal(TimeSpan.FromDays(7), response.Headers.CacheControl.MaxAge);
+
+        Assert.Equal(response.Content.Headers.ContentLength, actual.Length);
     }
 
     [Theory]


### PR DESCRIPTION
- Fix incorrect length value being stored when embedded resources are not served compressed.
- Extend integration tests to verify that the stream is the same length as the `Content-Length` header.

Fixes #3486 and #3487.
