### PR TITLE
Use CreateTempSubdirectory

### DIFF
--- a/test/Swashbuckle.AspNetCore.TestSupport/Utilities/TemporaryDirectory.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Utilities/TemporaryDirectory.cs
@@ -2,7 +2,7 @@
 
 public sealed class TemporaryDirectory : IDisposable
 {
-    private readonly DirectoryInfo _directory = Directory.CreateDirectory(System.IO.Path.Join(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName()));
+    private readonly DirectoryInfo _directory = Directory.CreateTempSubdirectory();
 
     public string Path => _directory.FullName;
 


### PR DESCRIPTION
Replace usage of `Path.GetTempPath()` with `Directory.CreateTempSubdirectory()`.
