### PR TITLE
Updated SwaggerSchemaAttribute.cs

### DIFF
--- a/src/Swashbuckle.AspNetCore.Annotations/SwaggerSchemaAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.Annotations/SwaggerSchemaAttribute.cs
@@ -33,6 +33,9 @@ public class SwaggerSchemaAttribute(string description = null) : Attribute
 
     public string[] Required { get; set; }
 
+    // To populate a default value for the model property wherever assigned.
+    public string? SeedValue {get; set;}
+
     public string Title { get; set; }
 
     internal bool? ReadOnlyFlag { get; private set; }


### PR DESCRIPTION
Added a new property to hold the default value for a property.

<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
[Feature request]: Default value for a property #3575

<!-- Please include the existing GitHub issue number where relevant, e.g. "Fixes #123" -->

## Details on the issue fix or feature implementation

The property added will hold the default value for a property which will help to display a real value in the API documentation instead of default data type value.

<!-- Information about your changes -->
