### PR TITLE
Remove ZIZMOR_VERSION

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,6 @@ permissions: {}
 env:
   FORCE_COLOR: 3
   TERM: xterm
-  ZIZMOR_VERSION: '1.23.1'
 
 jobs:
   lint:
@@ -48,7 +47,6 @@ jobs:
       uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
       with:
         persona: pedantic
-        version: ${{ env.ZIZMOR_VERSION }}
 
     - name: Lint markdown
       uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9 # v23.0.0


### PR DESCRIPTION
Rely on the built-in default pinned version instead.
