### PR TITLE
fix: null ref on uninitialized Security list

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -88,6 +88,7 @@ public class SwaggerGenerator(
             {
                 foreach (var requirement in requirements)
                 {
+                    document.Security ??= [];
                     document.Security.Add(requirement(document));
                 }
             }


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
We noticed a null ref when generating our specs with the current pre-release branch. It looks like a leftover case of uninitialized containers that the OpenAPI.NET v2 is making us all think long and hard about. The Async version of this method already has the initialization.

## Details on the issue fix or feature implementation
This should be simple enough, set the empty list if the `document.Security` is null.