### PR TITLE
Add clarifying example in migration guide to v10

### DIFF
--- a/docs/migrating-to-v10.md
+++ b/docs/migrating-to-v10.md
@@ -73,18 +73,17 @@ Migrating to Swashbuckle.AspNetCore v10+ will likely involve changes in the foll
 
 - Update any NuGet package references for Swashbuckle.AspNetCore and Microsoft.OpenApi to v10.0.0+ and v2.3.0+ respectively.
 - Update any `using` directives that reference types from the `Microsoft.OpenApi.Models` namespace to use the new namespace `Microsoft.OpenApi`.
-- Update model references (e.g. `OpenApiSchema`) to use the new interfaces (e.g. `IOpenApiSchema`) and cast to the relevant concrete types to mutate them (e.g. `OpenApiSchema`), for example like this in a `ISchemaFilter`:
+- Update model references (e.g. `OpenApiSchema`) to use the new interfaces (e.g. `IOpenApiSchema`) and use the relevant concrete types to mutate them (e.g. `OpenApiSchema`). An example of this is shown below for an `ISchemaFilter` implementation:
 
-   ```
+   ```csharp
   public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
   {
-     if (schema is not OpenApiSchema openApiSchema)
-     {
-        return;
-     }
-
-     // the properties are mutable only on the concrete type
-     openApiSchema.Type = JsonSchemaType.String;
+       if (schema is OpenApiSchema openApiSchema)
+       {
+            // The properties are only mutable on the concrete type
+            openApiSchema.Type = JsonSchemaType.String;
+       }
+   }     
    ```
 - Update any use of `.Reference` properties (e.g. `OpenApiSchema.ReferenceV3`) to use the new `*Reference` class instead (e.g. `OpenApiSchemaReference`).
 - Replace usage of the `OpenApiSchema.Type` property using a string (e.g. `"string"` or `"boolean"`) with the `JsonSchemaType` flags enumeration.


### PR DESCRIPTION
Added a concrete example on how to check for concrete types in order to mutate model properties in the migration guide. Without the example, I personally read over the bullet point in the migration guide.

It might or might not be helpful for others, if you don't think so please feel free to ignore the PR.
