### PR TITLE
Bump Microsoft.OpenApi

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/Swashbuckle.AspNetCore.Swagger.csproj
+++ b/src/Swashbuckle.AspNetCore.Swagger/Swashbuckle.AspNetCore.Swagger.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi" VersionOverride="2.0.0" />
+    <PackageReference Include="Microsoft.OpenApi" VersionOverride="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update Microsoft.OpenApi package version to 2.3.0.

Resolves #3640.
