### PR TITLE
.NET 10 preparation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,8 +12,8 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.19" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.19" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.19" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.20" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.20" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.OpenApi" Version="1.6.25" />
     <PackageVersion Include="Microsoft.OpenApi.Readers" Version="1.6.25" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,8 +8,8 @@
     <PackageVersion Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageVersion Include="JunitXml.TestLogger" Version="6.1.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.6.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.19" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.19" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.20" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.20" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.20" />

--- a/src/Swashbuckle.AspNetCore.Cli/Program.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/Program.cs
@@ -255,10 +255,12 @@ internal class Program
             return host.Services;
         }
 
+#pragma warning disable ASPDEPR008
         if (TryGetCustomHost(startupAssembly, "SwaggerWebHostFactory", "CreateWebHost", out IWebHost webHost))
         {
             return webHost.Services;
         }
+#pragma warning restore ASPDEPR008
 
         try
         {

--- a/test/Swashbuckle.AspNetCore.Annotations.Test/AnnotationsDocumentFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.Annotations.Test/AnnotationsDocumentFilterTests.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.OpenApi.Models;
-using Xunit;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Swashbuckle.AspNetCore.TestSupport;
+using Xunit;
 
 namespace Swashbuckle.AspNetCore.Annotations.Test;
 
@@ -13,7 +13,7 @@ public class AnnotationsDocumentFilterTests
         var document = new OpenApiDocument();
         var apiDescription = ApiDescriptionFactory.Create<FakeControllerWithSwaggerAnnotations>(c => nameof(c.ActionWithNoAttributes));
         var filterContext = new DocumentFilterContext(
-            apiDescriptions: new[] { apiDescription },
+            apiDescriptions: [apiDescription],
             schemaGenerator: null,
             schemaRepository: null);
 
@@ -24,8 +24,6 @@ public class AnnotationsDocumentFilterTests
         Assert.Equal("http://tempuri.org/", tag.ExternalDocs.Url.ToString());
     }
 
-    private AnnotationsDocumentFilter Subject()
-    {
-        return new AnnotationsDocumentFilter();
-    }
+    private static AnnotationsDocumentFilter Subject()
+        => new();
 }

--- a/test/Swashbuckle.AspNetCore.Annotations.Test/AnnotationsParameterFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.Annotations.Test/AnnotationsParameterFilterTests.cs
@@ -61,8 +61,5 @@ public class AnnotationsParameterFilterTests
         Assert.True(parameter.Required);
     }
 
-    private AnnotationsParameterFilter Subject()
-    {
-        return new AnnotationsParameterFilter();
-    }
+    private static AnnotationsParameterFilter Subject() => new();
 }

--- a/test/Swashbuckle.AspNetCore.Annotations.Test/AnnotationsRequestBodyFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.Annotations.Test/AnnotationsRequestBodyFilterTests.cs
@@ -61,7 +61,7 @@ public class AnnotationsRequestBodyFilterTests
         var context = new RequestBodyFilterContext(bodyParameterDescription, null, null, null);
 
         Subject().Apply(requestBody, context);
-        
+
         Assert.Equal("Description for StringWithSwaggerRequestBodyAttribute", requestBody.Description);
         Assert.True(requestBody.Required);
     }

--- a/test/Swashbuckle.AspNetCore.ApiTesting.Test/ApiTestRunnerBaseTests.cs
+++ b/test/Swashbuckle.AspNetCore.ApiTesting.Test/ApiTestRunnerBaseTests.cs
@@ -26,7 +26,7 @@ public class ApiTestRunnerBaseTests
         {
             c.OpenApiDocs.Add("v1", new OpenApiDocument());
         });
-            
+
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => subject.TestAsync(
             "v1",
             "GetProducts",
@@ -70,7 +70,7 @@ public class ApiTestRunnerBaseTests
                                 ],
                                 Responses = new OpenApiResponses
                                 {
-                                    [ "200" ] = new OpenApiResponse() 
+                                    [ "200" ] = new OpenApiResponse()
                                 }
                             }
                         }
@@ -118,7 +118,7 @@ public class ApiTestRunnerBaseTests
                                 Responses = new OpenApiResponses
                                 {
                                     ["400"] = new OpenApiResponse(),
-                                    ["200"] = new OpenApiResponse() 
+                                    ["200"] = new OpenApiResponse()
                                 }
                             }
                         }

--- a/test/Swashbuckle.AspNetCore.ApiTesting.Test/JsonValidatorTests.cs
+++ b/test/Swashbuckle.AspNetCore.ApiTesting.Test/JsonValidatorTests.cs
@@ -418,7 +418,7 @@ public class JsonValidatorTests
         var openApiSchema = new OpenApiSchema
         {
             Type = JsonSchemaTypes.Object,
-            Required = new SortedSet<string>(schemaRequired)
+            Required = new SortedSet<string>(schemaRequired),
         };
         var instance = JToken.Parse(instanceText);
 
@@ -541,7 +541,7 @@ public class JsonValidatorTests
             [
                 new OpenApiSchema { Type = JsonSchemaTypes.Object, Required = new SortedSet<string> { "p1" } },
                 new OpenApiSchema { Type = JsonSchemaTypes.Object, Required = new SortedSet<string> { "p2" } },
-                new OpenApiSchema { Type = JsonSchemaTypes.Object, Required = new SortedSet<string> { "p3" } }
+                new OpenApiSchema { Type = JsonSchemaTypes.Object, Required = new SortedSet<string> { "p3" } },
             ]
         };
         var instance = JToken.Parse(instanceText);
@@ -570,7 +570,7 @@ public class JsonValidatorTests
             [
                 new OpenApiSchema { Type = JsonSchemaTypes.Object, Required = new SortedSet<string> { "p1" } },
                 new OpenApiSchema { Type = JsonSchemaTypes.Object, Required = new SortedSet<string> { "p2" } },
-                new OpenApiSchema { Type = JsonSchemaTypes.Object, Required = new SortedSet<string> { "p3" } }
+                new OpenApiSchema { Type = JsonSchemaTypes.Object, Required = new SortedSet<string> { "p3" } },
             ]
         };
         var instance = JToken.Parse(instanceText);
@@ -600,7 +600,7 @@ public class JsonValidatorTests
             [
                 new OpenApiSchema { Type = JsonSchemaTypes.Object, Required = new SortedSet<string> { "p1" } },
                 new OpenApiSchema { Type = JsonSchemaTypes.Object, Required = new SortedSet<string> { "p2" } },
-                new OpenApiSchema { Type = JsonSchemaTypes.Object, Required = new SortedSet<string> { "p3" } }
+                new OpenApiSchema { Type = JsonSchemaTypes.Object, Required = new SortedSet<string> { "p3" } },
             ]
         };
         var instance = JToken.Parse(instanceText);

--- a/test/Swashbuckle.AspNetCore.ApiTesting.Test/RequestValidatorTests.cs
+++ b/test/Swashbuckle.AspNetCore.ApiTesting.Test/RequestValidatorTests.cs
@@ -392,6 +392,6 @@ public class RequestValidatorTests
 
     private static RequestValidator Subject(IEnumerable<IContentValidator> contentValidators = null)
     {
-        return new RequestValidator(contentValidators ?? []);
+        return new(contentValidators ?? []);
     }
 }

--- a/test/Swashbuckle.AspNetCore.ApiTesting.Test/ResponseValidatorTests.cs
+++ b/test/Swashbuckle.AspNetCore.ApiTesting.Test/ResponseValidatorTests.cs
@@ -215,7 +215,7 @@ public class ResponseValidatorTests
                             Schema = new OpenApiSchema
                             {
                                 Type = JsonSchemaTypes.Object,
-                                Required = new SortedSet<string> { "prop1", "prop2" }
+                                Required = new SortedSet<string> { "prop1", "prop2" },
                             }
                         }
                     }
@@ -259,6 +259,6 @@ public class ResponseValidatorTests
 
     private static ResponseValidator Subject(IEnumerable<IContentValidator> contentValidators = null)
     {
-        return new ResponseValidator(contentValidators ?? []);
+        return new(contentValidators ?? []);
     }
 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/CustomDocumentSerializerTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/CustomDocumentSerializerTests.cs
@@ -49,7 +49,7 @@ public class CustomDocumentSerializerTests(ITestOutputHelper outputHelper)
     {
         var testSite = new TestSite(typeof(CustomDocumentSerializer.Startup), outputHelper);
         var server = testSite.BuildServer();
-        var services = server.Host.Services;
+        var services = server.Services;
 
         var documentProvider = services.GetService<IDocumentProvider>();
         using var stream = new MemoryStream();
@@ -80,7 +80,7 @@ public class CustomDocumentSerializerTests(ITestOutputHelper outputHelper)
     {
         var testSite = new TestSite(typeof(CustomDocumentSerializer.Startup), outputHelper);
         var server = testSite.BuildServer();
-        var services = server.Host.Services;
+        var services = server.Services;
 
         var documentProvider = services.GetService<IDocumentProvider>();
         var options = services.GetService<IOptions<SwaggerOptions>>();

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/DocumentProviderTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/DocumentProviderTests.cs
@@ -18,7 +18,7 @@ public class DocumentProviderTests(ITestOutputHelper outputHelper)
     {
         var testSite = new TestSite(startupType, outputHelper);
         var server = testSite.BuildServer();
-        var services = server.Host.Services;
+        var services = server.Services;
         var documentProvider = (IDocumentProvider)services.GetService(typeof(IDocumentProvider));
 
         var documentNames = documentProvider.GetDocumentNames();
@@ -37,7 +37,7 @@ public class DocumentProviderTests(ITestOutputHelper outputHelper)
     {
         var testSite = new TestSite(startupType, outputHelper);
         var server = testSite.BuildServer();
-        var services = server.Host.Services;
+        var services = server.Services;
 
         var documentProvider = (IDocumentProvider)services.GetService(typeof(IDocumentProvider));
         using var stream = new MemoryStream();
@@ -51,6 +51,7 @@ public class DocumentProviderTests(ITestOutputHelper outputHelper)
         var (_, diagnostic) = await OpenApiDocumentLoader.LoadWithDiagnosticsAsync(stream);
         Assert.NotNull(diagnostic);
         Assert.Empty(diagnostic.Errors);
+        Assert.Empty(diagnostic.Warnings);
     }
 
     [Fact]
@@ -58,7 +59,7 @@ public class DocumentProviderTests(ITestOutputHelper outputHelper)
     {
         var testSite = new TestSite(typeof(Basic.Startup), outputHelper);
         var server = testSite.BuildServer();
-        var services = server.Host.Services;
+        var services = server.Services;
 
         var documentProvider = (IDocumentProvider)services.GetService(typeof(IDocumentProvider));
         using var writer = new StringWriter();

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerIntegrationTests.cs
@@ -36,7 +36,7 @@ public class SwaggerIntegrationTests(ITestOutputHelper outputHelper)
     [Fact]
     public async Task SwaggerEndpoint_ReturnsValidSwaggerJson_ForAutofaq()
     {
-        var testSite = new TestSiteAutofaq(typeof(CliExampleWithFactory.Startup));
+        var testSite = new TestSiteAutofaq(typeof(CliExampleWithFactory.Startup), outputHelper);
         using var client = testSite.BuildClient();
 
         await AssertValidSwaggerJson(client, "/swagger/v1/swagger_net8.0.json");
@@ -205,5 +205,6 @@ public class SwaggerIntegrationTests(ITestOutputHelper outputHelper)
         var (_, diagnostic) = await OpenApiDocumentLoader.LoadWithDiagnosticsAsync(contentStream);
         Assert.NotNull(diagnostic);
         Assert.Empty(diagnostic.Errors);
+        Assert.Empty(diagnostic.Warnings);
     }
 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/Swashbuckle.AspNetCore.IntegrationTests.csproj
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/Swashbuckle.AspNetCore.IntegrationTests.csproj
@@ -30,13 +30,13 @@
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="8.0.19" />
-    <PackageReference Update="Microsoft.AspNetCore.TestHost" VersionOverride="8.0.19" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="8.0.20" />
+    <PackageReference Update="Microsoft.AspNetCore.TestHost" VersionOverride="8.0.20" />
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="9.0.8" />
-    <PackageReference Update="Microsoft.AspNetCore.TestHost" VersionOverride="9.0.8" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="9.0.9" />
+    <PackageReference Update="Microsoft.AspNetCore.TestHost" VersionOverride="9.0.9" />
   </ItemGroup>
 
 </Project>

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/TestSiteAutofaq.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/TestSiteAutofaq.cs
@@ -1,38 +1,21 @@
-﻿using System.Reflection;
-using Autofac.Extensions.DependencyInjection;
+﻿using Autofac.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Hosting;
 
 namespace Swashbuckle.AspNetCore.IntegrationTests;
 
-public class TestSiteAutofaq
+public class TestSiteAutofaq(Type startupType, ITestOutputHelper outputHelper)
+    : TestSite(startupType, outputHelper)
 {
-    private readonly Type _startupType;
-
-    public TestSiteAutofaq(Type startupType)
+    protected override void Configure(IHostBuilder builder)
     {
-        _startupType = startupType;
+        base.Configure(builder);
+        builder.UseServiceProviderFactory(new AutofacServiceProviderFactory());
     }
 
-    public TestServer BuildServer()
+    protected override void Configure(IWebHostBuilder builder)
     {
-        var startupAssembly = _startupType.Assembly;
-        var applicationName = startupAssembly.GetName().Name;
-
-        var hostBuilder = new WebHostBuilder()
-            .UseEnvironment("Development")
-            .ConfigureServices(services => services.AddAutofac())
-            .UseSolutionRelativeContentRoot(Path.Combine("test", "WebSites", applicationName), "*.slnx")
-            .UseStartup(_startupType);
-
-        return new TestServer(hostBuilder);
-    }
-
-    public HttpClient BuildClient()
-    {
-        var server = BuildServer();
-        var client = server.CreateClient();
-
-        return client;
+        builder.ConfigureServices((services) => services.AddAutofac());
+        base.Configure(builder);
     }
 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/VerifyTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/VerifyTests.cs
@@ -42,7 +42,7 @@ public partial class VerifyTests(ITestOutputHelper outputHelper)
         var startupType = typeof(CliExampleWithFactory.Startup);
         const string swaggerRequestUri = "/swagger/v1/swagger_net8.0.json";
 
-        var testSite = new TestSiteAutofaq(startupType);
+        var testSite = new TestSiteAutofaq(startupType, outputHelper);
         using var client = testSite.BuildClient();
 
         using var swaggerResponse = await client.GetAsync(swaggerRequestUri, TestContext.Current.CancellationToken);

--- a/test/WebSites/MvcWithNullable/MvcWithNullable.csproj
+++ b/test/WebSites/MvcWithNullable/MvcWithNullable.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
-    <PackageReference Update="Microsoft.AspNetCore.OpenApi" VersionOverride="9.0.8" />
+    <PackageReference Update="Microsoft.AspNetCore.OpenApi" VersionOverride="9.0.9" />
   </ItemGroup>
 
 </Project>

--- a/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
+++ b/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
@@ -11,12 +11,12 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="8.0.19" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="8.0.20" />
     <PackageReference Include="Duende.IdentityServer" VersionOverride="7.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="9.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="9.0.9" />
     <PackageReference Include="Duende.IdentityServer" VersionOverride="7.3.1" />
   </ItemGroup>
 

--- a/test/WebSites/ReDoc/Startup.cs
+++ b/test/WebSites/ReDoc/Startup.cs
@@ -28,6 +28,7 @@ public class Startup(IConfiguration configuration)
         app.UseEndpoints(endpoints =>
         {
             endpoints.MapControllers();
+            endpoints.MapGet("/", () => Results.Redirect("api-docs"));
         });
 
         app.UseSwagger(c =>

--- a/test/WebSites/WebApi/EndPoints/OpenApiEndpoints.cs
+++ b/test/WebSites/WebApi/EndPoints/OpenApiEndpoints.cs
@@ -98,6 +98,7 @@ public static class OpenApiEndpoints
         return app;
     }
 }
+
 record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
 {
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);

--- a/test/WebSites/WebApi/WebApi.csproj
+++ b/test/WebSites/WebApi/WebApi.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
-    <PackageReference Update="Microsoft.AspNetCore.OpenApi" VersionOverride="9.0.8" />
+    <PackageReference Update="Microsoft.AspNetCore.OpenApi" VersionOverride="9.0.9" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Cherry-pick changes from #3283:

- Remove usage of `IWebHost` in tests.
- Style tweaks and use of newer C# features.
- Update NuGet packages to their latest versions.
- Assert OpenAPI documents have no warnings.
