### PR TITLE
Check Accept-Encoding quality

### DIFF
--- a/src/Shared/EmbeddedResourceProvider.cs
+++ b/src/Shared/EmbeddedResourceProvider.cs
@@ -94,7 +94,10 @@ internal sealed class EmbeddedResourceProvider(
 
         for (int i = 0; i < acceptEncoding.Count; i++)
         {
-            if (string.Equals(acceptEncoding[i]?.Value.Value, GZipEncodingValue, StringComparison.OrdinalIgnoreCase))
+            var encoding = acceptEncoding[i];
+
+            if (encoding.Quality is not 0 &&
+                string.Equals(encoding.Value.Value, GZipEncodingValue, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
@@ -77,9 +77,10 @@ internal sealed class ReDocMiddleware
                .DefaultIfEmpty(string.Empty)
                .FirstOrDefault();
 
-    private static void SetCacheHeaders(HttpResponse response, ReDocOptions options, string etag = null)
+    private static void SetHeaders(HttpResponse response, ReDocOptions options, string etag)
     {
         var headers = response.GetTypedHeaders();
+        headers.Append("x-redoc-version", ReDocVersion);
 
         if (options.CacheLifetime is { } maxAge)
         {
@@ -98,7 +99,7 @@ internal sealed class ReDocMiddleware
             };
         }
 
-        headers.ETag = new($"\"{etag ?? ReDocVersion}\"", isWeak: true);
+        headers.ETag = new($"\"{etag}\"", isWeak: true);
     }
 
     private static void RespondWithRedirect(HttpResponse response, string location)
@@ -154,7 +155,7 @@ internal sealed class ReDocMiddleware
             var text = content.ToString();
             var etag = HashText(text);
 
-            SetCacheHeaders(response, _options, etag);
+            SetHeaders(response, _options, etag);
 
             await response.WriteAsync(text, Encoding.UTF8, cancellationToken);
         }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -84,9 +84,10 @@ internal sealed partial class SwaggerUIMiddleware
                .DefaultIfEmpty(string.Empty)
                .FirstOrDefault();
 
-    private static void SetCacheHeaders(HttpResponse response, SwaggerUIOptions options, string etag = null)
+    private static void SetHeaders(HttpResponse response, SwaggerUIOptions options, string etag)
     {
         var headers = response.GetTypedHeaders();
+        headers.Append("x-swagger-ui-version", SwaggerUIVersion);
 
         if (options.CacheLifetime is { } maxAge)
         {
@@ -105,7 +106,7 @@ internal sealed partial class SwaggerUIMiddleware
             };
         }
 
-        headers.ETag = new($"\"{etag ?? SwaggerUIVersion}\"", isWeak: true);
+        headers.ETag = new($"\"{etag}\"", isWeak: true);
     }
 
     private static void RespondWithRedirect(HttpResponse response, string location)
@@ -154,7 +155,7 @@ internal sealed partial class SwaggerUIMiddleware
             var text = content.ToString();
             var etag = HashText(text);
 
-            SetCacheHeaders(response, _options, etag);
+            SetHeaders(response, _options, etag);
 
             await response.WriteAsync(text, Encoding.UTF8, cancellationToken);
         }


### PR DESCRIPTION
- Do not respond with gzip if the quality of an `Accept-Encoding` value is zero. See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/3492#discussion_r2193530519.
- Add a custom header that returns the Redoc/swagger-ui version to resolved uncovered code.
