### PR TITLE
Move NRT handling to DataContractResolver

### DIFF
--- a/src/Swashbuckle.AspNetCore.Newtonsoft/DependencyInjection/NewtonsoftServiceCollectionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Newtonsoft/DependencyInjection/NewtonsoftServiceCollectionExtensions.cs
@@ -25,8 +25,9 @@ public static class NewtonsoftServiceCollectionExtensions
             {
                 var serializerSettings = s.GetRequiredService<IOptions<MvcNewtonsoftJsonOptions>>().Value?.SerializerSettings
                     ?? new();
+                var generatorOptions = s.GetRequiredService<IOptions<SchemaGeneratorOptions>>().Value;
 
-                return new NewtonsoftDataContractResolver(serializerSettings);
+                return new NewtonsoftDataContractResolver(serializerSettings, generatorOptions);
             }));
     }
 }

--- a/src/Swashbuckle.AspNetCore.Newtonsoft/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.Newtonsoft/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Swashbuckle.AspNetCore.Newtonsoft.NewtonsoftDataContractResolver.NewtonsoftDataContractResolver(Newtonsoft.Json.JsonSerializerSettings serializerSettings, Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions generatorOptions) -> void

--- a/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/NewtonsoftDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/NewtonsoftDataContractResolver.cs
@@ -219,7 +219,8 @@ public class NewtonsoftDataContractResolver : ISerializerDataContractResolver
     {
         var nullable = propertyType.IsReferenceOrNullableType();
 
-        if (_generatorOptions.SupportNonNullableReferenceTypes
+        if ((_generatorOptions.SupportNonNullableReferenceTypes
+                || _generatorOptions.NonNullableReferenceTypesAsRequired)
             && memberInfo != null)
         {
             nullable &= !memberInfo.IsNonNullableReferenceType();

--- a/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/NewtonsoftDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/NewtonsoftDataContractResolver.cs
@@ -219,8 +219,7 @@ public class NewtonsoftDataContractResolver : ISerializerDataContractResolver
     {
         var nullable = propertyType.IsReferenceOrNullableType();
 
-        if ((_generatorOptions.SupportNonNullableReferenceTypes
-                || _generatorOptions.NonNullableReferenceTypesAsRequired)
+        if ((_generatorOptions.SupportNonNullableReferenceTypes || _generatorOptions.NonNullableReferenceTypesAsRequired)
             && memberInfo != null)
         {
             nullable &= !memberInfo.IsNonNullableReferenceType();

--- a/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/NewtonsoftDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.Newtonsoft/SchemaGenerator/NewtonsoftDataContractResolver.cs
@@ -10,11 +10,32 @@ namespace Swashbuckle.AspNetCore.Newtonsoft;
 /// <summary>
 /// A class representing an <see cref="ISerializerDataContractResolver"/> implementation that uses Newtonsoft.Json.
 /// </summary>
-/// <param name="serializerSettings">The <see cref="JsonSerializerSettings"/> to use.</param>
-public class NewtonsoftDataContractResolver(JsonSerializerSettings serializerSettings) : ISerializerDataContractResolver
+public class NewtonsoftDataContractResolver : ISerializerDataContractResolver
 {
-    private readonly JsonSerializerSettings _serializerSettings = serializerSettings;
-    private readonly IContractResolver _contractResolver = serializerSettings.ContractResolver ?? new DefaultContractResolver();
+    private readonly JsonSerializerSettings _serializerSettings;
+    private readonly SchemaGeneratorOptions _generatorOptions;
+    private readonly IContractResolver _contractResolver;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NewtonsoftDataContractResolver"/> class.
+    /// </summary>
+    /// <param name="serializerSettings">The <see cref="JsonSerializerSettings"/> to use.</param>
+    public NewtonsoftDataContractResolver(JsonSerializerSettings serializerSettings)
+        : this(serializerSettings, new SchemaGeneratorOptions())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NewtonsoftDataContractResolver"/> class.
+    /// </summary>
+    /// <param name="serializerSettings">The <see cref="JsonSerializerSettings"/> to use.</param>
+    /// <param name="generatorOptions">The <see cref="SchemaGeneratorOptions"/> to use.</param>
+    public NewtonsoftDataContractResolver(JsonSerializerSettings serializerSettings, SchemaGeneratorOptions generatorOptions)
+    {
+        _serializerSettings = serializerSettings;
+        _generatorOptions = generatorOptions ?? new SchemaGeneratorOptions();
+        _contractResolver = serializerSettings.ContractResolver ?? new DefaultContractResolver();
+    }
 
     /// <inheritdoc/>
     public DataContract GetDataContractForType(Type type)
@@ -164,14 +185,16 @@ public class NewtonsoftDataContractResolver(JsonSerializerSettings serializerSet
                         string.Equals(p.Name, jsonProperty.PropertyName, StringComparison.OrdinalIgnoreCase);
                 });
 
+            var propertyType = jsonProperty.PropertyType;
+
             dataProperties.Add(
                 new DataProperty(
                     name: jsonProperty.PropertyName,
                     isRequired: required == Required.Always || required == Required.AllowNull,
-                    isNullable: (required == Required.AllowNull || required == Required.Default) && jsonProperty.PropertyType.IsReferenceOrNullableType(),
+                    isNullable: (required == Required.AllowNull || required == Required.Default) && IsNullable(memberInfo, propertyType),
                     isReadOnly: jsonProperty.Readable && !jsonProperty.Writable && !isSetViaConstructor,
                     isWriteOnly: jsonProperty.Writable && !jsonProperty.Readable,
-                    memberType: jsonProperty.PropertyType,
+                    memberType: propertyType,
                     memberInfo: memberInfo));
         }
 
@@ -190,6 +213,19 @@ public class NewtonsoftDataContractResolver(JsonSerializerSettings serializerSet
         }
 
         return dataProperties;
+    }
+
+    private bool IsNullable(MemberInfo memberInfo, Type propertyType)
+    {
+        var nullable = propertyType.IsReferenceOrNullableType();
+
+        if (_generatorOptions.SupportNonNullableReferenceTypes
+            && memberInfo != null)
+        {
+            nullable &= !memberInfo.IsNonNullableReferenceType();
+        }
+
+        return nullable;
     }
 
     private static readonly Dictionary<Type, Tuple<DataType, string>> PrimitiveTypesAndFormats = new()

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenServiceCollectionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenServiceCollectionExtensions.cs
@@ -33,7 +33,8 @@ public static class SwaggerGenServiceCollectionExtensions
         services.TryAddSingleton<ISerializerDataContractResolver>(s =>
         {
             var serializerOptions = s.GetRequiredService<JsonSerializerOptionsProvider>().Options;
-            return new JsonSerializerDataContractResolver(serializerOptions);
+            var generatorOptions = s.GetRequiredService<IOptions<SchemaGeneratorOptions>>().Value;
+            return new JsonSerializerDataContractResolver(serializerOptions, generatorOptions);
         });
 
         // Used by the <c>dotnet-getdocument</c> tool from the Microsoft.Extensions.ApiDescription.Server package.

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
-﻿
-Swashbuckle.AspNetCore.SwaggerGen.JsonSerializerDataContractResolver.JsonSerializerDataContractResolver(System.Text.Json.JsonSerializerOptions serializerOptions, Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions generatorOptions) -> void
+﻿Swashbuckle.AspNetCore.SwaggerGen.JsonSerializerDataContractResolver.JsonSerializerDataContractResolver(System.Text.Json.JsonSerializerOptions serializerOptions, Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions generatorOptions) -> void

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 ﻿
+Swashbuckle.AspNetCore.SwaggerGen.JsonSerializerDataContractResolver.JsonSerializerDataContractResolver(System.Text.Json.JsonSerializerOptions serializerOptions, Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions generatorOptions) -> void

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
@@ -262,8 +262,8 @@ public class JsonSerializerDataContractResolver : ISerializerDataContractResolve
     {
         var nullable = propertyType.IsReferenceOrNullableType();
 
-        if (_generatorOptions.SupportNonNullableReferenceTypes
-            || _generatorOptions.NonNullableReferenceTypesAsRequired)
+        if (_generatorOptions.SupportNonNullableReferenceTypes ||
+            _generatorOptions.NonNullableReferenceTypesAsRequired)
         {
             nullable &= !propertyInfo.IsNonNullableReferenceType();
         }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
@@ -6,9 +6,21 @@ using Swashbuckle.AspNetCore.Annotations;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen;
 
-public class JsonSerializerDataContractResolver(JsonSerializerOptions serializerOptions) : ISerializerDataContractResolver
+public class JsonSerializerDataContractResolver : ISerializerDataContractResolver
 {
-    private readonly JsonSerializerOptions _serializerOptions = serializerOptions;
+    private readonly JsonSerializerOptions _serializerOptions;
+    private readonly SchemaGeneratorOptions _generatorOptions;
+
+    public JsonSerializerDataContractResolver(JsonSerializerOptions serializerOptions)
+        : this(serializerOptions, new SchemaGeneratorOptions())
+    {
+    }
+
+    public JsonSerializerDataContractResolver(JsonSerializerOptions serializerOptions, SchemaGeneratorOptions generatorOptions)
+    {
+        _serializerOptions = serializerOptions;
+        _generatorOptions = generatorOptions ?? new SchemaGeneratorOptions();
+    }
 
     public DataContract GetDataContractForType(Type type)
     {
@@ -230,18 +242,32 @@ public class JsonSerializerDataContractResolver(JsonSerializerOptions serializer
 
             isRequired = propertyInfo.GetCustomAttribute<JsonRequiredAttribute>() != null;
 
+            var propertyType = propertyInfo.PropertyType;
+
             dataProperties.Add(
                 new DataProperty(
                     name: name,
                     isRequired: isRequired,
-                    isNullable: propertyInfo.PropertyType.IsReferenceOrNullableType(),
+                    isNullable: IsNullable(propertyInfo, propertyType),
                     isReadOnly: propertyInfo.IsPubliclyReadable() && !propertyInfo.IsPubliclyWritable() && !isDeserializedViaConstructor,
                     isWriteOnly: propertyInfo.IsPubliclyWritable() && !propertyInfo.IsPubliclyReadable(),
-                    memberType: propertyInfo.PropertyType,
+                    memberType: propertyType,
                     memberInfo: propertyInfo));
         }
 
         return dataProperties;
+    }
+
+    private bool IsNullable(PropertyInfo propertyInfo, Type propertyType)
+    {
+        var nullable = propertyType.IsReferenceOrNullableType();
+
+        if (_generatorOptions.SupportNonNullableReferenceTypes)
+        {
+            nullable &= !propertyInfo.IsNonNullableReferenceType();
+        }
+
+        return nullable;
     }
 
     private static readonly Dictionary<Type, Tuple<DataType, string>> PrimitiveTypesAndFormats = new()

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
@@ -262,7 +262,8 @@ public class JsonSerializerDataContractResolver : ISerializerDataContractResolve
     {
         var nullable = propertyType.IsReferenceOrNullableType();
 
-        if (_generatorOptions.SupportNonNullableReferenceTypes)
+        if (_generatorOptions.SupportNonNullableReferenceTypes
+            || _generatorOptions.NonNullableReferenceTypesAsRequired)
         {
             nullable &= !propertyInfo.IsNonNullableReferenceType();
         }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -471,8 +471,7 @@ public class SchemaGenerator(
                 : GenerateSchemaForType(memberType, schemaRepository);
 
             var markNonNullableTypeAsRequired =
-                _generatorOptions.NonNullableReferenceTypesAsRequired &&
-                (dataProperty.MemberInfo?.IsNonNullableReferenceType() ?? false);
+                _generatorOptions.NonNullableReferenceTypesAsRequired && !dataProperty.IsNullable;
 
             if ((
                 dataProperty.IsRequired

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -137,14 +137,7 @@ public class SchemaGenerator(
 
     private bool IsNullable(RequiredAttribute requiredAttribute, DataProperty dataProperty, MemberInfo memberInfo)
     {
-        var nullable = dataProperty.IsNullable && requiredAttribute == null;
-
-        if (_generatorOptions.SupportNonNullableReferenceTypes || _generatorOptions.NonNullableReferenceTypesAsRequired)
-        {
-            nullable &= !memberInfo.IsNonNullableReferenceType();
-        }
-
-        return nullable;
+        return dataProperty.IsNullable && requiredAttribute == null;
     }
 
     private IOpenApiSchema GenerateSchemaForParameter(

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -214,7 +214,7 @@ public class SchemaGenerator(
             : GenerateConcreteSchema(dataContract, schemaRepository);
 
         ApplyFilters(schema, modelType, schemaRepository);
-         
+
         if (Nullable.GetUnderlyingType(modelType) != null && schema is OpenApiSchema concrete)
         {
             SetNullable(concrete, true);

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -1005,6 +1005,6 @@ public class NewtonsoftSchemaGeneratorTests
         var serializerSettings = new JsonSerializerSettings();
         configureSerializer?.Invoke(serializerSettings);
 
-        return new SchemaGenerator(generatorOptions, new NewtonsoftDataContractResolver(serializerSettings));
+        return new SchemaGenerator(generatorOptions, new NewtonsoftDataContractResolver(serializerSettings, generatorOptions));
     }
 }

--- a/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.Newtonsoft.Test/SchemaGenerator/NewtonsoftSchemaGeneratorTests.cs
@@ -288,6 +288,20 @@ public class NewtonsoftSchemaGeneratorTests
     }
 
     [Fact]
+    public void GenerateSchema_SupportsOption_SupportNonNullableReferenceTypes()
+    {
+        var schemaRepository = new SchemaRepository();
+
+        var referenceSchema = Assert.IsType<OpenApiSchemaReference>(
+            Subject(configureGenerator: c => c.SupportNonNullableReferenceTypes = true)
+                .GenerateSchema(typeof(TypeWithNullableContextAnnotated), schemaRepository));
+
+        var schema = schemaRepository.Schemas[referenceSchema.Reference.Id];
+        Assert.True(schema.Properties[nameof(TypeWithNullableContextAnnotated.NullableString)].Type.Value.HasFlag(JsonSchemaType.Null));
+        Assert.False(schema.Properties[nameof(TypeWithNullableContextAnnotated.NonNullableString)].Type.Value.HasFlag(JsonSchemaType.Null));
+    }
+
+    [Fact]
     public void GenerateSchema_DoesNotSetNullableFlag_IfReferencedEnum()
     {
         var schemaRepository = new SchemaRepository();

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/OptionalValue.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/OptionalValue.cs
@@ -6,6 +6,7 @@ public readonly struct OptionalValue<T>
     {
         HasValue = false;
     }
+
     public OptionalValue(T value)
     {
         Value = value;

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/OptionalValue.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/OptionalValue.cs
@@ -1,0 +1,18 @@
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test;
+
+public readonly struct OptionalValue<T>
+{
+    public OptionalValue()
+    {
+        HasValue = false;
+    }
+    public OptionalValue(T value)
+    {
+        Value = value;
+        HasValue = true;
+    }
+
+    public T Value { get; }
+
+    public bool HasValue { get; }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/OptionalValueDataContractResolver.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/OptionalValueDataContractResolver.cs
@@ -4,8 +4,8 @@ namespace Swashbuckle.AspNetCore.SwaggerGen.Test;
 
 public sealed class OptionalValueDataContractResolver(
     ISerializerDataContractResolver innerResolver,
-    SchemaGeneratorOptions generatorOptions
-) : ISerializerDataContractResolver
+    SchemaGeneratorOptions generatorOptions)
+    : ISerializerDataContractResolver
 {
     public DataContract GetDataContractForType(Type type)
     {
@@ -57,7 +57,7 @@ public sealed class OptionalValueDataContractResolver(
                 effectiveProperties,
                 dataContract.ObjectExtensionDataType,
                 dataContract.ObjectTypeNameProperty,
-                dataContract.ObjectTypeNameProperty,
+                dataContract.ObjectTypeNameValue,
                 dataContract.JsonConverter);
         }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/OptionalValueDataContractResolver.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/OptionalValueDataContractResolver.cs
@@ -1,0 +1,90 @@
+using System.Reflection;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test;
+
+public sealed class OptionalValueDataContractResolver(
+    ISerializerDataContractResolver innerResolver,
+    SchemaGeneratorOptions generatorOptions
+) : ISerializerDataContractResolver
+{
+    public DataContract GetDataContractForType(Type type)
+    {
+        Type effectiveType = type;
+        if (IsOptionType(type, out var underlyingType))
+        {
+            effectiveType = underlyingType;
+        }
+
+        var dataContract = innerResolver.GetDataContractForType(effectiveType);
+        if (dataContract.DataType != DataType.Object)
+        {
+            return dataContract;
+        }
+
+        if (dataContract is { DataType: DataType.Object })
+        {
+            var effectiveProperties = new List<DataProperty>();
+            foreach (DataProperty property in dataContract.ObjectProperties)
+            {
+                DataProperty effectiveProperty = property;
+                if (IsOptionType(property.MemberType, out underlyingType))
+                {
+                    // By default an OptionalValue<T> is treated as nullable.
+                    var isNullable = true;
+                    if (generatorOptions.SupportNonNullableReferenceTypes)
+                    {
+                        var nullabilityInfo = GetNullabilityInfo(property.MemberInfo);
+                        // set the nullability here when enabled
+                        var underlyingNullabilityInfo = nullabilityInfo?.GenericTypeArguments.FirstOrDefault();
+                        isNullable = underlyingNullabilityInfo?.ReadState == NullabilityState.Nullable;
+                    }
+
+                    effectiveProperty = new DataProperty(
+                        name: property.Name,
+                        memberType: underlyingType,
+                        isRequired: false,
+                        isNullable: isNullable,
+                        isReadOnly: property.IsReadOnly,
+                        isWriteOnly: property.IsWriteOnly,
+                        memberInfo: property.MemberInfo);
+                }
+
+                effectiveProperties.Add(effectiveProperty);
+            }
+
+            dataContract = DataContract.ForObject(
+                dataContract.UnderlyingType,
+                effectiveProperties,
+                dataContract.ObjectExtensionDataType,
+                dataContract.ObjectTypeNameProperty,
+                dataContract.ObjectTypeNameProperty,
+                dataContract.JsonConverter);
+        }
+
+        return dataContract;
+    }
+
+    private static bool IsOptionType(Type type, out Type underlyingType)
+    {
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(OptionalValue<>))
+        {
+            underlyingType = type.GetGenericArguments()[0];
+            return true;
+        }
+
+        underlyingType = null;
+        return false;
+    }
+
+    private static NullabilityInfo GetNullabilityInfo(ICustomAttributeProvider memberInfo)
+    {
+        var nullabilityInfoContext = new NullabilityInfoContext();
+        return memberInfo switch
+        {
+            PropertyInfo propertyInfo => nullabilityInfoContext.Create(propertyInfo),
+            FieldInfo fieldInfo => nullabilityInfoContext.Create(fieldInfo),
+            ParameterInfo parameterInfo => nullabilityInfoContext.Create(parameterInfo),
+            _ => null,
+        };
+    }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TypeWithOptionProperty.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TypeWithOptionProperty.cs
@@ -1,0 +1,21 @@
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test.Fixtures;
+
+#nullable enable
+
+public class TypeWithOptionProperty
+{
+    public int Int { get; set; }
+    public int? NullableInt { get; set; }
+    public OptionalValue<int> OptionalInt { get; set; }
+    public OptionalValue<int?> NullableOptionalInt { get; set; }
+
+    public string String { get; set; } = null!;
+    public string? NullableString { get; set; }
+    public OptionalValue<string> OptionalString { get; set; }
+    public OptionalValue<string?> NullableOptionalString { get; set; }
+
+    public TypeWithOptionProperty Self { get; set; } = null!;
+    public TypeWithOptionProperty? NullableSelf { get; set; }
+    public OptionalValue<TypeWithOptionProperty> OptionalSelf { get; set; }
+    public OptionalValue<TypeWithOptionProperty?> NullableOptionalSelf { get; set; }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -1519,6 +1519,21 @@ public class JsonSerializerSchemaGeneratorTests
         Assert.Equal(JsonSchemaTypes.Integer, schema.Type);
     }
 
+    [Fact]
+    public void GenerateSchema_SupportNonNullableReferenceTypes_DoesNotOverrideDataPropertyNullable_ForValueTypeMembers()
+    {
+        var subject = new SchemaGenerator(
+            new SchemaGeneratorOptions { SupportNonNullableReferenceTypes = true },
+            new NullableValueTypeDataContractResolver());
+        var schemaRepository = new SchemaRepository();
+
+        var referenceSchema = subject.GenerateSchema(typeof(TypeWithNullableValueTypeWrapper), schemaRepository);
+
+        var reference = Assert.IsType<OpenApiSchemaReference>(referenceSchema);
+        var propertySchema = schemaRepository.Schemas[reference.Reference.Id].Properties[nameof(TypeWithNullableValueTypeWrapper.Optional)];
+        AssertIsNullable(propertySchema);
+    }
+
     private static SchemaGenerator Subject(
         Action<SchemaGeneratorOptions> configureGenerator = null,
         Action<JsonSerializerOptions> configureSerializer = null)
@@ -1537,4 +1552,41 @@ public class JsonSerializerSchemaGeneratorTests
         Assert.True(schema.Type.HasValue);
         Assert.Equal(expected, schema.Type.Value.HasFlag(JsonSchemaType.Null));
     }
+
+    private sealed class NullableValueTypeDataContractResolver : ISerializerDataContractResolver
+    {
+        public DataContract GetDataContractForType(Type type)
+        {
+            if (type == typeof(TypeWithNullableValueTypeWrapper))
+            {
+                return DataContract.ForObject(
+                    underlyingType: type,
+                    properties:
+                    [
+                        new DataProperty(
+                            name: nameof(TypeWithNullableValueTypeWrapper.Optional),
+                            memberType: typeof(NullableValueTypeWrapper),
+                            isNullable: true,
+                            memberInfo: type.GetProperty(nameof(TypeWithNullableValueTypeWrapper.Optional)))
+                    ]);
+            }
+
+            if (type == typeof(NullableValueTypeWrapper))
+            {
+                return DataContract.ForPrimitive(
+                    underlyingType: type,
+                    dataType: DataType.String,
+                    dataFormat: null);
+            }
+
+            throw new InvalidOperationException($"Unexpected type: {type}");
+        }
+    }
+
+    private sealed class TypeWithNullableValueTypeWrapper
+    {
+        public NullableValueTypeWrapper Optional { get; set; }
+    }
+
+    private readonly struct NullableValueTypeWrapper;
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -1209,7 +1209,7 @@ public class JsonSerializerSchemaGeneratorTests
 
         var serializerOptions = new JsonSerializerOptions();
 
-        var subject = new SchemaGenerator(generatorOptions, new JsonSerializerDataContractResolver(serializerOptions));
+        var subject = new SchemaGenerator(generatorOptions, new JsonSerializerDataContractResolver(serializerOptions, generatorOptions));
         var schemaRepository = new SchemaRepository();
 
         subject.GenerateSchema(type, schemaRepository);
@@ -1529,7 +1529,7 @@ public class JsonSerializerSchemaGeneratorTests
         var serializerOptions = new JsonSerializerOptions();
         configureSerializer?.Invoke(serializerOptions);
 
-        return new SchemaGenerator(generatorOptions, new JsonSerializerDataContractResolver(serializerOptions));
+        return new SchemaGenerator(generatorOptions, new JsonSerializerDataContractResolver(serializerOptions, generatorOptions));
     }
 
     private static void AssertIsNullable(IOpenApiSchema schema, bool expected = true)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -1519,21 +1519,6 @@ public class JsonSerializerSchemaGeneratorTests
         Assert.Equal(JsonSchemaTypes.Integer, schema.Type);
     }
 
-    [Fact]
-    public void GenerateSchema_SupportNonNullableReferenceTypes_DoesNotOverrideDataPropertyNullable_ForValueTypeMembers()
-    {
-        var subject = new SchemaGenerator(
-            new SchemaGeneratorOptions { SupportNonNullableReferenceTypes = true },
-            new NullableValueTypeDataContractResolver());
-        var schemaRepository = new SchemaRepository();
-
-        var referenceSchema = subject.GenerateSchema(typeof(TypeWithNullableValueTypeWrapper), schemaRepository);
-
-        var reference = Assert.IsType<OpenApiSchemaReference>(referenceSchema);
-        var propertySchema = schemaRepository.Schemas[reference.Reference.Id].Properties[nameof(TypeWithNullableValueTypeWrapper.Optional)];
-        AssertIsNullable(propertySchema);
-    }
-
     private static SchemaGenerator Subject(
         Action<SchemaGeneratorOptions> configureGenerator = null,
         Action<JsonSerializerOptions> configureSerializer = null)
@@ -1552,41 +1537,4 @@ public class JsonSerializerSchemaGeneratorTests
         Assert.True(schema.Type.HasValue);
         Assert.Equal(expected, schema.Type.Value.HasFlag(JsonSchemaType.Null));
     }
-
-    private sealed class NullableValueTypeDataContractResolver : ISerializerDataContractResolver
-    {
-        public DataContract GetDataContractForType(Type type)
-        {
-            if (type == typeof(TypeWithNullableValueTypeWrapper))
-            {
-                return DataContract.ForObject(
-                    underlyingType: type,
-                    properties:
-                    [
-                        new DataProperty(
-                            name: nameof(TypeWithNullableValueTypeWrapper.Optional),
-                            memberType: typeof(NullableValueTypeWrapper),
-                            isNullable: true,
-                            memberInfo: type.GetProperty(nameof(TypeWithNullableValueTypeWrapper.Optional)))
-                    ]);
-            }
-
-            if (type == typeof(NullableValueTypeWrapper))
-            {
-                return DataContract.ForPrimitive(
-                    underlyingType: type,
-                    dataType: DataType.String,
-                    dataFormat: null);
-            }
-
-            throw new InvalidOperationException($"Unexpected type: {type}");
-        }
-    }
-
-    private sealed class TypeWithNullableValueTypeWrapper
-    {
-        public NullableValueTypeWrapper Optional { get; set; }
-    }
-
-    private readonly struct NullableValueTypeWrapper;
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/VerifyTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/VerifyTests.cs
@@ -1654,7 +1654,6 @@ public partial class VerifyTests
         await Verify(document);
     }
 
-#nullable enable
     [Fact]
     public async Task GenerateSchema_CustomResolver_OptionOfString_RendersCorrectly()
     {
@@ -1684,7 +1683,6 @@ public partial class VerifyTests
 
         await VerifyV31(document);
     }
-#nullable restore
 
     private static SwaggerGenerator Subject(
             IEnumerable<ApiDescription> apiDescriptions,

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/VerifyTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/VerifyTests.cs
@@ -1666,7 +1666,7 @@ public partial class VerifyTests
         var subject = new SchemaGenerator(
             generatorOptions,
             new OptionalValueDataContractResolver(
-                new JsonSerializerDataContractResolver(new JsonSerializerOptions()),
+                new JsonSerializerDataContractResolver(new JsonSerializerOptions(), generatorOptions),
                 generatorOptions
             )
         );
@@ -1699,7 +1699,7 @@ public partial class VerifyTests
         return new SwaggerGenerator(
             options ?? DefaultOptions,
             new FakeApiDescriptionGroupCollectionProvider(apiDescriptions),
-            new SchemaGenerator(schemaGeneratorOptions, new JsonSerializerDataContractResolver(new JsonSerializerOptions())),
+            new SchemaGenerator(schemaGeneratorOptions, new JsonSerializerDataContractResolver(new JsonSerializerOptions(), schemaGeneratorOptions)),
             new FakeAuthenticationSchemeProvider(authenticationSchemes ?? [])
         );
     }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/VerifyTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/VerifyTests.cs
@@ -1654,6 +1654,38 @@ public partial class VerifyTests
         await Verify(document);
     }
 
+#nullable enable
+    [Fact]
+    public async Task GenerateSchema_CustomResolver_OptionOfString_RendersCorrectly()
+    {
+        var generatorOptions = new SchemaGeneratorOptions
+        {
+            // We enable NRT so we can verify the underlying nullability.
+            SupportNonNullableReferenceTypes = true
+        };
+        var subject = new SchemaGenerator(
+            generatorOptions,
+            new OptionalValueDataContractResolver(
+                new JsonSerializerDataContractResolver(new JsonSerializerOptions()),
+                generatorOptions
+            )
+        );
+        var schemaRepository = new SchemaRepository();
+
+        subject.GenerateSchema(typeof(TypeWithOptionProperty), schemaRepository);
+
+        var document = new OpenApiDocument
+        {
+            Components = new OpenApiComponents
+            {
+                Schemas = schemaRepository.Schemas
+            }
+        };
+
+        await VerifyV31(document);
+    }
+#nullable restore
+
     private static SwaggerGenerator Subject(
             IEnumerable<ApiDescription> apiDescriptions,
             SwaggerGeneratorOptions options = null,
@@ -1690,9 +1722,25 @@ public partial class VerifyTests
         return NormalizeLineBreaks(stringWriter.ToString());
     }
 
+    private static string ToJsonV31(OpenApiDocument document)
+    {
+        using var stringWriter = new StringWriter();
+        var jsonWriter = new OpenApiJsonWriter(stringWriter);
+
+        document.SerializeAsV31(jsonWriter);
+
+        return NormalizeLineBreaks(stringWriter.ToString());
+    }
+
     private static async Task Verify(OpenApiDocument document)
     {
         await Verifier.Verify(ToJson(document))
+                      .UseDirectory($"snapshots/{Environment.Version.Major}_{Environment.Version.Minor}");
+    }
+
+    private static async Task VerifyV31(OpenApiDocument document)
+    {
+        await Verifier.Verify(ToJsonV31(document))
                       .UseDirectory($"snapshots/{Environment.Version.Major}_{Environment.Version.Minor}");
     }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/VerifyTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/VerifyTests.cs
@@ -1666,9 +1666,7 @@ public partial class VerifyTests
             generatorOptions,
             new OptionalValueDataContractResolver(
                 new JsonSerializerDataContractResolver(new JsonSerializerOptions(), generatorOptions),
-                generatorOptions
-            )
-        );
+                generatorOptions));
         var schemaRepository = new SchemaRepository();
 
         subject.GenerateSchema(typeof(TypeWithOptionProperty), schemaRepository);
@@ -1681,7 +1679,7 @@ public partial class VerifyTests
             }
         };
 
-        await VerifyV31(document);
+        await Verify(document, OpenApiSpecVersion.OpenApi3_1);
     }
 
     private static SwaggerGenerator Subject(
@@ -1710,35 +1708,23 @@ public partial class VerifyTests
         }
     };
 
-    private static string ToJson(OpenApiDocument document)
+    private static string ToJson(
+        OpenApiDocument document,
+        OpenApiSpecVersion version = OpenApiSpecVersion.OpenApi3_0)
     {
         using var stringWriter = new StringWriter();
         var jsonWriter = new OpenApiJsonWriter(stringWriter);
 
-        document.SerializeAsV3(jsonWriter);
+        document.SerializeAs(version, jsonWriter);
 
         return NormalizeLineBreaks(stringWriter.ToString());
     }
 
-    private static string ToJsonV31(OpenApiDocument document)
+    private static async Task Verify(
+        OpenApiDocument document,
+        OpenApiSpecVersion version = OpenApiSpecVersion.OpenApi3_0)
     {
-        using var stringWriter = new StringWriter();
-        var jsonWriter = new OpenApiJsonWriter(stringWriter);
-
-        document.SerializeAsV31(jsonWriter);
-
-        return NormalizeLineBreaks(stringWriter.ToString());
-    }
-
-    private static async Task Verify(OpenApiDocument document)
-    {
-        await Verifier.Verify(ToJson(document))
-                      .UseDirectory($"snapshots/{Environment.Version.Major}_{Environment.Version.Minor}");
-    }
-
-    private static async Task VerifyV31(OpenApiDocument document)
-    {
-        await Verifier.Verify(ToJsonV31(document))
+        await Verifier.Verify(ToJson(document, version))
                       .UseDirectory($"snapshots/{Environment.Version.Major}_{Environment.Version.Minor}");
     }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/10_0/VerifyTests.GenerateSchema_CustomResolver_OptionOfString_RendersCorrectly.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/10_0/VerifyTests.GenerateSchema_CustomResolver_OptionOfString_RendersCorrectly.verified.txt
@@ -1,0 +1,67 @@
+﻿{
+  "openapi": "3.1.1",
+  "info": { },
+  "paths": { },
+  "components": {
+    "schemas": {
+      "TypeWithOptionProperty": {
+        "type": "object",
+        "properties": {
+          "Int": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "NullableInt": {
+            "type": [
+              "null",
+              "integer"
+            ],
+            "format": "int32"
+          },
+          "OptionalInt": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "NullableOptionalInt": {
+            "type": [
+              "null",
+              "integer"
+            ],
+            "format": "int32"
+          },
+          "String": {
+            "type": "string"
+          },
+          "NullableString": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "OptionalString": {
+            "type": "string"
+          },
+          "NullableOptionalString": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Self": {
+            "$ref": "#/components/schemas/TypeWithOptionProperty"
+          },
+          "NullableSelf": {
+            "$ref": "#/components/schemas/TypeWithOptionProperty"
+          },
+          "OptionalSelf": {
+            "$ref": "#/components/schemas/TypeWithOptionProperty"
+          },
+          "NullableOptionalSelf": {
+            "$ref": "#/components/schemas/TypeWithOptionProperty"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/8_0/VerifyTests.GenerateSchema_CustomResolver_OptionOfString_RendersCorrectly.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/8_0/VerifyTests.GenerateSchema_CustomResolver_OptionOfString_RendersCorrectly.verified.txt
@@ -1,0 +1,67 @@
+﻿{
+  "openapi": "3.1.1",
+  "info": { },
+  "paths": { },
+  "components": {
+    "schemas": {
+      "TypeWithOptionProperty": {
+        "type": "object",
+        "properties": {
+          "Int": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "NullableInt": {
+            "type": [
+              "null",
+              "integer"
+            ],
+            "format": "int32"
+          },
+          "OptionalInt": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "NullableOptionalInt": {
+            "type": [
+              "null",
+              "integer"
+            ],
+            "format": "int32"
+          },
+          "String": {
+            "type": "string"
+          },
+          "NullableString": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "OptionalString": {
+            "type": "string"
+          },
+          "NullableOptionalString": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Self": {
+            "$ref": "#/components/schemas/TypeWithOptionProperty"
+          },
+          "NullableSelf": {
+            "$ref": "#/components/schemas/TypeWithOptionProperty"
+          },
+          "OptionalSelf": {
+            "$ref": "#/components/schemas/TypeWithOptionProperty"
+          },
+          "NullableOptionalSelf": {
+            "$ref": "#/components/schemas/TypeWithOptionProperty"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/9_0/VerifyTests.GenerateSchema_CustomResolver_OptionOfString_RendersCorrectly.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/9_0/VerifyTests.GenerateSchema_CustomResolver_OptionOfString_RendersCorrectly.verified.txt
@@ -1,0 +1,67 @@
+﻿{
+  "openapi": "3.1.1",
+  "info": { },
+  "paths": { },
+  "components": {
+    "schemas": {
+      "TypeWithOptionProperty": {
+        "type": "object",
+        "properties": {
+          "Int": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "NullableInt": {
+            "type": [
+              "null",
+              "integer"
+            ],
+            "format": "int32"
+          },
+          "OptionalInt": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "NullableOptionalInt": {
+            "type": [
+              "null",
+              "integer"
+            ],
+            "format": "int32"
+          },
+          "String": {
+            "type": "string"
+          },
+          "NullableString": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "OptionalString": {
+            "type": "string"
+          },
+          "NullableOptionalString": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "Self": {
+            "$ref": "#/components/schemas/TypeWithOptionProperty"
+          },
+          "NullableSelf": {
+            "$ref": "#/components/schemas/TypeWithOptionProperty"
+          },
+          "OptionalSelf": {
+            "$ref": "#/components/schemas/TypeWithOptionProperty"
+          },
+          "NullableOptionalSelf": {
+            "$ref": "#/components/schemas/TypeWithOptionProperty"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Problem
When `SupportNonNullableReferenceTypes` is enabled, the `SchemaGenerator` was overriding the `DataProperty.IsNullable` values provided by custom data contract resolvers. This prevented libraries which give an `OptionalValue<T>` Type from correctly marking struct-based nullable wrapper properties as nullable, as described in #2359.

### Solution
1. **Move NRT logic to the data contract resolvers** - Both `JsonSerializerDataContractResolver` and `NewtonsoftDataContractResolver` now handle NRT nullability checks internally
2. **Remove NRT override from SchemaGenerator** - The `SchemaGenerator.IsNullable()` method no longer applies non-nullable reference type metadata, allowing it to respect the resolver-provided `DataProperty.IsNullable` values

These changes make the DataContractResolver the `IsNullable` authority.

### Related Issues
- Fixes #3977 (custom resolver nullability being overwritten)
- Addresses nullability challenges described in #2359 (mapping `Optional<T>` wrapper types)