### PR TITLE
Fix InvalidOperationException if no route matches

### DIFF
--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Routing;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.ReDoc;
@@ -52,7 +53,20 @@ public static class ReDocBuilderExtensions
             .UseReDoc(options)
             .Build();
 
-        return endpoints.Map(GetRoutePattern(options.RoutePrefix), pipeline);
+        return endpoints.Map(GetRoutePattern(options.RoutePrefix), async (context) =>
+        {
+            var endpoint = context.GetEndpoint();
+            context.SetEndpoint(null);
+
+            try
+            {
+                await pipeline(context);
+            }
+            finally
+            {
+                context.SetEndpoint(endpoint);
+            }
+        });
     }
 
     private static ReDocOptions ResolveOptions(IServiceProvider serviceProvider, Action<ReDocOptions> setupAction)

--- a/src/Swashbuckle.AspNetCore.Swagger/DependencyInjection/SwaggerBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/DependencyInjection/SwaggerBuilderExtensions.cs
@@ -1,7 +1,7 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.Routing.Template;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.Swagger;
@@ -47,7 +47,20 @@ public static class SwaggerBuilderExtensions
             .UseSwagger(Configure)
             .Build();
 
-        return endpoints.MapMethods(pattern, [HttpMethods.Get, HttpMethods.Head], pipeline);
+        return endpoints.MapMethods(pattern, [HttpMethods.Get, HttpMethods.Head], async (context) =>
+        {
+            var endpoint = context.GetEndpoint();
+            context.SetEndpoint(null);
+
+            try
+            {
+                await pipeline(context);
+            }
+            finally
+            {
+                context.SetEndpoint(endpoint);
+            }
+        });
 
         void Configure(SwaggerOptions options)
         {

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIBuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -60,7 +61,20 @@ public static class SwaggerUIBuilderExtensions
             .UseSwaggerUI(options)
             .Build();
 
-        return endpoints.Map(GetRoutePattern(options.RoutePrefix), pipeline);
+        return endpoints.Map(GetRoutePattern(options.RoutePrefix), async (context) =>
+        {
+            var endpoint = context.GetEndpoint();
+            context.SetEndpoint(null);
+
+            try
+            {
+                await pipeline(context);
+            }
+            finally
+            {
+                context.SetEndpoint(endpoint);
+            }
+        });
     }
 
     private static SwaggerUIOptions ResolveOptions(IServiceProvider serviceProvider, Action<SwaggerUIOptions> setupAction)


### PR DESCRIPTION
Fix `InvalidOperationException` being thrown if no match for the route pattern is found while executing the request pipelline.

Resolves #3984.

