### PR TITLE
Add UI tests for SwaggerUI and Redoc

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.OpenApi" Version="2.0.0" />
     <PackageVersion Include="Microsoft.OpenApi.YamlReader" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.54.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/HttpServerFixture.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/HttpServerFixture.cs
@@ -1,0 +1,20 @@
+﻿#if NET10_0_OR_GREATER
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Swashbuckle.AspNetCore.IntegrationTests;
+
+public class HttpApplicationFixture<TEntryPoint> : WebApplicationFactory<TEntryPoint>
+    where TEntryPoint : class
+{
+    public HttpApplicationFixture() => UseKestrel(0);
+
+    public string ServerUrl
+    {
+        get
+        {
+            StartServer();
+            return ClientOptions.BaseAddress.ToString();
+        }
+    }
+}
+#endif

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/PlaywrightFixture.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/PlaywrightFixture.cs
@@ -1,0 +1,65 @@
+﻿#if NET10_0_OR_GREATER
+using Microsoft.Playwright;
+
+namespace Swashbuckle.AspNetCore.IntegrationTests;
+
+public sealed class PlaywrightFixture : IAsyncLifetime
+{
+    private bool _installed;
+
+    public ValueTask InitializeAsync()
+    {
+        EnsureInstalled();
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+        return ValueTask.CompletedTask;
+    }
+
+    public async Task VerifyPage(string url, Func<IPage, Task> test)
+    {
+        EnsureInstalled();
+
+        using var playwright = await Playwright.CreateAsync();
+        var browserType = playwright[BrowserType.Chromium];
+
+        var options = new BrowserTypeLaunchOptions();
+
+        if (System.Diagnostics.Debugger.IsAttached)
+        {
+#pragma warning disable CS0612
+            options.Devtools = true;
+#pragma warning restore CS0612
+            options.Headless = false;
+            options.SlowMo = 100;
+        }
+
+        await using var browser = await playwright[BrowserType.Chromium].LaunchAsync(options);
+        await using var context = await browser.NewContextAsync();
+
+        var page = await context.NewPageAsync();
+
+        await page.GotoAsync(url, new() { WaitUntil = WaitUntilState.NetworkIdle });
+
+        await test(page);
+    }
+
+    private void EnsureInstalled()
+    {
+        if (!_installed)
+        {
+            int result = Microsoft.Playwright.Program.Main(["install", "chromium", "--only-shell", "--with-deps"]);
+
+            if (result != 0)
+            {
+                throw new InvalidOperationException($"Failed to install Playwright dependencies: {result}.");
+            }
+
+            _installed = true;
+        }
+    }
+}
+#endif

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/Swashbuckle.AspNetCore.IntegrationTests.csproj
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/Swashbuckle.AspNetCore.IntegrationTests.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.OpenApi.YamlReader" />
+    <PackageReference Include="Microsoft.Playwright" />
     <PackageReference Include="Verify.XunitV3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit.v3" />

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/UITests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/UITests.cs
@@ -1,0 +1,48 @@
+﻿#if NET10_0_OR_GREATER
+using ReDocApp = ReDoc;
+
+namespace Swashbuckle.AspNetCore.IntegrationTests;
+
+public class UITests(PlaywrightFixture fixture) : IClassFixture<PlaywrightFixture>
+{
+    [Fact]
+    public async Task Can_Load_SwaggerUI_Page_And_Make_Request()
+    {
+        // Arrange
+        await using var application = new SwaggerUIFixture();
+
+        // Act and Assert
+        await fixture.VerifyPage(application.ServerUrl, async (page) =>
+        {
+            var operation = await page.WaitForSelectorAsync("text=Searches the collection of products by description key words");
+            await operation.ClickAsync();
+
+            var button = await page.WaitForSelectorAsync("text=Try it out");
+            await button.ClickAsync();
+
+            button = await page.WaitForSelectorAsync("text=Execute");
+            await button.ClickAsync();
+
+            var response = await page.WaitForSelectorAsync(".live-responses-table");
+            await response.WaitForSelectorAsync("text=200");
+        });
+    }
+
+    [Fact]
+    public async Task Can_Load_Redoc_Page()
+    {
+        // Arrange
+        await using var application = new RedocFixture();
+
+        // Act and Assert
+        await fixture.VerifyPage(application.ServerUrl, async (page) =>
+        {
+            await page.QuerySelectorAsync("text=/products");
+        });
+    }
+
+    private sealed class RedocFixture : HttpApplicationFixture<ReDocApp.Program>;
+
+    private sealed class SwaggerUIFixture : HttpApplicationFixture<Basic.Startup>;
+}
+#endif

--- a/test/WebSites/Basic/Startup.cs
+++ b/test/WebSites/Basic/Startup.cs
@@ -61,11 +61,11 @@ public class Startup
             endpoints.MapSwagger("swagger/{documentName}/swagger.json");
             endpoints.MapSwagger("swagger/{documentName}/swaggerv2.json", c =>
             {
-                c.OpenApiVersion = Microsoft.OpenApi.OpenApiSpecVersion.OpenApi2_0;
+                c.OpenApiVersion = OpenApiSpecVersion.OpenApi2_0;
             });
             endpoints.MapSwagger("swagger/{documentName}/swaggerv3_1.json", c =>
             {
-                c.OpenApiVersion = Microsoft.OpenApi.OpenApiSpecVersion.OpenApi3_1;
+                c.OpenApiVersion = OpenApiSpecVersion.OpenApi3_1;
             });
         });
 

--- a/test/WebSites/ReDoc/Program.cs
+++ b/test/WebSites/ReDoc/Program.cs
@@ -1,16 +1,14 @@
-﻿using Microsoft.AspNetCore;
-
-namespace ReDoc;
+﻿namespace ReDoc;
 
 public class Program
 {
-    public static void Main(string[] args)
-    {
-        BuildWebHost(args).Run();
-    }
+    public static void Main(string[] args) =>
+        CreateHostBuilder(args).Build().Run();
 
-    public static IWebHost BuildWebHost(string[] args) =>
-        WebHost.CreateDefaultBuilder(args)
-               .UseStartup<Startup>()
-               .Build();
+    public static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseStartup<Startup>();
+            });
 }

--- a/test/WebSites/ReDoc/Startup.cs
+++ b/test/WebSites/ReDoc/Startup.cs
@@ -28,6 +28,7 @@ public class Startup(IConfiguration configuration)
         app.UseEndpoints(endpoints =>
         {
             endpoints.MapControllers();
+            endpoints.MapGet("/", () => Results.Redirect("api-docs"));
         });
 
         app.UseSwagger(c =>


### PR DESCRIPTION
Add end-to-end UI tests for SwaggerUI and Redoc to help validate upstream changes.

Resolves #3514.
