### PR TITLE
Annotate TryLookupByType for nullability

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SchemaRepository.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SchemaRepository.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.OpenApi;
+﻿using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.OpenApi;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -24,7 +26,7 @@ public class SchemaRepository(string documentName = null)
         _reservedIds.Add(type, schemaId);
     }
 
-    public bool TryLookupByType(Type type, out OpenApiSchemaReference referenceSchema)
+    public bool TryLookupByType(Type type, [NotNullWhen(true)] out OpenApiSchemaReference referenceSchema)
     {
         if (_reservedIds.TryGetValue(type, out string schemaId))
         {


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

Fixes #3659

## Details on the issue fix or feature implementation

- Annotated `SchemaRepository.TryLookupByType` with `[NotNullWhen(true)]` so callers get nullability warnings when the lookup fails.
- Added the `System.Diagnostics.CodeAnalysis` import and kept the signature otherwise unchanged to maintain API compatibility.
- Verified the entire solution with `dotnet build` and `dotnet test` (net8/net9/net10) to ensure no regressions.