### PR TITLE
Update Microsoft.OpenApi to 2.7.5

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -24,7 +24,7 @@
       "rollForward": false
     },
     "meziantou.framework.nugetpackagevalidation.tool": {
-      "version": "1.0.52",
+      "version": "1.0.53",
       "commands": [
         "meziantou.validate-nuget-package"
       ],

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,8 +17,8 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Kiota.Bundle" Version="2.0.0" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.0" />
-    <PackageVersion Include="Microsoft.OpenApi.YamlReader" Version="2.7.0" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.6" />
+    <PackageVersion Include="Microsoft.OpenApi.YamlReader" Version="2.7.6" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.60.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="MSBuild.ProjectCreation" Version="18.0.0" />
@@ -27,8 +27,8 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSwag.CodeGeneration.CSharp" Version="14.7.1" />
     <PackageVersion Include="NSwag.MSBuild" Version="14.7.1" />
-    <PackageVersion Include="ReportGenerator" Version="5.5.7" />
-    <PackageVersion Include="Verify.XunitV3" Version="31.18.0" />
+    <PackageVersion Include="ReportGenerator" Version="5.5.10" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.19.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3.mtp-off" Version="3.2.2" />

--- a/src/Swashbuckle.AspNetCore.ApiTesting/Swashbuckle.AspNetCore.ApiTesting.csproj
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/Swashbuckle.AspNetCore.ApiTesting.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi" VersionOverride="2.4.1" />
+    <PackageReference Include="Microsoft.OpenApi" VersionOverride="2.7.5" />
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 

--- a/src/Swashbuckle.AspNetCore.Swagger/Swashbuckle.AspNetCore.Swagger.csproj
+++ b/src/Swashbuckle.AspNetCore.Swagger/Swashbuckle.AspNetCore.Swagger.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi" VersionOverride="2.4.1" />
+    <PackageReference Include="Microsoft.OpenApi" VersionOverride="2.7.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Update Microsoft.OpenApi in shipping packages to 2.7.5 to pick up fix for GHSA-v5pm-xwqc-g5wc.
- Update Microsoft.OpenApi for tests to 2.7.6.
- Update meziantou.framework.nugetpackagevalidation.tool, ReportGenerator and Verify.XunitV3 to their latest versions.

Resolves #3973.
