### PR TITLE
Update Microsoft.OpenApi to 2.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,8 +15,8 @@
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0-preview.6.25358.103" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.17" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="2.0.0-preview.29" />
-    <PackageVersion Include="Microsoft.OpenApi.YamlReader" Version="2.0.0-preview.29" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.OpenApi.YamlReader" Version="2.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />


### PR DESCRIPTION
Update to the stable release of Microsoft.OpenApi 2.0.0.
