### PR TITLE
Bump xunit dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,9 +22,9 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.4.0" />
     <PackageVersion Include="ReportGenerator" Version="5.4.7" />
-    <PackageVersion Include="Verify.XunitV3" Version="30.4.0" />
+    <PackageVersion Include="Verify.XunitV3" Version="30.5.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
     <PackageVersion Include="xunit.v3" Version="3.0.0" />
     <PackageVersion Include="xunit.v3.extensibility.core" Version="3.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Manual edition of #3507 without `.targets` changes.
