### PR TITLE
fix: map MinLength/MaxLength to minProperties/maxProperties for object types

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
@@ -185,6 +185,10 @@ public static class OpenApiSchemaExtensions
         {
             schema.MinItems = minLengthAttribute.Length;
         }
+        else if (schema.Type is { } objType && objType.HasFlag(JsonSchemaTypes.Object))
+        {
+            schema.MinProperties = minLengthAttribute.Length;
+        }
         else
         {
             schema.MinLength = minLengthAttribute.Length;
@@ -196,6 +200,10 @@ public static class OpenApiSchemaExtensions
         if (schema.Type is { } type && type.HasFlag(JsonSchemaTypes.Array))
         {
             schema.MinItems = minLengthRouteConstraint.MinLength;
+        }
+        else if (schema.Type is { } objType && objType.HasFlag(JsonSchemaTypes.Object))
+        {
+            schema.MinProperties = minLengthRouteConstraint.MinLength;
         }
         else
         {
@@ -209,6 +217,10 @@ public static class OpenApiSchemaExtensions
         {
             schema.MaxItems = maxLengthAttribute.Length;
         }
+        else if (schema.Type is { } objType && objType.HasFlag(JsonSchemaTypes.Object))
+        {
+            schema.MaxProperties = maxLengthAttribute.Length;
+        }
         else
         {
             schema.MaxLength = maxLengthAttribute.Length;
@@ -220,6 +232,10 @@ public static class OpenApiSchemaExtensions
         if (schema.Type is { } type && type.HasFlag(JsonSchemaTypes.Array))
         {
             schema.MaxItems = maxLengthRouteConstraint.MaxLength;
+        }
+        else if (schema.Type is { } objType && objType.HasFlag(JsonSchemaTypes.Object))
+        {
+            schema.MaxProperties = maxLengthRouteConstraint.MaxLength;
         }
         else
         {
@@ -233,6 +249,11 @@ public static class OpenApiSchemaExtensions
         {
             schema.MinItems = lengthAttribute.MinimumLength;
             schema.MaxItems = lengthAttribute.MaximumLength;
+        }
+        else if (schema.Type is { } objType && objType.HasFlag(JsonSchemaTypes.Object))
+        {
+            schema.MinProperties = lengthAttribute.MinimumLength;
+            schema.MaxProperties = lengthAttribute.MaximumLength;
         }
         else
         {
@@ -343,7 +364,20 @@ public static class OpenApiSchemaExtensions
 
     private static void ApplyLengthRouteConstraint(OpenApiSchema schema, LengthRouteConstraint lengthRouteConstraint)
     {
-        schema.MinLength = lengthRouteConstraint.MinLength;
-        schema.MaxLength = lengthRouteConstraint.MaxLength;
+        if (schema.Type is { } type && type.HasFlag(JsonSchemaTypes.Array))
+        {
+            schema.MinItems = lengthRouteConstraint.MinLength;
+            schema.MaxItems = lengthRouteConstraint.MaxLength;
+        }
+        else if (schema.Type is { } objType && objType.HasFlag(JsonSchemaTypes.Object))
+        {
+            schema.MinProperties = lengthRouteConstraint.MinLength;
+            schema.MaxProperties = lengthRouteConstraint.MaxLength;
+        }
+        else
+        {
+            schema.MinLength = lengthRouteConstraint.MinLength;
+            schema.MaxLength = lengthRouteConstraint.MaxLength;
+        }
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.ComponentModel.DataAnnotations;
 using System.Dynamic;
 using System.Globalization;
@@ -377,6 +377,10 @@ public class JsonSerializerSchemaGeneratorTests
         Assert.Equal(3, schema.Properties["StringWithLength"].MaxLength);
         Assert.Equal(1, schema.Properties["ArrayWithLength"].MinItems);
         Assert.Equal(3, schema.Properties["ArrayWithLength"].MaxItems);
+        Assert.Equal(1, schema.Properties["DictionaryWithMinMaxLength"].MinProperties);
+        Assert.Equal(10, schema.Properties["DictionaryWithMinMaxLength"].MaxProperties);
+        Assert.Null(schema.Properties["DictionaryWithMinMaxLength"].MinLength);
+        Assert.Null(schema.Properties["DictionaryWithMinMaxLength"].MaxLength);
         Assert.NotNull(schema.Properties["IntWithExclusiveRange"].ExclusiveMinimum);
         Assert.NotNull(schema.Properties["IntWithExclusiveRange"].ExclusiveMaximum);
         Assert.Equal("byte", schema.Properties["StringWithBase64"].Format);

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributes.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/TypeWithValidationAttributes.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
 namespace Swashbuckle.AspNetCore.TestSupport;
@@ -46,6 +46,10 @@ public class TypeWithValidationAttributes
 
     [ReadOnly(true)]
     public string StringWithReadOnly { get; set; }
+
+    [MinLength(1)]
+    [MaxLength(10)]
+    public IReadOnlyDictionary<string, string?> DictionaryWithMinMaxLength { get; set; }
 
     [Required]
     public IntEnum? NullableIntEnumWithRequired { get; set; }


### PR DESCRIPTION
## What

Fixes #3915

When `[MinLength(1)]` is applied to a dictionary property (e.g. `IReadOnlyDictionary<string, string?>`), Swashbuckle generates `"minLength": 1` in the OpenAPI schema. This is invalid — `minLength` is a string constraint. For dictionary/object types, OpenAPI requires `"minProperties": 1`.

## Why

The `ApplyMinLengthAttribute` method (and related methods) in `OpenApiSchemaExtensions.cs` only check for `JsonSchemaTypes.Array` and fall through to string semantics (`MinLength`) for everything else — including object types (dictionaries). Dictionaries serialize as `type: "object"` with `additionalProperties`, so they hit the `else` branch and incorrectly get `minLength` instead of `minProperties`.

## How

Added an `else if` branch checking for `JsonSchemaTypes.Object` in all six affected methods:

- `ApplyMinLengthAttribute` → `MinProperties`
- `ApplyMinLengthRouteConstraint` → `MinProperties`
- `ApplyMaxLengthAttribute` → `MaxProperties`
- `ApplyMaxLengthRouteConstraint` → `MaxProperties`
- `ApplyLengthAttribute` → both `MinProperties` and `MaxProperties`
- `ApplyLengthRouteConstraint` → both `MinProperties` and `MaxProperties`

## Testing

- Added `DictionaryWithMinMaxLength` property to `TypeWithValidationAttributes` test fixture
- Added assertions in `JsonSerializerSchemaGeneratorTests` verifying that dictionary properties generate `minProperties`/`maxProperties` instead of `minLength`/`maxLength`

Made with [Cursor](https://cursor.com)