### PR TITLE
Update NuGet dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,12 +8,12 @@
     <PackageVersion Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageVersion Include="JunitXml.TestLogger" Version="6.1.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.6.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.17" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.18" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.18" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.17" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.17" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.18" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.18" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.23" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.23" />

--- a/src/Swashbuckle.AspNetCore.ApiTesting.Xunit/Swashbuckle.AspNetCore.ApiTesting.Xunit.csproj
+++ b/src/Swashbuckle.AspNetCore.ApiTesting.Xunit/Swashbuckle.AspNetCore.ApiTesting.Xunit.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" VersionOverride="2.4.1" />
+    <PackageReference Include="xunit" VersionOverride="2.6.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Swashbuckle.AspNetCore.ApiTesting/Swashbuckle.AspNetCore.ApiTesting.csproj
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/Swashbuckle.AspNetCore.ApiTesting.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="8.0.5" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/Swashbuckle.AspNetCore.IntegrationTests.csproj
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/Swashbuckle.AspNetCore.IntegrationTests.csproj
@@ -28,15 +28,15 @@
     <EmbeddedResource Include="../../src/Swashbuckle.AspNetCore.SwaggerUI/node_modules/swagger-ui-dist/**/*" Exclude="**/*/index.html;**/*/index.js;**/*/*.map;**/*/*.json;**/*/*.md;**/*/swagger-ui-es-*;**/*/LICENSE;**/*/NOTICE" Link="Embedded/SwaggerUI/%(RecursiveDir)%(FileName)%(Extension)" />
     <EmbeddedResource Include="../../src/Swashbuckle.AspNetCore.ReDoc/node_modules/redoc/bundles/redoc.standalone.js" Link="Embedded/ReDoc/%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="8.0.17" />
-    <PackageReference Update="Microsoft.AspNetCore.TestHost" VersionOverride="8.0.17" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="8.0.18" />
+    <PackageReference Update="Microsoft.AspNetCore.TestHost" VersionOverride="8.0.18" />
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="9.0.6" />
-    <PackageReference Update="Microsoft.AspNetCore.TestHost" VersionOverride="9.0.6" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="9.0.7" />
+    <PackageReference Update="Microsoft.AspNetCore.TestHost" VersionOverride="9.0.7" />
   </ItemGroup>
 
 </Project>

--- a/test/WebSites/MvcWithNullable/MvcWithNullable.csproj
+++ b/test/WebSites/MvcWithNullable/MvcWithNullable.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
-    <PackageReference Update="Microsoft.AspNetCore.OpenApi" VersionOverride="9.0.6" />
+    <PackageReference Update="Microsoft.AspNetCore.OpenApi" VersionOverride="9.0.7" />
   </ItemGroup>
 
 </Project>

--- a/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
+++ b/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
@@ -11,12 +11,12 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="8.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="8.0.18" />
     <PackageReference Include="Duende.IdentityServer" VersionOverride="7.2.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="9.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="9.0.7" />
     <PackageReference Include="Duende.IdentityServer" VersionOverride="7.2.4" />
   </ItemGroup>
 

--- a/test/WebSites/WebApi/WebApi.csproj
+++ b/test/WebSites/WebApi/WebApi.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
-    <PackageReference Update="Microsoft.AspNetCore.OpenApi" VersionOverride="9.0.6" />
+    <PackageReference Update="Microsoft.AspNetCore.OpenApi" VersionOverride="9.0.7" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Bump xunit from 2.4.1 to 2.6.6 to resolve https://github.com/domaindrivendev/Swashbuckle.AspNetCore/security/dependabot/25 and https://github.com/domaindrivendev/Swashbuckle.AspNetCore/security/dependabot/26.
- Bump Microsoft.AspNetCore.Mvc.Testing to resolve https://github.com/domaindrivendev/Swashbuckle.AspNetCore/security/dependabot/27 and https://github.com/domaindrivendev/Swashbuckle.AspNetCore/security/dependabot/28.
- Bump test dependencies to latest versions for .NET 8.0.18 and 9.0.7.
