### PR TITLE
Log exception when app fails to start in CLI

### DIFF
--- a/src/Swashbuckle.AspNetCore.Cli/HostingApplication.cs
+++ b/src/Swashbuckle.AspNetCore.Cli/HostingApplication.cs
@@ -88,10 +88,10 @@ internal class HostingApplication
 
             return services;
         }
-        catch (InvalidOperationException exception)
+        catch (InvalidOperationException ex)
         {
             // We're unable to resolve the host, log the exception and return null
-            Console.Error.WriteLine(exception.ToString());
+            Console.Error.WriteLine(ex.ToString());
         }
 
         return null;


### PR DESCRIPTION
There is a misleading logging that happens under the following conditions:

1) We use .NET app with minimal hosting model
2) We use dotnet tool in our csproj file like this:
  <Target Name="CreateSwaggerJson" AfterTargets="PostBuildEvent" Inputs="$(TargetPath)" Outputs="$(SwaggerJsonPath)">
    <Exec Command="dotnet swagger tofile --output &quot;$(SwaggerJsonPath)&quot; &quot;$(TargetPath)&quot; v1" WorkingDirectory="$(ProjectDir)" EnvironmentVariables="DOTNET_ENVIRONMENT=Development;SWAGGER_GEN=true" />
  </Target>

3) We introduce an issue in our Program.cs, so the application just cannot start up.

We receive an error like the following:

AI.Crawl.Client -> C:\Users\oldukhno\work\Invictus\artifacts\bin\AI.Crawl.Client\debug_net10.0\AI.Crawl.Client.dll
     AI.Search.Services.Internal -> C:\Users\oldukhno\work\Invictus\artifacts\bin\AI.Search.Services.Internal\debug_net10.0\AI.Search.Services.Internal.dll
     AI.Search.Services.Agents.Foundry -> C:\Users\oldukhno\work\Invictus\artifacts\bin\AI.Search.Services.Agents.Foundry\debug_net10.0\AI.Search.Services.Agents.Foundry.dll
     AI.Search.Host -> C:\Users\oldukhno\work\Invictus\artifacts\bin\AI.Search.Host\debug\AI.Search.Host.dll
     Unhandled exception. System.InvalidOperationException: A type named 'StartupDevelopment' or 'Startup' could not be found in assembly 'AI.Search.Host'.
        at Microsoft.AspNetCore.Hosting.StartupLoader.FindStartupType(String startupAssemblyName, String environmentName)
        at Microsoft.AspNetCore.Hosting.GenericWebHostBuilder.ScanAssemblyAndRegisterStartup(HostBuilderContext context, IServiceCollection services, WebHostBuilderContext webhostContext, WebHostOptions webHostOptions)
        at Microsoft.AspNetCore.Hosting.GenericWebHostBuilder.<.ctor>b__4_2(HostBuilderContext context, IServiceCollection services)
        at Microsoft.Extensions.Hosting.HostBuilder.InitializeServiceProvider()
        at Microsoft.Extensions.Hosting.HostBuilder.Build()
        at Swashbuckle.AspNetCore.Cli.Program.GetServiceProvider(Assembly startupAssembly) in /_/src/Swashbuckle.AspNetCore.Cli/Program.cs:line 257
        at Swashbuckle.AspNetCore.Cli.Program.SetupAndRetrieveSwaggerProviderAndOptions(IDictionary`2 namedArgs, ISwaggerProvider& swaggerProvider, IOptions`1& swaggerOptions) in /_/src/Swashbuckle.AspNetCore.Cli/Program.cs:line 195
        at Swashbuckle.AspNetCore.Cli.Program.<>c.<Main>b__1_5(IDictionary`2 namedArgs) in /_/src/Swashbuckle.AspNetCore.Cli/Program.cs:line 65
        at Swashbuckle.AspNetCore.Cli.CommandRunner.Run(IEnumerable`1 args) in /_/src/Swashbuckle.AspNetCore.Cli/CommandRunner.cs:line 56
        at Swashbuckle.AspNetCore.Cli.CommandRunner.Run(IEnumerable`1 args) in /_/src/Swashbuckle.AspNetCore.Cli/CommandRunner.cs:line 47
        at Swashbuckle.AspNetCore.Cli.Program.Main(String[] args) in /_/src/Swashbuckle.AspNetCore.Cli/Program.cs:line 189
   C:\Users\oldukhno\work\Invictus\src\hosts\AI.Search.Host\AI.Search.Host.csproj(72,5): error MSB3073:
 
 The command "dotnet swagger tofile --output "C:\Users\oldukhno\work\Invictus\src\hosts\AI.Search.Host/../../clients/AI.Search.Client/swagger.json" "C:\Users\oldukhno\work\Invictus\artifacts\bin\AI.Search.Host\debug\AI.Search.Host.dll" v1" exited with code -532462766.


This is misleading and hiding the actual issue. We had better output the error message to stderr instead just swallowing it.

