### PR TITLE
Fix GitHub step summaries

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -19,7 +19,7 @@ if ($LASTEXITCODE -ne 0) {
 $additionalArgs = @()
 
 if (![string]::IsNullOrEmpty(${env:GITHUB_SHA})) {
-    $additionalArgs += "--logger:GitHubActions;report-warnings=false"
+    $additionalArgs += "--logger:GitHubActions;report-warnings=false;summary-include-passed=false"
     $additionalArgs += "--logger:junit;LogFilePath=junit.xml"
 }
 


### PR DESCRIPTION
Disable including passed tests to fix the step summaries being too large since the upgrade to GitHubActionsTestLogger v3.

