### PR TITLE
Fix ExposeSwaggerDocumentUrlsRoute behaviour

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -63,11 +63,14 @@ internal sealed partial class SwaggerUIMiddleware
                 return;
             }
 
-            var pattern = $"^/?{Regex.Escape(_options.RoutePrefix)}/{_options.SwaggerDocumentUrlsPath}/?$";
-            if (Regex.IsMatch(path, pattern, RegexOptions.IgnoreCase))
+            if (_options.ExposeSwaggerDocumentUrlsRoute)
             {
-                await RespondWithDocumentUrls(httpContext);
-                return;
+                var pattern = $"^/?{Regex.Escape(_options.RoutePrefix)}/{_options.SwaggerDocumentUrlsPath}/?$";
+                if (Regex.IsMatch(path, pattern, RegexOptions.IgnoreCase))
+                {
+                    await RespondWithDocumentUrls(httpContext);
+                    return;
+                }
             }
         }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIOptionsExtensions.cs
@@ -329,7 +329,7 @@ public static class SwaggerUIOptionsExtensions
 
     /// <summary>
     /// Function to enable the <see cref="SwaggerUIOptions.ExposeSwaggerDocumentUrlsRoute"/> option to expose the available
-    /// Swagger document urls to external parties.
+    /// Swagger document URLs to external parties.
     /// </summary>
     /// <param name="options"></param>
     public static void EnableSwaggerDocumentUrlsEndpoint(this SwaggerUIOptions options)


### PR DESCRIPTION
Fix `SwaggerUIOptions.ExposeSwaggerDocumentUrlsRoute` not being respected.

Fixes #3983.
