### PR TITLE
Migrate to actions/attest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
         upload-release-assets: true
 
     - name: Attest artifacts
-      uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
       if: |
         runner.os == 'Windows' &&
         github.event.repository.fork == false &&


### PR DESCRIPTION
Migrate from now-deprecated attestation action to `actions/attest`.
