### PR TITLE
Fix incorrect ETag values

### DIFF
--- a/src/Shared/EmbeddedResourceProvider.cs
+++ b/src/Shared/EmbeddedResourceProvider.cs
@@ -139,6 +139,8 @@ internal sealed class EmbeddedResourceProvider(
             using var gzip = new GZipStream(compressed, CompressionMode.Decompress);
 
             gzip.CopyTo(decompressed);
+
+            compressed.Seek(0, SeekOrigin.Begin);
             decompressed.Seek(0, SeekOrigin.Begin);
 
             // Some embedded resources may already be compressed or compress worse than the original

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
@@ -10,6 +10,8 @@ namespace Swashbuckle.AspNetCore.IntegrationTests;
 [Collection("TestSite")]
 public class ReDocIntegrationTests(ITestOutputHelper outputHelper)
 {
+    private const string EmptyStringSha256Hash = "2jmj7l5rSw0yVb/vlWAYkK/YBwk=";
+
     [Fact]
     public async Task RoutePrefix_RedirectsToIndexUrl()
     {
@@ -202,12 +204,13 @@ public class ReDocIntegrationTests(ITestOutputHelper outputHelper)
         var actualHash = SHA1.HashData(actual);
         var expectedHash = SHA1.HashData(expected);
 
-        Assert.NotEqual("2jmj7l5rSw0yVb/vlWAYkK/YBwk=", Convert.ToBase64String(actualHash));
+        Assert.NotEqual(EmptyStringSha256Hash, Convert.ToBase64String(actualHash));
         Assert.Equal(expectedHash, actualHash);
 
         Assert.NotNull(response.Headers.ETag);
         Assert.False(response.Headers.ETag.IsWeak);
         Assert.NotEmpty(response.Headers.ETag.Tag);
+        Assert.DoesNotContain(EmptyStringSha256Hash, response.Headers.ETag.Tag);
 
         Assert.NotNull(response.Headers.CacheControl);
         Assert.True(response.Headers.CacheControl.Private);
@@ -254,12 +257,13 @@ public class ReDocIntegrationTests(ITestOutputHelper outputHelper)
         var actualHash = SHA1.HashData(decompressed);
         var expectedHash = SHA1.HashData(expected);
 
-        Assert.NotEqual("2jmj7l5rSw0yVb/vlWAYkK/YBwk=", Convert.ToBase64String(actualHash));
+        Assert.NotEqual(EmptyStringSha256Hash, Convert.ToBase64String(actualHash));
         Assert.Equal(expectedHash, actualHash);
 
         Assert.NotNull(response.Headers.ETag);
         Assert.False(response.Headers.ETag.IsWeak);
         Assert.NotEmpty(response.Headers.ETag.Tag);
+        Assert.DoesNotContain(EmptyStringSha256Hash, response.Headers.ETag.Tag);
 
         Assert.NotNull(response.Headers.CacheControl);
         Assert.True(response.Headers.CacheControl.Private);

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -7,6 +7,8 @@ namespace Swashbuckle.AspNetCore.IntegrationTests;
 [Collection("TestSite")]
 public class SwaggerUIIntegrationTests(ITestOutputHelper outputHelper)
 {
+    private const string EmptyStringSha256Hash = "2jmj7l5rSw0yVb/vlWAYkK/YBwk=";
+
     public static TheoryData<string, string> SwaggerUIFiles()
     {
         const string Prefix = "Swashbuckle.AspNetCore.IntegrationTests.Embedded.SwaggerUI.";
@@ -266,12 +268,13 @@ public class SwaggerUIIntegrationTests(ITestOutputHelper outputHelper)
         var actualHash = SHA1.HashData(actual);
         var expectedHash = SHA1.HashData(expected);
 
-        Assert.NotEqual("2jmj7l5rSw0yVb/vlWAYkK/YBwk=", Convert.ToBase64String(actualHash));
+        Assert.NotEqual(EmptyStringSha256Hash, Convert.ToBase64String(actualHash));
         Assert.Equal(expectedHash, actualHash);
 
         Assert.NotNull(response.Headers.ETag);
         Assert.False(response.Headers.ETag.IsWeak);
         Assert.NotEmpty(response.Headers.ETag.Tag);
+        Assert.DoesNotContain(EmptyStringSha256Hash, response.Headers.ETag.Tag);
 
         Assert.NotNull(response.Headers.CacheControl);
         Assert.True(response.Headers.CacheControl.Private);
@@ -324,12 +327,13 @@ public class SwaggerUIIntegrationTests(ITestOutputHelper outputHelper)
         var actualHash = SHA1.HashData(decompressed);
         var expectedHash = SHA1.HashData(expected);
 
-        Assert.NotEqual("2jmj7l5rSw0yVb/vlWAYkK/YBwk=", Convert.ToBase64String(actualHash));
+        Assert.NotEqual(EmptyStringSha256Hash, Convert.ToBase64String(actualHash));
         Assert.Equal(expectedHash, actualHash);
 
         Assert.NotNull(response.Headers.ETag);
         Assert.False(response.Headers.ETag.IsWeak);
         Assert.NotEmpty(response.Headers.ETag.Tag);
+        Assert.DoesNotContain(EmptyStringSha256Hash, response.Headers.ETag.Tag);
 
         Assert.NotNull(response.Headers.CacheControl);
         Assert.True(response.Headers.CacheControl.Private);


### PR DESCRIPTION
Fix incorrect `ETag` for compressed files by resetting the compressed stream to the beginning before computing the SHA256 hash.

See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3486#issuecomment-3049325068.
