### PR TITLE
Remove WebHost usage

### DIFF
--- a/src/Swashbuckle.AspNetCore.Cli/Program.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/Program.cs
@@ -3,7 +3,6 @@ using System.Globalization;
 using System.Reflection;
 using System.Runtime.Loader;
 using System.Text;
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -263,8 +262,8 @@ internal class Program
 
         try
         {
-            return WebHost.CreateDefaultBuilder()
-               .UseStartup(startupAssembly.GetName().Name)
+            return Host.CreateDefaultBuilder()
+               .ConfigureWebHostDefaults(builder => builder.UseStartup(startupAssembly.GetName().Name))
                .Build()
                .Services;
         }

--- a/test/WebSites/CliExample/Program.cs
+++ b/test/WebSites/CliExample/Program.cs
@@ -1,13 +1,14 @@
-﻿using Microsoft.AspNetCore;
-
-namespace CliExample;
+﻿namespace CliExample;
 
 public class Program
 {
-    public static void Main(string[] args) => BuildWebHost(args).Run();
+    public static void Main(string[] args) =>
+        CreateHostBuilder(args).Build().Run();
 
-    public static IWebHost BuildWebHost(string[] args) =>
-        WebHost.CreateDefaultBuilder(args)
-               .UseStartup<Startup>()
-               .Build();
+    public static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseStartup<Startup>();
+            });
 }

--- a/test/WebSites/ConfigFromFile/Program.cs
+++ b/test/WebSites/ConfigFromFile/Program.cs
@@ -1,16 +1,14 @@
-﻿using Microsoft.AspNetCore;
-
-namespace ConfigFromFile;
+﻿namespace ConfigFromFile;
 
 public class Program
 {
-    public static void Main(string[] args)
-    {
-        BuildWebHost(args).Run();
-    }
+    public static void Main(string[] args) =>
+        CreateHostBuilder(args).Build().Run();
 
-    public static IWebHost BuildWebHost(string[] args) =>
-        WebHost.CreateDefaultBuilder(args)
-               .UseStartup<Startup>()
-               .Build();
+    public static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseStartup<Startup>();
+            });
 }

--- a/test/WebSites/ReDoc/Program.cs
+++ b/test/WebSites/ReDoc/Program.cs
@@ -1,16 +1,14 @@
-﻿using Microsoft.AspNetCore;
-
-namespace ReDoc;
+﻿namespace ReDoc;
 
 public class Program
 {
-    public static void Main(string[] args)
-    {
-        BuildWebHost(args).Run();
-    }
+    public static void Main(string[] args) =>
+        CreateHostBuilder(args).Build().Run();
 
-    public static IWebHost BuildWebHost(string[] args) =>
-        WebHost.CreateDefaultBuilder(args)
-               .UseStartup<Startup>()
-               .Build();
+    public static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseStartup<Startup>();
+            });
 }

--- a/test/WebSites/TestFirst/Program.cs
+++ b/test/WebSites/TestFirst/Program.cs
@@ -1,18 +1,14 @@
-﻿using Microsoft.AspNetCore;
-
-namespace TestFirst;
+﻿namespace TestFirst;
 
 public class Program
 {
-    public static void Main(string[] args)
-    {
-        var webHostBuilder = CreateWebHostBuilder(args);
-        webHostBuilder.Build().Run();
-    }
+    public static void Main(string[] args) =>
+        CreateHostBuilder(args).Build().Run();
 
-    public static IWebHostBuilder CreateWebHostBuilder(string[] args)
-    {
-        return WebHost.CreateDefaultBuilder(args)
-            .UseStartup<Startup>();
-    }
+    public static IHostBuilder CreateHostBuilder(string[] args) =>
+        Host.CreateDefaultBuilder(args)
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseStartup<Startup>();
+            });
 }


### PR DESCRIPTION
Remove long-deprecated `WebHost` usage and instead use `Host`.

Flushed out by trying to use `WebApplicationFactory<T>` for Redoc with #3516.
