### PR TITLE
Disable npm install scripts

### DIFF
--- a/src/Swashbuckle.AspNetCore.ReDoc/.npmrc‎
+++ b/src/Swashbuckle.AspNetCore.ReDoc/.npmrc‎
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org
+ignore-scripts=true

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/.npmrc‎
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/.npmrc‎
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org
+ignore-scripts=true


### PR DESCRIPTION
- Disable npm install scripts.
- Force the registry to be npm.
