### PR TITLE
Fix document URL serialization

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -183,16 +183,12 @@ internal sealed partial class SwaggerUIMiddleware
     private async Task RespondWithDocumentUrls(HttpContext context)
     {
         var response = context.Response;
+        var urls = _options.ConfigObject.Urls ?? [];
 
-        string json = "[]";
-
-        if (_jsonSerializerOptions is null)
-        {
-            var l = new List<UrlDescriptor>(_options.ConfigObject.Urls);
-            json = JsonSerializer.Serialize(l, SwaggerUIOptionsJsonContext.Default.ListUrlDescriptor);
-        }
-
-        json ??= JsonSerializer.Serialize(_options.ConfigObject.Urls, _jsonSerializerOptions);
+        string json =
+            _jsonSerializerOptions is { } options ?
+            JsonSerializer.Serialize(urls, options) :
+            JsonSerializer.Serialize([.. urls], SwaggerUIOptionsJsonContext.Default.ListUrlDescriptor);
 
         var etag = GetETag(json);
         var ifNoneMatch = context.Request.Headers.IfNoneMatch;


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/3772#discussion_r2769015200

## Details on the issue fix or feature implementation

Fix URLs not being serialized correctly if a custom `JsonSerializerOptions` is provided.
