### PR TITLE
fix(SwaggerGen): include endpoints with GroupName in OpenAPI document

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
@@ -81,7 +81,10 @@ public class SwaggerGeneratorOptions
 
     private bool DefaultDocInclusionPredicate(string documentName, ApiDescription apiDescription)
     {
-        return apiDescription.GroupName == null || apiDescription.GroupName == documentName;
+        // If the endpoint's GroupName doesn't match any registered document, treat it as
+        // ungrouped (include it). This ensures endpoints with a GroupName that's not mapped
+        // to a specific document are not inadvertently excluded from the OpenAPI document.
+        return !_options.SwaggerDocs.ContainsKey(apiDescription.GroupName) || apiDescription.GroupName == documentName;
     }
 
     private string DefaultOperationIdSelector(ApiDescription apiDescription)


### PR DESCRIPTION
## Summary
Fixes the issue where endpoints configured with `WithGroupName()` on a `MapGroup` would not appear in the generated OpenAPI document.

## Problem
When an endpoint had a `GroupName` attribute set (via `WithGroupName()` on a `MapGroup`), the `DefaultDocInclusionPredicate` would exclude it if the `GroupName` did not match any registered document name. This meant that endpoints with `GroupName="segments"` would be excluded from the default "v1" document when no "segments" document was registered.

## Root Cause
The `DefaultDocInclusionPredicate` was:
```csharp
return apiDescription.GroupName == null || apiDescription.GroupName == documentName;
```

This excluded any endpoint whose `GroupName` was set but didn't match the requested document name, even when no document with that name existed.

## Fix
Changed the predicate to:
```csharp
return !_options.SwaggerDocs.ContainsKey(apiDescription.GroupName) || apiDescription.GroupName == documentName;
```

This treats an endpoint's `GroupName` as a filter only when a document with that name is registered. If no such document exists, the endpoint is treated as ungrouped and included in all documents.

## Behavior Change
- **Before**: `GroupName` set but not matching docName → endpoint excluded
- **After**: `GroupName` set but not matching any registered doc → endpoint included

This preserves the existing behavior for registered document names (endpoints with `GroupName="v2"` only appear in the "v2" document when both "v1" and "v2" documents are registered), while fixing the bug where endpoints with unhandled group names were inadvertently excluded.