### PR TITLE
Simplify release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,28 +49,17 @@ jobs:
             const draft = process.env.DRAFT === 'true';
             const version = process.env.VERSION;
             const tag_name = `v${version}`;
+            const target_commitish = process.env.DEFAULT_BRANCH;
             const name = tag_name;
-
-            const { data: notes } = await github.rest.repos.generateReleaseNotes({
-              owner,
-              repo,
-              tag_name,
-              target_commitish: process.env.DEFAULT_BRANCH,
-            });
-
-            const body = notes.body
-              .split('\n')
-              .filter((line) => !line.includes(' @dependabot '))
-              .filter((line) => !line.includes(' @github-actions '))
-              .join('\n');
 
             const { data: release } = await github.rest.repos.createRelease({
               owner,
               repo,
               tag_name,
+              target_commitish,
               name,
-              body,
               draft,
+              generate_release_notes: true,
             });
 
             core.notice(`Created release ${release.name}: ${release.html_url}`);


### PR DESCRIPTION
With #3502, the release draft can be created in one request, rather than generating the notes and then manually editing them.
