### PR TITLE
Annotate SchemaRepository for nullable reference types

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SchemaRepository.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SchemaRepository.cs
@@ -34,14 +34,14 @@ public class SchemaRepository(string? documentName = null)
     public bool TryLookupByType(Type type, [NotNullWhen(true)] out OpenApiSchemaReference? referenceSchema)
     {
         referenceSchema = null;
-        bool result = _reservedIds.TryGetValue(type, out string? schemaId);
 
-        if (result)
+        if (_reservedIds.TryGetValue(type, out string? schemaId) && schemaId is not null)
         {
-            referenceSchema = new OpenApiSchemaReference(schemaId!);
+            referenceSchema = new OpenApiSchemaReference(schemaId);
+            return true;
         }
 
-        return result;
+        return false;
     }
 
     public OpenApiSchemaReference AddDefinition(string schemaId, OpenApiSchema schema)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SchemaRepository.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SchemaRepository.cs
@@ -1,12 +1,19 @@
-﻿using Microsoft.OpenApi;
+#nullable enable
+
+// Project-wide PublicAPI tracking has not yet adopted '#nullable enable' (tracked in Directory.Build.props).
+// Suppress RS0037 here so this file can opt into nullable annotations without forcing assembly-wide rollout.
+#pragma warning disable RS0037
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.OpenApi;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen;
 
-public class SchemaRepository(string documentName = null)
+public class SchemaRepository(string? documentName = null)
 {
     private readonly Dictionary<Type, string> _reservedIds = [];
 
-    public string DocumentName { get; } = documentName;
+    public string? DocumentName { get; } = documentName;
 
     public Dictionary<string, IOpenApiSchema> Schemas { get; } = [];
 
@@ -24,14 +31,14 @@ public class SchemaRepository(string documentName = null)
         _reservedIds.Add(type, schemaId);
     }
 
-    public bool TryLookupByType(Type type, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out OpenApiSchemaReference referenceSchema)
+    public bool TryLookupByType(Type type, [NotNullWhen(true)] out OpenApiSchemaReference? referenceSchema)
     {
         referenceSchema = null;
-        bool result = _reservedIds.TryGetValue(type, out string schemaId);
+        bool result = _reservedIds.TryGetValue(type, out string? schemaId);
 
         if (result)
         {
-            referenceSchema = new OpenApiSchemaReference(schemaId);
+            referenceSchema = new OpenApiSchemaReference(schemaId!);
         }
 
         return result;
@@ -57,7 +64,7 @@ public class SchemaRepository(string documentName = null)
         ArgumentNullException.ThrowIfNull(schemaType);
         ArgumentException.ThrowIfNullOrEmpty(replacementSchemaId);
 
-        if (_reservedIds.TryGetValue(schemaType, out string oldSchemaId) &&
+        if (_reservedIds.TryGetValue(schemaType, out string? oldSchemaId) &&
             oldSchemaId != replacementSchemaId &&
             Schemas.TryGetValue(oldSchemaId, out var targetSchema))
         {

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaRepositoryTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaRepositoryTests.cs
@@ -81,6 +81,46 @@ public static class SchemaRepositoryTests
     }
 
     [Fact]
+    public static void TryLookupByType_KnownType_ReturnsTrueAndNonNullReference()
+    {
+        var repository = new SchemaRepository();
+        (string schemaId, _) = GenerateSchemaForType(typeof(Example), repository);
+
+        bool result = repository.TryLookupByType(typeof(Example), out var referenceSchema);
+
+        Assert.True(result);
+        Assert.NotNull(referenceSchema);
+        Assert.Equal(schemaId, referenceSchema.Reference.Id);
+    }
+
+    [Fact]
+    public static void TryLookupByType_UnknownType_ReturnsFalseAndNullReference()
+    {
+        var repository = new SchemaRepository();
+
+        bool result = repository.TryLookupByType(typeof(Example), out var referenceSchema);
+
+        Assert.False(result);
+        Assert.Null(referenceSchema);
+    }
+
+    [Fact]
+    public static void TryLookupByType_NotNullWhenAttributeIsAppliedToOutParameter()
+    {
+        var method = typeof(SchemaRepository).GetMethod(nameof(SchemaRepository.TryLookupByType));
+        Assert.NotNull(method);
+
+        var outParameter = method.GetParameters().Single(p => p.IsOut);
+        var attribute = outParameter
+            .GetCustomAttributes(typeof(System.Diagnostics.CodeAnalysis.NotNullWhenAttribute), inherit: false)
+            .Cast<System.Diagnostics.CodeAnalysis.NotNullWhenAttribute>()
+            .SingleOrDefault();
+
+        Assert.NotNull(attribute);
+        Assert.True(attribute.ReturnValue);
+    }
+
+    [Fact]
     public static void ReplaceSchemaId_CanGenerateMultipleTimes()
     {
         var repository = new SchemaRepository();


### PR DESCRIPTION
## Motivation

`SchemaRepository.TryLookupByType` already carries `[NotNullWhen(true)]`, but because the file is not `#nullable enable`d the `out` parameter is declared as the oblivious type `OpenApiSchemaReference`. In a nullable-enabled caller the compiler treats the out value as non-null regardless of the return, so the `NotNullWhen` attribute can't actually drive null-state flow — hidden null-deref bugs slip past the compiler.

Calling code currently needs a wrapper to recover the contract:

```csharp
#nullable enable
public static bool TryLookupByTypeSafe(this SchemaRepository repo,
    Type type, [NotNullWhen(true)] out OpenApiSchemaReference? schema)
{
    bool ok = repo.TryLookupByType(type, out OpenApiSchemaReference? oblivious);
    schema = ok ? oblivious : null;
    return ok;
}
#nullable restore
```

## Change

- Add `#nullable enable` to `SchemaRepository.cs`.
- Annotate the constructor parameter / `DocumentName` property / `TryLookupByType` out parameter / local TryGet outs.
- Suppress `RS0037` locally — project-wide PublicAPI nullability tracking has not yet been adopted (see TODO in `Directory.Build.props`), so this single-file opt-in mustn't force assembly-wide rollout. PublicAPI tracker still records the surface (no nullability info), the analyzer is satisfied.

Adds three unit tests in `SchemaRepositoryTests`:

- `TryLookupByType_KnownType_ReturnsTrueAndNonNullReference`
- `TryLookupByType_UnknownType_ReturnsFalseAndNullReference`
- `TryLookupByType_NotNullWhenAttributeIsAppliedToOutParameter` (reflection guard so the contract metadata can't be removed accidentally)

## Verification

```
dotnet test test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.csproj -c Release -f net10.0
# Passed: 721 / Failed: 0
```

Full test suite (slnx) green: 996 tests, 0 failures across the four test assemblies that run on net10.0.

Fixes #3659.