### PR TITLE
Fix empty parameter example not generated

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
@@ -74,7 +74,7 @@ public class XmlCommentsParameterFilter(IReadOnlyDictionary<string, XPathNavigat
             if (parameter is OpenApiParameter concrete)
             {
                 var example = paramNode.GetAttribute("example");
-                if (!string.IsNullOrEmpty(example))
+                if (example != null)
                 {
                     concrete.Example = XmlCommentsExampleHelper.Create(context.SchemaRepository, parameter.Schema, example);
                 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsParameterFilter.cs
@@ -73,10 +73,10 @@ public class XmlCommentsParameterFilter(IReadOnlyDictionary<string, XPathNavigat
 
             if (parameter is OpenApiParameter concrete)
             {
-                var example = paramNode.GetAttribute("example");
+                var example = paramNode.SelectSingleNode("@example");
                 if (example != null)
                 {
-                    concrete.Example = XmlCommentsExampleHelper.Create(context.SchemaRepository, parameter.Schema, example);
+                    concrete.Example = XmlCommentsExampleHelper.Create(context.SchemaRepository, parameter.Schema, example.ToString());
                 }
             }
         }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeConstructedControllerWithXmlComments.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeConstructedControllerWithXmlComments.cs
@@ -22,7 +22,8 @@ public class GenericControllerWithXmlComments<T>
     /// <param name="param1" example="Example for &quot;param1&quot;">Description for param1</param>
     /// <param name="param2" example="http://test.com/?param1=1&amp;param2=2">Description for param2</param>
     /// <param name="param3" example="">Description for param3 with empty example</param>
-    public void ActionWithParamTags(T param1, T param2, T param3)
+    /// <param name="param4"></param>
+    public void ActionWithParamTags(T param1, T param2, T param3, T param4)
     {
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeConstructedControllerWithXmlComments.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeConstructedControllerWithXmlComments.cs
@@ -20,8 +20,9 @@ public class GenericControllerWithXmlComments<T>
     }
 
     /// <param name="param1" example="Example for &quot;param1&quot;">Description for param1</param>
-    /// <param name="param2" example="Example for &quot;param2&quot;">Description for param2</param>
-    public void ActionWithParamTags(T param1, T param2)
+    /// <param name="param2" example="http://test.com/?param1=1&amp;param2=2">Description for param2</param>
+    /// <param name="param3" example="">Description for param3 with empty example</param>
+    public void ActionWithParamTags(T param1, T param2, T param3)
     {
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithXmlComments.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithXmlComments.cs
@@ -21,7 +21,8 @@ public class FakeControllerWithXmlComments
     /// <param name="param1" example="Example for &quot;param1&quot;">Description for param1</param>
     /// <param name="param2" example="http://test.com/?param1=1&amp;param2=2">Description for param2</param>
     /// <param name="param3" example="">Description for param3 with empty example</param>
-    public void ActionWithParamTags(string param1, string param2, string param3)
+    /// <param name="param4"></param>
+    public void ActionWithParamTags(string param1, string param2, string param3, string param4)
     {
     }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithXmlComments.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeControllerWithXmlComments.cs
@@ -20,7 +20,8 @@ public class FakeControllerWithXmlComments
 
     /// <param name="param1" example="Example for &quot;param1&quot;">Description for param1</param>
     /// <param name="param2" example="http://test.com/?param1=1&amp;param2=2">Description for param2</param>
-    public void ActionWithParamTags(string param1, string param2)
+    /// <param name="param3" example="">Description for param3 with empty example</param>
+    public void ActionWithParamTags(string param1, string param2, string param3)
     {
     }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsParameterFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsParameterFilterTests.cs
@@ -9,58 +9,46 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test;
 
 public class XmlCommentsParameterFilterTests
 {
-    [Fact]
-    public void Apply_SetsDescriptionAndExample_FromActionParamTag()
+    [Theory]
+    [InlineData(0, "Description for param1", "\"Example for \\u0022param1\\u0022\"")]
+    [InlineData(1, "Description for param2", "\"http://test.com/?param1=1\\u0026param2=2\"")]
+    [InlineData(2, "Description for param3 with empty example", "\"\"")]
+    public void Apply_SetsDescriptionAndExample_FromActionParamTag(int p, string expectedDescription, string expectedExample)
     {
         var parameter = new OpenApiParameter { Schema = new OpenApiSchema { Type = JsonSchemaTypes.String } };
         var parameterInfo = typeof(FakeControllerWithXmlComments)
             .GetMethod(nameof(FakeControllerWithXmlComments.ActionWithParamTags))
-            .GetParameters()[0];
+            .GetParameters()[p];
         var apiParameterDescription = new ApiParameterDescription { };
         var filterContext = new ParameterFilterContext(apiParameterDescription, null, null, null, parameterInfo: parameterInfo);
 
         Subject().Apply(parameter, filterContext);
 
-        Assert.Equal("Description for param1", parameter.Description);
+        Assert.Equal(expectedDescription, parameter.Description);
         Assert.NotNull(parameter.Example);
 
-        Assert.Equal("\"Example for \\u0022param1\\u0022\"", parameter.Example.ToJson());
+        Assert.Equal(expectedExample, parameter.Example.ToJson());
     }
 
-    [Fact]
-    public void Apply_SetsDescriptionAndExample_FromUriTypeActionParamTag()
-    {
-        var parameter = new OpenApiParameter { Schema = new OpenApiSchema { Type = JsonSchemaTypes.String } };
-        var parameterInfo = typeof(FakeControllerWithXmlComments)
-            .GetMethod(nameof(FakeControllerWithXmlComments.ActionWithParamTags))
-            .GetParameters()[1];
-        var apiParameterDescription = new ApiParameterDescription { };
-        var filterContext = new ParameterFilterContext(apiParameterDescription, null, null, null, parameterInfo: parameterInfo);
-
-        Subject().Apply(parameter, filterContext);
-
-        Assert.Equal("Description for param2", parameter.Description);
-        Assert.NotNull(parameter.Example);
-
-        Assert.Equal("\"http://test.com/?param1=1\\u0026param2=2\"", parameter.Example.ToJson());
-    }
-
-    [Fact]
-    public void Apply_SetsDescriptionAndExample_FromUnderlyingGenericTypeActionParamTag()
+    [Theory]
+    [InlineData(0, "Description for param1", "\"Example for \\u0022param1\\u0022\"")]
+    [InlineData(1, "Description for param2", "\"http://test.com/?param1=1\\u0026param2=2\"")]
+    [InlineData(2, "Description for param3 with empty example", "\"\"")]
+    public void Apply_SetsDescriptionAndExample_FromUnderlyingGenericTypeActionParamTag(int p, string expectedDescription, string expectedExample)
     {
         var parameter = new OpenApiParameter { Schema = new OpenApiSchema { Type = JsonSchemaTypes.String } };
         var parameterInfo = typeof(FakeConstructedControllerWithXmlComments)
             .GetMethod(nameof(FakeConstructedControllerWithXmlComments.ActionWithParamTags))
-            .GetParameters()[0];
+            .GetParameters()[p];
         var apiParameterDescription = new ApiParameterDescription { };
         var filterContext = new ParameterFilterContext(apiParameterDescription, null, null, null, parameterInfo: parameterInfo);
 
         Subject().Apply(parameter, filterContext);
 
-        Assert.Equal("Description for param1", parameter.Description);
+        Assert.Equal(expectedDescription, parameter.Description);
         Assert.NotNull(parameter.Example);
 
-        Assert.Equal("\"Example for \\u0022param1\\u0022\"", parameter.Example.ToJson());
+        Assert.Equal(expectedExample, parameter.Example.ToJson());
     }
 
     [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsParameterFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsParameterFilterTests.cs
@@ -13,6 +13,7 @@ public class XmlCommentsParameterFilterTests
     [InlineData(0, "Description for param1", "\"Example for \\u0022param1\\u0022\"")]
     [InlineData(1, "Description for param2", "\"http://test.com/?param1=1\\u0026param2=2\"")]
     [InlineData(2, "Description for param3 with empty example", "\"\"")]
+    [InlineData(3, "", null)]
     public void Apply_SetsDescriptionAndExample_FromActionParamTag(int p, string expectedDescription, string expectedExample)
     {
         var parameter = new OpenApiParameter { Schema = new OpenApiSchema { Type = JsonSchemaTypes.String } };
@@ -25,15 +26,14 @@ public class XmlCommentsParameterFilterTests
         Subject().Apply(parameter, filterContext);
 
         Assert.Equal(expectedDescription, parameter.Description);
-        Assert.NotNull(parameter.Example);
-
-        Assert.Equal(expectedExample, parameter.Example.ToJson());
+        Assert.Equal(expectedExample, parameter.Example?.ToJson());
     }
 
     [Theory]
     [InlineData(0, "Description for param1", "\"Example for \\u0022param1\\u0022\"")]
     [InlineData(1, "Description for param2", "\"http://test.com/?param1=1\\u0026param2=2\"")]
     [InlineData(2, "Description for param3 with empty example", "\"\"")]
+    [InlineData(3, "", null)]
     public void Apply_SetsDescriptionAndExample_FromUnderlyingGenericTypeActionParamTag(int p, string expectedDescription, string expectedExample)
     {
         var parameter = new OpenApiParameter { Schema = new OpenApiSchema { Type = JsonSchemaTypes.String } };
@@ -46,9 +46,7 @@ public class XmlCommentsParameterFilterTests
         Subject().Apply(parameter, filterContext);
 
         Assert.Equal(expectedDescription, parameter.Description);
-        Assert.NotNull(parameter.Example);
-
-        Assert.Equal(expectedExample, parameter.Example.ToJson());
+        Assert.Equal(expectedExample, parameter.Example?.ToJson());
     }
 
     [Fact]


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

Fixes: #3931

## Details on the issue fix or feature implementation

Add example also when example string is empty. This allows an empty example to be documented on a parameter.
