### PR TITLE
Update Duende.IdentityServer

### DIFF
--- a/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
+++ b/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Duende.IdentityServer" VersionOverride="7.4.6" />
+    <PackageReference Include="Duende.IdentityServer" VersionOverride="7.4.7" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">


### PR DESCRIPTION
Updated Duende.IdentityServer package version from 7.4.6 to 7.4.7 to resolve https://github.com/domaindrivendev/Swashbuckle.AspNetCore/security/dependabot/39.
