### PR TITLE
.NET 11 prep

### DIFF
--- a/benchmark.ps1
+++ b/benchmark.ps1
@@ -4,7 +4,7 @@
 #Requires -Version 7
 
 param(
-    [Parameter(Mandatory = $false)][string] $Framework = "net8.0",
+    [Parameter(Mandatory = $false)][string] $Framework = "net10.0",
     [Parameter(Mandatory = $false)][string] $Job = ""
 )
 

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/ClientGenerator.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/ClientGenerator.cs
@@ -233,7 +233,7 @@ internal sealed class ClientGenerator(ITestOutputHelper outputHelper)
             .Property("NoWarn", "$(NoWarn)")
             .Property("Nullable", "enable")
             .Property("OutputType", "Library")
-            .Property("TargetFramework", "net10.0")
+            .Property("TargetFramework", $"net{Environment.Version.ToString(2)}")
             .Property("TreatWarningsAsErrors", "false");
 
         foreach (var name in packageReferences)

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SnapshotTestData.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SnapshotTestData.cs
@@ -22,6 +22,11 @@ public static class SnapshotTestData
 
         foreach (var path in Directory.EnumerateFiles(snapshotsPath, "*.txt", SearchOption.AllDirectories))
         {
+            if (Path.GetFileName(path).Contains(".received."))
+            {
+                continue;
+            }
+
             using var snapshot = File.OpenRead(path);
             using var document = JsonDocument.Parse(snapshot);
 

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerIntegrationTests.cs
@@ -11,7 +11,7 @@ public class SwaggerIntegrationTests(ITestOutputHelper outputHelper)
 {
     [Theory]
     [InlineData(typeof(Basic.Startup), "/swagger/v1/swagger.json")]
-    [InlineData(typeof(CliExample.Startup), "/swagger/v1/swagger_net8.0.json")]
+    [InlineData(typeof(CliExample.Startup), "/swagger/v1/swagger_net10.0.json")]
     [InlineData(typeof(ConfigFromFile.Startup), "/swagger/v1/swagger.json")]
     [InlineData(typeof(CustomUIConfig.Startup), "/swagger/v1/swagger.json")]
     [InlineData(typeof(CustomUIIndex.Startup), "/swagger/v1/swagger.json")]
@@ -38,7 +38,7 @@ public class SwaggerIntegrationTests(ITestOutputHelper outputHelper)
         var testSite = new TestSiteAutofaq(typeof(CliExampleWithFactory.Startup), outputHelper);
         using var client = testSite.BuildClient();
 
-        await AssertValidSwaggerJson(client, "/swagger/v1/swagger_net8.0.json");
+        await AssertValidSwaggerJson(client, "/swagger/v1/swagger_net10.0.json");
     }
 
     [Fact]

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/VerifyTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/VerifyTests.cs
@@ -9,7 +9,7 @@ public partial class VerifyTests(ITestOutputHelper outputHelper)
     [Theory]
     [InlineData(typeof(Basic.Startup), "/swagger/v1/swagger.json")]
     [InlineData(typeof(NSwagClientExample.Startup), "/swagger/v1/swagger.json")]
-    [InlineData(typeof(CliExample.Startup), "/swagger/v1/swagger_net8.0.json")]
+    [InlineData(typeof(CliExample.Startup), "/swagger/v1/swagger_net10.0.json")]
     [InlineData(typeof(ConfigFromFile.Startup), "/swagger/v1/swagger.json")]
     [InlineData(typeof(CustomDocumentSerializer.Startup), "/swagger/v1/swagger.json")]
     [InlineData(typeof(CustomUIConfig.Startup), "/swagger/v1/swagger.json")]
@@ -40,7 +40,7 @@ public partial class VerifyTests(ITestOutputHelper outputHelper)
     public async Task SwaggerEndpoint_ReturnsValidSwaggerJson_ForAutofaq()
     {
         var startupType = typeof(CliExampleWithFactory.Startup);
-        const string swaggerRequestUri = "/swagger/v1/swagger_net8.0.json";
+        const string swaggerRequestUri = "/swagger/v1/swagger_net10.0.json";
 
         var testSite = new TestSiteAutofaq(startupType, outputHelper);
         using var client = testSite.BuildClient();


### PR DESCRIPTION
- Cherry-pick changes from #3789 to minimise diff.
- Update default TFM for benchmarks.
