### PR TITLE
Fix conflicting required+nullable schema when only NonNullableReferen…

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -139,7 +139,7 @@ public class SchemaGenerator(
     {
         var nullable = dataProperty.IsNullable && requiredAttribute == null;
 
-        if (_generatorOptions.SupportNonNullableReferenceTypes)
+        if (_generatorOptions.SupportNonNullableReferenceTypes || _generatorOptions.NonNullableReferenceTypesAsRequired)
         {
             nullable &= !memberInfo.IsNonNullableReferenceType();
         }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -1127,6 +1127,23 @@ public class JsonSerializerSchemaGeneratorTests
     }
 
     [Theory]
+    [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContextAnnotated.NonNullableString))]
+    [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.SubTypeWithOneNonNullableContent), nameof(TypeWithNullableContextNotAnnotated.NonNullableString))]
+    public void GenerateSchema_NonNullableReferenceTypesAsRequired_DoesNotMarkPropertyAsNullable(
+        Type declaringType,
+        string subType,
+        string propertyName)
+    {
+        var subject = Subject(c => c.NonNullableReferenceTypesAsRequired = true);
+        var schemaRepository = new SchemaRepository();
+
+        subject.GenerateSchema(declaringType, schemaRepository);
+
+        var propertySchema = schemaRepository.Schemas[subType].Properties[propertyName];
+        AssertIsNullable(propertySchema, expected: false);
+    }
+
+    [Theory]
     [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.SubTypeWithNestedSubType.Nested), nameof(TypeWithNullableContextAnnotated.SubTypeWithNestedSubType.Nested.NullableString), true)]
     [InlineData(typeof(TypeWithNullableContextAnnotated), nameof(TypeWithNullableContextAnnotated.SubTypeWithNestedSubType.Nested), nameof(TypeWithNullableContextAnnotated.SubTypeWithNestedSubType.Nested.NonNullableString), false)]
     [InlineData(typeof(TypeWithNullableContextNotAnnotated), nameof(TypeWithNullableContextNotAnnotated.SubTypeWithNestedSubType.Nested), nameof(TypeWithNullableContextAnnotated.SubTypeWithNestedSubType.Nested.NullableString), true)]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -483,6 +483,31 @@ public class JsonSerializerSchemaGeneratorTests
         AssertIsNullable(schema.Properties["RequiredNonNullableString"], false);
         Assert.Contains("RequiredNonNullableString", schema.Required.ToArray());
     }
+
+    [Fact]
+    public void GenerateSchema_NonNullableReferenceTypesAsRequired_PreservesNullable_IfPropertyHasRequiredKeywordAndIsNullable()
+    {
+        var schemaRepository = new SchemaRepository();
+
+        var referenceSchema = Subject(configureGenerator: (c) => c.NonNullableReferenceTypesAsRequired = true).GenerateSchema(typeof(TypeWithNullableReferenceTypes), schemaRepository);
+
+        var reference = Assert.IsType<OpenApiSchemaReference>(referenceSchema);
+
+        Assert.NotNull(reference);
+        Assert.NotNull(reference.Reference);
+        Assert.NotNull(reference.Reference.Id);
+
+        var schema = schemaRepository.Schemas[reference.Reference.Id];
+        Assert.NotNull(schema.Properties);
+
+        // required string? — must be present (required) AND may be null (nullable: true)
+        AssertIsNullable(schema.Properties["RequiredNullableString"]);
+        Assert.Contains("RequiredNullableString", schema.Required.ToArray());
+
+        // required string — must be present (required) AND must have a value (nullable: false)
+        AssertIsNullable(schema.Properties["RequiredNonNullableString"], false);
+        Assert.Contains("RequiredNonNullableString", schema.Required.ToArray());
+    }
 #nullable disable
 
     [Theory]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -499,12 +499,13 @@ public class JsonSerializerSchemaGeneratorTests
 
         var schema = schemaRepository.Schemas[reference.Reference.Id];
         Assert.NotNull(schema.Properties);
+        Assert.NotNull(schema.Required);
 
-        // required string? — must be present (required) AND may be null (nullable: true)
+        // required string? - must be present (required) AND may be null (nullable: true)
         AssertIsNullable(schema.Properties["RequiredNullableString"]);
         Assert.Contains("RequiredNullableString", schema.Required.ToArray());
 
-        // required string — must be present (required) AND must have a value (nullable: false)
+        // required string - must be present (required) AND must have a value (nullable: false)
         AssertIsNullable(schema.Properties["RequiredNonNullableString"], false);
         Assert.Contains("RequiredNonNullableString", schema.Required.ToArray());
     }


### PR DESCRIPTION
## Fix conflicting `required` + `nullable` schema when only `NonNullableReferenceTypesAsRequired` is enabled

Fixes #3297

### Problem

When `NonNullableReferenceTypesAsRequired()` is enabled **without** `SupportNonNullableReferenceTypes()`, non-nullable reference-type properties end up with both `"required": true` and `"nullable": true` in the generated schema.

### Root cause

`IsNullable` only checks `SupportNonNullableReferenceTypes`:

```csharp
if (_generatorOptions.SupportNonNullableReferenceTypes)
{
    nullable &= !memberInfo.IsNonNullableReferenceType();
}
```

So when only `-AsRequired` is set, the property gets added to `required` (via `GenerateSchemaForMembers`) but `nullable` is never cleared.

### Fix

```csharp
if (_generatorOptions.SupportNonNullableReferenceTypes || _generatorOptions.NonNullableReferenceTypesAsRequired)
{
    nullable &= !memberInfo.IsNonNullableReferenceType();
}
```

### Before / after

`builder.Services.AddSwaggerGen(c => c.NonNullableReferenceTypesAsRequired());`

```csharp
public class WeatherForecast
{
    public string Summary { get; set; }
}
```

**Before:**
```json
"summary": { "type": "string", "nullable": true }
```

**After:**
```json
"summary": { "type": "string" }
```

### Tests

Added `GenerateSchema_NonNullableReferenceTypesAsRequired_DoesNotMarkPropertyAsNullable` for both `TypeWithNullableContextAnnotated` and `TypeWithNullableContextNotAnnotated`. Fails on `main`, passes after the fix. Full suite 720/720 on `net10.0`, clean build on `net8.0`/`net9.0`/`net10.0`.
