### PR TITLE
Support HEAD requests

### DIFF
--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
@@ -10,6 +10,7 @@ namespace Swashbuckle.AspNetCore.ReDoc;
 
 internal sealed class ReDocMiddleware
 {
+    private static readonly string[] AllowedHttpMethods = [HttpMethods.Get, HttpMethods.Head];
     private static readonly string ReDocVersion = GetReDocVersion();
 
     private readonly RequestDelegate _next;
@@ -37,7 +38,7 @@ internal sealed class ReDocMiddleware
 
     public async Task Invoke(HttpContext httpContext)
     {
-        if (HttpMethods.IsGet(httpContext.Request.Method))
+        if (AllowedHttpMethods.Contains(httpContext.Request.Method, StringComparer.OrdinalIgnoreCase))
         {
             var path = httpContext.Request.Path.Value;
 
@@ -165,7 +166,12 @@ internal sealed class ReDocMiddleware
 
             SetHeaders(response, _options, etag);
 
-            await response.WriteAsync(text, Encoding.UTF8, cancellationToken);
+            response.ContentLength = Encoding.UTF8.GetByteCount(text);
+
+            if (!HttpMethods.IsHead(context.Request.Method))
+            {
+                await response.WriteAsync(text, Encoding.UTF8, cancellationToken);
+            }
         }
 
         static string GetETag(string text)

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
@@ -10,7 +10,7 @@ namespace Swashbuckle.AspNetCore.ReDoc;
 
 internal sealed class ReDocMiddleware
 {
-    private static readonly string[] AllowedHttpMethods = [HttpMethods.Get, HttpMethods.Head];
+    private static readonly HashSet<string> AllowedHttpMethods = new(StringComparer.OrdinalIgnoreCase) { HttpMethods.Get, HttpMethods.Head };
     private static readonly string ReDocVersion = GetReDocVersion();
 
     private readonly RequestDelegate _next;
@@ -38,7 +38,7 @@ internal sealed class ReDocMiddleware
 
     public async Task Invoke(HttpContext httpContext)
     {
-        if (AllowedHttpMethods.Contains(httpContext.Request.Method, StringComparer.OrdinalIgnoreCase))
+        if (AllowedHttpMethods.Contains(httpContext.Request.Method))
         {
             var path = httpContext.Request.Path.Value;
 
@@ -166,11 +166,14 @@ internal sealed class ReDocMiddleware
 
             SetHeaders(response, _options, etag);
 
-            response.ContentLength = Encoding.UTF8.GetByteCount(text);
-
-            if (!HttpMethods.IsHead(context.Request.Method))
+            if (HttpMethods.IsGet(context.Request.Method))
             {
                 await response.WriteAsync(text, Encoding.UTF8, cancellationToken);
+            }
+            else if (HttpMethods.IsHead(context.Request.Method))
+            {
+                // HEAD response must have an empty body, but have correct Content-Length header
+                response.ContentLength = Encoding.UTF8.GetByteCount(text);
             }
         }
 

--- a/src/Swashbuckle.AspNetCore.Swagger/DependencyInjection/SwaggerBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/DependencyInjection/SwaggerBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.Routing.Template;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Swagger;
@@ -46,7 +47,7 @@ public static class SwaggerBuilderExtensions
             .UseSwagger(Configure)
             .Build();
 
-        return endpoints.MapGet(pattern, pipeline);
+        return endpoints.MapMethods(pattern, [HttpMethods.Get, HttpMethods.Head], pipeline);
 
         void Configure(SwaggerOptions options)
         {

--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
@@ -12,6 +12,7 @@ namespace Swashbuckle.AspNetCore.Swagger;
 internal sealed class SwaggerMiddleware
 {
     private static readonly Encoding UTF8WithoutBom = new UTF8Encoding(false);
+    private static readonly string[] AllowedHttpMethods = [HttpMethods.Get, HttpMethods.Head];
 
     private readonly RequestDelegate _next;
     private readonly SwaggerOptions _options;
@@ -74,13 +75,15 @@ internal sealed class SwaggerMiddleware
                 filter(swagger, httpContext.Request);
             }
 
+            var isHeadRequest = HttpMethods.IsHead(httpContext.Request.Method);
+
             if (extension is ".yaml" or ".yml")
             {
-                await RespondWithSwaggerYaml(httpContext.Response, swagger);
+                await RespondWithSwaggerYaml(httpContext.Response, swagger, isHeadRequest);
             }
             else
             {
-                await RespondWithSwaggerJson(httpContext.Response, swagger);
+                await RespondWithSwaggerJson(httpContext.Response, swagger, isHeadRequest);
             }
         }
         catch (UnknownSwaggerDocument)
@@ -94,7 +97,7 @@ internal sealed class SwaggerMiddleware
         documentName = null;
         extension = null;
 
-        if (!HttpMethods.IsGet(request.Method))
+        if (!AllowedHttpMethods.Contains(request.Method, StringComparer.OrdinalIgnoreCase))
         {
             return false;
         }
@@ -125,7 +128,7 @@ internal sealed class SwaggerMiddleware
         return false;
     }
 
-    private async Task RespondWithSwaggerJson(HttpResponse response, OpenApiDocument swagger)
+    private async Task RespondWithSwaggerJson(HttpResponse response, OpenApiDocument swagger, bool isHeadRequest)
     {
         string json;
 
@@ -140,11 +143,15 @@ internal sealed class SwaggerMiddleware
 
         response.StatusCode = 200;
         response.ContentType = "application/json;charset=utf-8";
+        response.ContentLength = UTF8WithoutBom.GetByteCount(json);
 
-        await response.WriteAsync(json, UTF8WithoutBom);
+        if (!isHeadRequest)
+        {
+            await response.WriteAsync(json, UTF8WithoutBom);
+        }
     }
 
-    private async Task RespondWithSwaggerYaml(HttpResponse response, OpenApiDocument swagger)
+    private async Task RespondWithSwaggerYaml(HttpResponse response, OpenApiDocument swagger, bool isHeadRequest)
     {
         string yaml;
 
@@ -159,8 +166,12 @@ internal sealed class SwaggerMiddleware
 
         response.StatusCode = 200;
         response.ContentType = "text/yaml;charset=utf-8";
+        response.ContentLength = UTF8WithoutBom.GetByteCount(yaml);
 
-        await response.WriteAsync(yaml, UTF8WithoutBom);
+        if (!isHeadRequest)
+        {
+            await response.WriteAsync(yaml, UTF8WithoutBom);
+        }
     }
 
     private void SerializeDocument(

--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
@@ -12,7 +12,7 @@ namespace Swashbuckle.AspNetCore.Swagger;
 internal sealed class SwaggerMiddleware
 {
     private static readonly Encoding UTF8WithoutBom = new UTF8Encoding(false);
-    private static readonly string[] AllowedHttpMethods = [HttpMethods.Get, HttpMethods.Head];
+    private static readonly HashSet<string> AllowedHttpMethods = new(StringComparer.OrdinalIgnoreCase) { HttpMethods.Get, HttpMethods.Head };
 
     private readonly RequestDelegate _next;
     private readonly SwaggerOptions _options;
@@ -97,7 +97,7 @@ internal sealed class SwaggerMiddleware
         documentName = null;
         extension = null;
 
-        if (!AllowedHttpMethods.Contains(request.Method, StringComparer.OrdinalIgnoreCase))
+        if (!AllowedHttpMethods.Contains(request.Method))
         {
             return false;
         }
@@ -143,9 +143,13 @@ internal sealed class SwaggerMiddleware
 
         response.StatusCode = 200;
         response.ContentType = "application/json;charset=utf-8";
-        response.ContentLength = UTF8WithoutBom.GetByteCount(json);
 
-        if (!isHeadRequest)
+        if (isHeadRequest)
+        {
+            // HEAD response must have an empty body, but have correct Content-Length header
+            response.ContentLength = UTF8WithoutBom.GetByteCount(json);
+        }
+        else
         {
             await response.WriteAsync(json, UTF8WithoutBom);
         }
@@ -166,9 +170,13 @@ internal sealed class SwaggerMiddleware
 
         response.StatusCode = 200;
         response.ContentType = "text/yaml;charset=utf-8";
-        response.ContentLength = UTF8WithoutBom.GetByteCount(yaml);
 
-        if (!isHeadRequest)
+        if (isHeadRequest)
+        {
+            // HEAD response must have an empty body, but have correct Content-Length header
+            response.ContentLength = UTF8WithoutBom.GetByteCount(yaml);
+        }
+        else
         {
             await response.WriteAsync(yaml, UTF8WithoutBom);
         }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -10,6 +10,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI;
 
 internal sealed partial class SwaggerUIMiddleware
 {
+    private static readonly string[] AllowedHttpMethods = [HttpMethods.Get, HttpMethods.Head];
     private static readonly string SwaggerUIVersion = GetSwaggerUIVersion();
 
     private readonly RequestDelegate _next;
@@ -37,7 +38,7 @@ internal sealed partial class SwaggerUIMiddleware
 
     public async Task Invoke(HttpContext httpContext)
     {
-        if (HttpMethods.IsGet(httpContext.Request.Method))
+        if (AllowedHttpMethods.Contains(httpContext.Request.Method, StringComparer.OrdinalIgnoreCase))
         {
             var path = httpContext.Request.Path.Value;
 
@@ -167,7 +168,12 @@ internal sealed partial class SwaggerUIMiddleware
 
                 SetHeaders(response, _options, etag);
 
-                await response.WriteAsync(text, Encoding.UTF8, cancellationToken);
+                response.ContentLength = Encoding.UTF8.GetByteCount(text);
+
+                if (!HttpMethods.IsHead(context.Request.Method))
+                {
+                    await response.WriteAsync(text, Encoding.UTF8, cancellationToken);
+                }
             }
         }
     }

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -10,7 +10,7 @@ namespace Swashbuckle.AspNetCore.SwaggerUI;
 
 internal sealed partial class SwaggerUIMiddleware
 {
-    private static readonly string[] AllowedHttpMethods = [HttpMethods.Get, HttpMethods.Head];
+    private static readonly HashSet<string> AllowedHttpMethods = new(StringComparer.OrdinalIgnoreCase) { HttpMethods.Get, HttpMethods.Head };
     private static readonly string SwaggerUIVersion = GetSwaggerUIVersion();
 
     private readonly RequestDelegate _next;
@@ -38,7 +38,7 @@ internal sealed partial class SwaggerUIMiddleware
 
     public async Task Invoke(HttpContext httpContext)
     {
-        if (AllowedHttpMethods.Contains(httpContext.Request.Method, StringComparer.OrdinalIgnoreCase))
+        if (AllowedHttpMethods.Contains(httpContext.Request.Method))
         {
             var path = httpContext.Request.Path.Value;
 
@@ -168,11 +168,14 @@ internal sealed partial class SwaggerUIMiddleware
 
                 SetHeaders(response, _options, etag);
 
-                response.ContentLength = Encoding.UTF8.GetByteCount(text);
-
-                if (!HttpMethods.IsHead(context.Request.Method))
+                if (HttpMethods.IsGet(context.Request.Method))
                 {
                     await response.WriteAsync(text, Encoding.UTF8, cancellationToken);
+                }
+                else if (HttpMethods.IsHead(context.Request.Method))
+                {
+                    // HEAD response must have an empty body, but have correct Content-Length header
+                    response.ContentLength = Encoding.UTF8.GetByteCount(text);
                 }
             }
         }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
@@ -35,7 +35,7 @@ public class ReDocIntegrationTests(ITestOutputHelper outputHelper)
         using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.True(response.Content.Headers.ContentLength > 0, $"Content-Length should be greater than 0, but was {response.Content.Headers.ContentLength}");
+        Assert.True(response.Content.Headers.ContentLength > 0, "Content-Length should not be zero.");
         Assert.Empty(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
     }
 

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
@@ -27,6 +27,19 @@ public class ReDocIntegrationTests(ITestOutputHelper outputHelper)
     }
 
     [Fact]
+    public async Task IndexUrl_HeadRequest_ReturnsMetadata()
+    {
+        var site = new TestSite(typeof(ReDocApp.Startup), outputHelper);
+        using var client = site.BuildClient();
+        using var request = new HttpRequestMessage(HttpMethod.Head, "/api-docs/index.html");
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(response.Content.Headers.ContentLength > 0, $"Content-Length should be greater than 0, but was {response.Content.Headers.ContentLength}");
+        Assert.Empty(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
     public async Task IndexUrl_ReturnsEmbeddedVersionOfTheRedocUI()
     {
         var cancellationToken = TestContext.Current.CancellationToken;

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerIntegrationTests.cs
@@ -65,7 +65,7 @@ public class SwaggerIntegrationTests(ITestOutputHelper outputHelper)
         using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.True(response.Content.Headers.ContentLength > 0, $"{HeaderNames.ContentLength} should be greater than 0, but was {response.Content.Headers.ContentLength}");
+        Assert.True(response.Content.Headers.ContentLength > 0, "Content-Length should not be zero.");
         Assert.Empty(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
     }
 

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerIntegrationTests.cs
@@ -1,7 +1,9 @@
 using System.Globalization;
+using System.Net;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Net.Http.Headers;
 using ReDocApp = ReDoc;
 
 namespace Swashbuckle.AspNetCore.IntegrationTests;
@@ -51,7 +53,20 @@ public class SwaggerIntegrationTests(ITestOutputHelper outputHelper)
 
         using var swaggerResponse = await client.GetAsync("/swagger/v2/swagger.json", TestContext.Current.CancellationToken);
 
-        Assert.Equal(System.Net.HttpStatusCode.NotFound, swaggerResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound, swaggerResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task SwaggerEndpoint_ReturnsMetadata_ForHeadRequest()
+    {
+        var testSite = new TestSite(typeof(Basic.Startup), outputHelper);
+        using var client = testSite.BuildClient();
+        using var request = new HttpRequestMessage(HttpMethod.Head, "/swagger/v1/swagger.json");
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(response.Content.Headers.ContentLength > 0, $"{HeaderNames.ContentLength} should be greater than 0, but was {response.Content.Headers.ContentLength}");
+        Assert.Empty(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerIntegrationTests.cs
@@ -3,7 +3,6 @@ using System.Net;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
-using Microsoft.Net.Http.Headers;
 using ReDocApp = ReDoc;
 
 namespace Swashbuckle.AspNetCore.IntegrationTests;

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO.Compression;
 using System.Net;
 using System.Security.Cryptography;
+using Microsoft.Net.Http.Headers;
 
 namespace Swashbuckle.AspNetCore.IntegrationTests;
 
@@ -51,6 +52,23 @@ public class SwaggerUIIntegrationTests(ITestOutputHelper outputHelper)
 
         Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
         Assert.Equal(expectedRedirectPath, response.Headers.Location.ToString());
+    }
+
+    [Theory]
+    [InlineData(typeof(Basic.Startup), "/index.html")]
+    [InlineData(typeof(CustomUIConfig.Startup), "/swagger/index.html")]
+    public async Task IndexUrl_HeadRequest_ReturnsMetadata(
+        Type startupType,
+        string requestPath)
+    {
+        var site = new TestSite(startupType, outputHelper);
+        using var client = site.BuildClient();
+        using var request = new HttpRequestMessage(HttpMethod.Head, requestPath);
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(response.Content.Headers.ContentLength > 0, $"{HeaderNames.ContentLength} should be greater than 0, but was {response.Content.Headers.ContentLength}");
+        Assert.Empty(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
     }
 
     [Theory]

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.IO.Compression;
 using System.Net;
 using System.Security.Cryptography;
-using Microsoft.Net.Http.Headers;
 
 namespace Swashbuckle.AspNetCore.IntegrationTests;
 
@@ -67,7 +66,7 @@ public class SwaggerUIIntegrationTests(ITestOutputHelper outputHelper)
         using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        Assert.True(response.Content.Headers.ContentLength > 0, $"{HeaderNames.ContentLength} should be greater than 0, but was {response.Content.Headers.ContentLength}");
+        Assert.True(response.Content.Headers.ContentLength > 0, "Content-Length should not be be 0.");
         Assert.Empty(await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed

Fixes #2174 

## Details on the issue fix or feature implementation

HEAD requests now return resource metadata
```http
HTTP/1.1 200 OK
Content-Length: 1234567
NO BODY
```