### PR TITLE
Fix #3978: add UseAnnotatedEnumValues option to generate oneOf/const/description enum schemas

### DIFF
--- a/docs/configure-and-customize-swaggergen.md
+++ b/docs/configure-and-customize-swaggergen.md
@@ -854,6 +854,60 @@ services.AddSwaggerGen(options =>
 > Filter pipelines are DI-aware. That is, you can create filters with constructor parameters and if the parameter types
 > are registered with the DI framework, they'll be automatically injected when the filters are instantiated.
 
+### Describe Enum Members with Annotated Enum Values
+
+By default, Swashbuckle generates enum schemas as a flat array of values:
+
+```yaml
+CvvCheckResult:
+  type: string
+  enum:
+    - D
+    - M
+    - N
+```
+
+If your enum members are annotated with `[Description]` or `[Display(Description = "...")]`, you can opt in to generating per-value descriptions using the [OpenAPI annotated enumeration pattern](https://spec.openapis.org/oas/v3.1.1.html#fixed-fields-20) (`oneOf` with `const` + `description` sub-schemas):
+
+```cs
+services.AddSwaggerGen(options =>
+{
+    options.UseAnnotatedEnumValues();
+});
+```
+
+With this option enabled, enum members decorated with `[Description]` or `[Display(Description = "...")]`:
+
+```cs
+public enum CvvCheckResult
+{
+    [Description("Suspicious transaction")]
+    D,
+
+    [Description("Match")]
+    M,
+
+    [Description("No Match")]
+    N,
+}
+```
+
+…are rendered as:
+
+```yaml
+CvvCheckResult:
+  type: string
+  oneOf:
+    - const: '"D"'
+      description: Suspicious transaction
+    - const: '"M"'
+      description: Match
+    - const: '"N"'
+      description: No Match
+```
+
+Members without a `[Description]` still appear in the `oneOf` list; their `description` field is simply omitted.
+
 ### Schema Filters
 
 Swashbuckle.AspnetCore generates an OpenAPI-flavored [JSONSchema](https://swagger.io/specification/#schema-object) for every parameter, response

--- a/docs/configure-and-customize-swaggergen.md
+++ b/docs/configure-and-customize-swaggergen.md
@@ -867,7 +867,7 @@ CvvCheckResult:
     - N
 ```
 
-If your enum members are annotated with `[Description]` or `[Display(Description = "...")]`, you can opt in to generating per-value descriptions using the [OpenAPI annotated enumeration pattern](https://spec.openapis.org/oas/v3.1.1.html#fixed-fields-20) (`oneOf` with `const` + `description` sub-schemas):
+If your enum members are annotated with `[Description]`, `[Display(Description = "...")]`, or XML doc comments (`/// <summary>`), you can opt in to generating per-value descriptions using the [OpenAPI annotated enumeration pattern](https://spec.openapis.org/oas/v3.1.1.html#fixed-fields-20) (`oneOf` with `const` + `description` sub-schemas):
 
 ```cs
 services.AddSwaggerGen(options =>
@@ -907,6 +907,34 @@ CvvCheckResult:
 ```
 
 Members without a `[Description]` still appear in the `oneOf` list; their `description` field is simply omitted.
+
+#### XML Doc Comments as Descriptions
+
+If you have called `IncludeXmlComments`, XML `<summary>` comments on enum members are also used as descriptions:
+
+```cs
+services.AddSwaggerGen(options =>
+{
+    options.UseAnnotatedEnumValues();
+    options.IncludeXmlComments("MyApi.xml");
+});
+```
+
+```cs
+public enum CvvCheckResult
+{
+    /// <summary>Suspicious transaction</summary>
+    D,
+
+    /// <summary>Match</summary>
+    M,
+
+    /// <summary>No Match</summary>
+    N,
+}
+```
+
+When a member has both an attribute and an XML doc comment, the attribute takes priority and the XML comment is ignored for that member.
 
 ### Schema Filters
 

--- a/docs/configure-and-customize-swaggergen.md
+++ b/docs/configure-and-customize-swaggergen.md
@@ -892,7 +892,7 @@ public enum CvvCheckResult
 }
 ```
 
-…are rendered as:
+...are rendered as:
 
 ```yaml
 CvvCheckResult:

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
@@ -26,6 +26,7 @@ internal class ConfigureSchemaGeneratorOptions(
         target.UseInlineDefinitionsForEnums = source.UseInlineDefinitionsForEnums;
         target.UseAnnotatedEnumValues = source.UseAnnotatedEnumValues;
         target.AnnotatedEnumOpenApiVersion = source.AnnotatedEnumOpenApiVersion;
+        target.EnumMemberDescriptionProviders = [.. source.EnumMemberDescriptionProviders];
         target.SchemaIdSelector = source.SchemaIdSelector;
         target.IgnoreObsoleteProperties = source.IgnoreObsoleteProperties;
         target.UseAllOfForInheritance = source.UseAllOfForInheritance;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
@@ -24,6 +24,7 @@ internal class ConfigureSchemaGeneratorOptions(
     {
         target.CustomTypeMappings = new Dictionary<Type, Func<IOpenApiSchema>>(source.CustomTypeMappings);
         target.UseInlineDefinitionsForEnums = source.UseInlineDefinitionsForEnums;
+        target.UseAnnotatedEnumValues = source.UseAnnotatedEnumValues;
         target.SchemaIdSelector = source.SchemaIdSelector;
         target.IgnoreObsoleteProperties = source.IgnoreObsoleteProperties;
         target.UseAllOfForInheritance = source.UseAllOfForInheritance;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/ConfigureSchemaGeneratorOptions.cs
@@ -25,6 +25,7 @@ internal class ConfigureSchemaGeneratorOptions(
         target.CustomTypeMappings = new Dictionary<Type, Func<IOpenApiSchema>>(source.CustomTypeMappings);
         target.UseInlineDefinitionsForEnums = source.UseInlineDefinitionsForEnums;
         target.UseAnnotatedEnumValues = source.UseAnnotatedEnumValues;
+        target.AnnotatedEnumOpenApiVersion = source.AnnotatedEnumOpenApiVersion;
         target.SchemaIdSelector = source.SchemaIdSelector;
         target.IgnoreObsoleteProperties = source.IgnoreObsoleteProperties;
         target.UseAllOfForInheritance = source.UseAllOfForInheritance;

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -823,6 +823,18 @@ public static class SwaggerGenOptionsExtensions
         swaggerGenOptions.AddOperationFilterInstance(new XmlCommentsOperationFilter(xmlDocMembers, swaggerGenOptions.SwaggerGeneratorOptions));
         swaggerGenOptions.AddSchemaFilterInstance(new XmlCommentsSchemaFilter(xmlDocMembers, swaggerGenOptions.SwaggerGeneratorOptions));
 
+        swaggerGenOptions.SchemaGeneratorOptions.EnumMemberDescriptionProviders.Add(field =>
+        {
+            var memberName = XmlCommentsNodeNameHelper.GetMemberNameForFieldOrProperty(field);
+            if (xmlDocMembers.TryGetValue(memberName, out var memberNode))
+            {
+                var summaryNode = memberNode.SelectFirstChild("summary");
+                if (summaryNode != null)
+                    return XmlCommentsTextHelper.Humanize(summaryNode.InnerXml, swaggerGenOptions.SwaggerGeneratorOptions.XmlCommentEndOfLine);
+            }
+            return null;
+        });
+
         if (includeControllerXmlComments)
         {
             swaggerGenOptions.AddDocumentFilterInstance(new XmlCommentsDocumentFilter(xmlDocMembers, swaggerGenOptions.SwaggerGeneratorOptions));

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -189,14 +189,25 @@ public static class SwaggerGenOptionsExtensions
     }
 
     /// <summary>
-    /// Generate enum schemas as annotated enumerations when enum members have
+    /// Generates enum schemas as <c>oneOf/const</c> enumerations (OpenAPI 3.1+) or as
+    /// flat <c>enum</c> arrays (&lt;3.1) when enum members have
     /// <see cref="System.ComponentModel.DescriptionAttribute"/> or
     /// <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute"/> descriptions.
     /// </summary>
     /// <param name="swaggerGenOptions"></param>
-    public static void UseAnnotatedEnumValues(this SwaggerGenOptions swaggerGenOptions)
+    /// <param name="openApiVersion">
+    /// Target OpenAPI version. Use <see cref="OpenApiSpecVersion.OpenApi3_1"/> (default) to emit
+    /// <c>oneOf/const/description</c> per enum member. Use <see cref="OpenApiSpecVersion.OpenApi3_0"/>
+    /// or <see cref="OpenApiSpecVersion.OpenApi2_0"/> to fall back to a flat <c>enum</c> array
+    /// (per-value descriptions are dropped as they cannot be expressed in those versions).
+    /// This must match the <c>OpenApiVersion</c> configured on <c>UseSwagger</c>.
+    /// </param>
+    public static void UseAnnotatedEnumValues(
+        this SwaggerGenOptions swaggerGenOptions,
+        OpenApiSpecVersion openApiVersion = OpenApiSpecVersion.OpenApi3_1)
     {
         swaggerGenOptions.SchemaGeneratorOptions.UseAnnotatedEnumValues = true;
+        swaggerGenOptions.SchemaGeneratorOptions.AnnotatedEnumOpenApiVersion = openApiVersion;
     }
 
     /// <summary>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -189,8 +189,8 @@ public static class SwaggerGenOptionsExtensions
     }
 
     /// <summary>
-    /// Generate enum schemas as annotated enumerations (oneOf with const + description sub-schemas)
-    /// when enum members have <see cref="System.ComponentModel.DescriptionAttribute"/> or
+    /// Generate enum schemas as annotated enumerations when enum members have
+    /// <see cref="System.ComponentModel.DescriptionAttribute"/> or
     /// <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute"/> descriptions.
     /// </summary>
     /// <param name="swaggerGenOptions"></param>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/DependencyInjection/SwaggerGenOptionsExtensions.cs
@@ -189,6 +189,17 @@ public static class SwaggerGenOptionsExtensions
     }
 
     /// <summary>
+    /// Generate enum schemas as annotated enumerations (oneOf with const + description sub-schemas)
+    /// when enum members have <see cref="System.ComponentModel.DescriptionAttribute"/> or
+    /// <see cref="System.ComponentModel.DataAnnotations.DisplayAttribute"/> descriptions.
+    /// </summary>
+    /// <param name="swaggerGenOptions"></param>
+    public static void UseAnnotatedEnumValues(this SwaggerGenOptions swaggerGenOptions)
+    {
+        swaggerGenOptions.SchemaGeneratorOptions.UseAnnotatedEnumValues = true;
+    }
+
+    /// <summary>
     /// Provide a custom strategy for generating the unique Ids that are used to reference object Schemas
     /// </summary>
     /// <param name="swaggerGenOptions"></param>

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
-﻿
+Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions.UseAnnotatedEnumValues.get -> bool
+Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions.UseAnnotatedEnumValues.set -> void
+static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.UseAnnotatedEnumValues(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions) -> void

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
+Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions.AnnotatedEnumOpenApiVersion.get -> Microsoft.OpenApi.OpenApiSpecVersion
+Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions.AnnotatedEnumOpenApiVersion.set -> void
 Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions.UseAnnotatedEnumValues.get -> bool
 Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions.UseAnnotatedEnumValues.set -> void
-static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.UseAnnotatedEnumValues(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions) -> void
+static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.UseAnnotatedEnumValues(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, Microsoft.OpenApi.OpenApiSpecVersion openApiVersion = Microsoft.OpenApi.OpenApiSpecVersion.OpenApi3_1) -> void

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions.AnnotatedEnumOpenApiVersion.get -> Microsoft.OpenApi.OpenApiSpecVersion
 Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions.AnnotatedEnumOpenApiVersion.set -> void
+Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions.EnumMemberDescriptionProviders.get -> System.Collections.Generic.IList<System.Func<System.Reflection.FieldInfo, string>>
+Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions.EnumMemberDescriptionProviders.set -> void
 Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions.UseAnnotatedEnumValues.get -> bool
 Swashbuckle.AspNetCore.SwaggerGen.SchemaGeneratorOptions.UseAnnotatedEnumValues.set -> void
 static Microsoft.Extensions.DependencyInjection.SwaggerGenOptionsExtensions.UseAnnotatedEnumValues(this Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenOptions swaggerGenOptions, Microsoft.OpenApi.OpenApiSpecVersion openApiVersion = Microsoft.OpenApi.OpenApiSpecVersion.OpenApi3_1) -> void

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi;
+using DisplayAttribute = System.ComponentModel.DataAnnotations.DisplayAttribute;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -292,7 +293,7 @@ public class SchemaGenerator(
             case DataType.Number:
             case DataType.String:
                 {
-                    schemaFactory = () => CreatePrimitiveSchema(dataContract);
+                    schemaFactory = () => CreatePrimitiveSchema(dataContract, _generatorOptions);
                     returnAsReference = dataContract.UnderlyingType.IsEnum && !_generatorOptions.UseInlineDefinitionsForEnums;
                     break;
                 }
@@ -338,7 +339,7 @@ public class SchemaGenerator(
             (modelType.IsConstructedGenericType && _generatorOptions.CustomTypeMappings.TryGetValue(modelType.GetGenericTypeDefinition(), out schemaFactory));
     }
 
-    private static OpenApiSchema CreatePrimitiveSchema(DataContract dataContract)
+    private static OpenApiSchema CreatePrimitiveSchema(DataContract dataContract, SchemaGeneratorOptions options = null)
     {
         var schema = new OpenApiSchema
         {
@@ -360,13 +361,42 @@ public class SchemaGenerator(
                 enumValues = enumValues.Append(null);
             }*/
 
-            schema.Enum = [.. enumValues
-                .Select(value => dataContract.JsonConverter(value))
-                .Distinct()
-                .Select(JsonModelFactory.CreateFromJson)];
+            if (options?.UseAnnotatedEnumValues == true && HasEnumMemberDescriptions(underlyingType))
+            {
+                schema.OneOf = [.. enumValues
+                    .Select(value => (Raw: value, Json: dataContract.JsonConverter(value)))
+                    .GroupBy(x => x.Json)
+                    .Select(g => g.First())
+                    .Select(x => (IOpenApiSchema)new OpenApiSchema
+                    {
+                        Const = x.Json,
+                        Description = GetEnumMemberDescription(underlyingType, x.Raw)
+                    })];
+            }
+            else
+            {
+                schema.Enum = [.. enumValues
+                    .Select(value => dataContract.JsonConverter(value))
+                    .Distinct()
+                    .Select(JsonModelFactory.CreateFromJson)];
+            }
         }
 
         return schema;
+    }
+
+    private static bool HasEnumMemberDescriptions(Type enumType) =>
+        enumType.GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Any(f => f.GetCustomAttribute<DescriptionAttribute>() != null
+                   || f.GetCustomAttribute<DisplayAttribute>()?.GetDescription() != null);
+
+    private static string GetEnumMemberDescription(Type enumType, object value)
+    {
+        var name = Enum.GetName(enumType, value);
+        if (name is null) return null;
+        var field = enumType.GetField(name);
+        return field?.GetCustomAttribute<DescriptionAttribute>()?.Description
+            ?? field?.GetCustomAttribute<DisplayAttribute>()?.GetDescription();
     }
 
     private OpenApiSchema CreateArraySchema(DataContract dataContract, SchemaRepository schemaRepository)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -369,7 +369,7 @@ public class SchemaGenerator(
                     .Select(g => g.First())
                     .Select(x => (IOpenApiSchema)new OpenApiSchema
                     {
-                        Const = x.Json,
+                        Const = JsonModelFactory.CreateFromJson(x.Json)?.ToString(),
                         Description = GetEnumMemberDescription(underlyingType, x.Raw)
                     })];
             }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -363,7 +363,7 @@ public class SchemaGenerator(
 
             if (options?.UseAnnotatedEnumValues == true
                 && options.AnnotatedEnumOpenApiVersion >= OpenApiSpecVersion.OpenApi3_1
-                && HasEnumMemberDescriptions(underlyingType))
+                && HasEnumMemberDescriptions(underlyingType, options))
             {
                 schema.OneOf = [.. enumValues
                     .Select(value => (Raw: value, Json: dataContract.JsonConverter(value)))
@@ -372,7 +372,7 @@ public class SchemaGenerator(
                     .Select(x => (IOpenApiSchema)new OpenApiSchema
                     {
                         Const = JsonModelFactory.CreateFromJson(x.Json)?.ToString(),
-                        Description = GetEnumMemberDescription(underlyingType, x.Raw)
+                        Description = GetEnumMemberDescription(underlyingType, x.Raw, options)
                     })];
             }
             else
@@ -387,12 +387,11 @@ public class SchemaGenerator(
         return schema;
     }
 
-    private static bool HasEnumMemberDescriptions(Type enumType) =>
+    private static bool HasEnumMemberDescriptions(Type enumType, SchemaGeneratorOptions options) =>
         enumType.GetFields(BindingFlags.Public | BindingFlags.Static)
-            .Any(f => f.GetCustomAttribute<DescriptionAttribute>() != null
-                   || f.GetCustomAttribute<DisplayAttribute>()?.GetDescription() != null);
+            .Any(f => GetFieldDescription(f, options) != null);
 
-    private static string GetEnumMemberDescription(Type enumType, object value)
+    private static string GetEnumMemberDescription(Type enumType, object value, SchemaGeneratorOptions options)
     {
         var name = Enum.GetName(enumType, value);
 
@@ -402,8 +401,34 @@ public class SchemaGenerator(
         }
 
         var field = enumType.GetField(name);
-        return field?.GetCustomAttribute<DescriptionAttribute>()?.Description
-            ?? field?.GetCustomAttribute<DisplayAttribute>()?.GetDescription();
+        return GetFieldDescription(field, options);
+    }
+
+    private static string GetFieldDescription(FieldInfo field, SchemaGeneratorOptions options)
+    {
+        if (field is null)
+        {
+            return null;
+        }
+
+        var description = field.GetCustomAttribute<DescriptionAttribute>()?.Description
+            ?? field.GetCustomAttribute<DisplayAttribute>()?.GetDescription();
+
+        if (description != null)
+        {
+            return description;
+        }
+
+        if (options?.EnumMemberDescriptionProviders is { Count: > 0 } providers)
+        {
+            foreach (var provider in providers)
+            {
+                var result = provider(field);
+                if (result != null) return result;
+            }
+        }
+
+        return null;
     }
 
     private OpenApiSchema CreateArraySchema(DataContract dataContract, SchemaRepository schemaRepository)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -361,7 +361,9 @@ public class SchemaGenerator(
                 enumValues = enumValues.Append(null);
             }*/
 
-            if (options?.UseAnnotatedEnumValues == true && HasEnumMemberDescriptions(underlyingType))
+            if (options?.UseAnnotatedEnumValues == true
+                && options.AnnotatedEnumOpenApiVersion >= OpenApiSpecVersion.OpenApi3_1
+                && HasEnumMemberDescriptions(underlyingType))
             {
                 schema.OneOf = [.. enumValues
                     .Select(value => (Raw: value, Json: dataContract.JsonConverter(value)))

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -395,7 +395,12 @@ public class SchemaGenerator(
     private static string GetEnumMemberDescription(Type enumType, object value)
     {
         var name = Enum.GetName(enumType, value);
-        if (name is null) return null;
+
+        if (name is null)
+        {
+            return null;
+        }
+
         var field = enumType.GetField(name);
         return field?.GetCustomAttribute<DescriptionAttribute>()?.Description
             ?? field?.GetCustomAttribute<DisplayAttribute>()?.GetDescription();

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
@@ -20,6 +20,8 @@ public class SchemaGeneratorOptions
 
     public bool UseAnnotatedEnumValues { get; set; }
 
+    public OpenApiSpecVersion AnnotatedEnumOpenApiVersion { get; set; } = OpenApiSpecVersion.OpenApi3_1;
+
     public Func<Type, string> SchemaIdSelector { get; set; }
 
     public bool IgnoreObsoleteProperties { get; set; }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.OpenApi;
+﻿using System.Reflection;
+using Microsoft.OpenApi;
 
 namespace Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -21,6 +22,8 @@ public class SchemaGeneratorOptions
     public bool UseAnnotatedEnumValues { get; set; }
 
     public OpenApiSpecVersion AnnotatedEnumOpenApiVersion { get; set; } = OpenApiSpecVersion.OpenApi3_1;
+
+    public IList<Func<FieldInfo, string>> EnumMemberDescriptionProviders { get; set; } = [];
 
     public Func<Type, string> SchemaIdSelector { get; set; }
 

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGeneratorOptions.cs
@@ -18,6 +18,8 @@ public class SchemaGeneratorOptions
 
     public bool UseInlineDefinitionsForEnums { get; set; }
 
+    public bool UseAnnotatedEnumValues { get; set; }
+
     public Func<Type, string> SchemaIdSelector { get; set; }
 
     public bool IgnoreObsoleteProperties { get; set; }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSchemaGeneratorOptionsTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSchemaGeneratorOptionsTests.cs
@@ -16,7 +16,7 @@ public static class ConfigureSchemaGeneratorOptionsTests
 
         // If this assertion fails, it means that a new property has been added
         // to SwaggerGeneratorOptions and ConfigureSchemaGeneratorOptions.DeepCopy() needs to be updated
-        Assert.Equal(13, publicProperties.Length);
+        Assert.Equal(14, publicProperties.Length);
     }
 
     [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSchemaGeneratorOptionsTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSchemaGeneratorOptionsTests.cs
@@ -16,7 +16,7 @@ public static class ConfigureSchemaGeneratorOptionsTests
 
         // If this assertion fails, it means that a new property has been added
         // to SwaggerGeneratorOptions and ConfigureSchemaGeneratorOptions.DeepCopy() needs to be updated
-        Assert.Equal(14, publicProperties.Length);
+        Assert.Equal(15, publicProperties.Length);
     }
 
     [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSchemaGeneratorOptionsTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/ConfigureSchemaGeneratorOptionsTests.cs
@@ -16,7 +16,7 @@ public static class ConfigureSchemaGeneratorOptionsTests
 
         // If this assertion fails, it means that a new property has been added
         // to SwaggerGeneratorOptions and ConfigureSchemaGeneratorOptions.DeepCopy() needs to be updated
-        Assert.Equal(15, publicProperties.Length);
+        Assert.Equal(16, publicProperties.Length);
     }
 
     [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -1532,11 +1532,14 @@ public class JsonSerializerSchemaGeneratorTests
         Assert.NotNull(schema.OneOf);
         Assert.Null(schema.Enum);
         Assert.Equal(3, schema.OneOf.Count);
-        Assert.Equal("0", schema.OneOf[0].Const);
-        Assert.Equal("Value zero description", schema.OneOf[0].Description);
-        Assert.Equal("1", schema.OneOf[1].Const);
-        Assert.Equal("Value one description", schema.OneOf[1].Description);
-        Assert.Equal("2", schema.OneOf[2].Const);
+        // Const reflects the actual underlying integer value serialized as a string
+        // (OpenApiSchema.Const is typed System.String, so const is always a JSON string:
+        // https://learn.microsoft.com/en-us/dotnet/api/microsoft.openapi.openapischema.const)
+        Assert.Equal("2", schema.OneOf[0].Const);
+        Assert.Equal("Value two description", schema.OneOf[0].Description);
+        Assert.Equal("4", schema.OneOf[1].Const);
+        Assert.Equal("Value four description", schema.OneOf[1].Description);
+        Assert.Equal("8", schema.OneOf[2].Const);
         Assert.Null(schema.OneOf[2].Description);
     }
 
@@ -1552,8 +1555,8 @@ public class JsonSerializerSchemaGeneratorTests
         var schema = schemaRepository.Schemas[reference.Reference.Id];
         Assert.NotNull(schema.OneOf);
         Assert.Equal(3, schema.OneOf.Count);
-        Assert.Equal("Value zero display description", schema.OneOf[0].Description);
-        Assert.Equal("Value one display description", schema.OneOf[1].Description);
+        Assert.Equal("Value two display description", schema.OneOf[0].Description);
+        Assert.Equal("Value four display description", schema.OneOf[1].Description);
         Assert.Null(schema.OneOf[2].Description);
     }
 
@@ -1585,12 +1588,39 @@ public class JsonSerializerSchemaGeneratorTests
         var schema = schemaRepository.Schemas[reference.Reference.Id];
         Assert.NotNull(schema.OneOf);
         Assert.Equal(3, schema.OneOf.Count);
-        Assert.Equal("Zero", schema.OneOf[0].Const);
-        Assert.Equal("Value zero description", schema.OneOf[0].Description);
-        Assert.Equal("One", schema.OneOf[1].Const);
-        Assert.Equal("Value one description", schema.OneOf[1].Description);
-        Assert.Equal("Two", schema.OneOf[2].Const);
+        // With JsonStringEnumConverter, Const reflects the member name (not the numeric value)
+        Assert.Equal("Two", schema.OneOf[0].Const);
+        Assert.Equal("Value two description", schema.OneOf[0].Description);
+        Assert.Equal("Four", schema.OneOf[1].Const);
+        Assert.Equal("Value four description", schema.OneOf[1].Description);
+        Assert.Equal("Eight", schema.OneOf[2].Const);
         Assert.Null(schema.OneOf[2].Description);
+    }
+
+    [Fact]
+    public void GenerateSchema_GeneratesOneOfEnumSchema_ConstIsAlwaysStringTyped_ForBothIntegerAndStringSerializedEnums()
+    {
+        // OpenApiSchema.Const is System.String, so const is always emitted as a JSON string regardless of
+        // how the enum serializes. See:
+        // https://learn.microsoft.com/en-us/dotnet/api/microsoft.openapi.openapischema.const
+        //
+        // Integer-serialized enum (default): Const = the string form of the numeric value ("2","4","8").
+        var intRepository = new SchemaRepository();
+        var intReferenceSchema = Subject(configureGenerator: c => c.UseAnnotatedEnumValues = true)
+            .GenerateSchema(typeof(IntEnumWithDescriptions), intRepository);
+        var intReference = Assert.IsType<OpenApiSchemaReference>(intReferenceSchema);
+        var intSchema = intRepository.Schemas[intReference.Reference.Id];
+        Assert.Equal(["2", "4", "8"], intSchema.OneOf.Select(s => s.Const));
+
+        // String-serialized enum (JsonStringEnumConverter): Const = the member name ("Two","Four","Eight").
+        var strRepository = new SchemaRepository();
+        var strReferenceSchema = Subject(
+                configureGenerator: c => c.UseAnnotatedEnumValues = true,
+                configureSerializer: c => c.Converters.Add(new JsonStringEnumConverter()))
+            .GenerateSchema(typeof(IntEnumWithDescriptions), strRepository);
+        var strReference = Assert.IsType<OpenApiSchemaReference>(strReferenceSchema);
+        var strSchema = strRepository.Schemas[strReference.Reference.Id];
+        Assert.Equal(["Two", "Four", "Eight"], strSchema.OneOf.Select(s => s.Const));
     }
 
     private static SchemaGenerator Subject(

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -1623,6 +1623,59 @@ public class JsonSerializerSchemaGeneratorTests
         Assert.Equal(["Two", "Four", "Eight"], strSchema.OneOf.Select(s => s.Const));
     }
 
+    [Fact]
+    public void GenerateSchema_GeneratesOneOfEnumSchema_WhenUseAnnotatedEnumValuesEnabled_AndTargetVersionIs31()
+    {
+        // Default AnnotatedEnumOpenApiVersion is OpenApi3_1 — oneOf/const schema is generated.
+        var schemaRepository = new SchemaRepository();
+
+        var referenceSchema = Subject(configureGenerator: c =>
+            {
+                c.UseAnnotatedEnumValues = true;
+                c.AnnotatedEnumOpenApiVersion = OpenApiSpecVersion.OpenApi3_1;
+            })
+            .GenerateSchema(typeof(IntEnumWithDescriptions), schemaRepository);
+
+        var reference = Assert.IsType<OpenApiSchemaReference>(referenceSchema);
+        var schema = schemaRepository.Schemas[reference.Reference.Id];
+
+        Assert.NotNull(schema.OneOf);
+        Assert.Null(schema.Enum);
+        Assert.Equal(3, schema.OneOf.Count);
+        Assert.Equal("2", schema.OneOf[0].Const);
+        Assert.Equal("Value two description", schema.OneOf[0].Description);
+        Assert.Equal("4", schema.OneOf[1].Const);
+        Assert.Equal("Value four description", schema.OneOf[1].Description);
+        Assert.Equal("8", schema.OneOf[2].Const);
+        Assert.Null(schema.OneOf[2].Description);
+    }
+
+    [Fact]
+    public void GenerateSchema_GeneratesFlatEnumSchema_WhenUseAnnotatedEnumValuesEnabled_AndTargetVersionIsLessThan31()
+    {
+        // For target versions < 3.1, oneOf/const cannot be expressed correctly (const is a
+        // 3.1-only keyword). The generator falls back to a flat enum array; per-value
+        // descriptions are dropped as they have no standard representation in < 3.1.
+        foreach (var version in new[] { OpenApiSpecVersion.OpenApi3_0, OpenApiSpecVersion.OpenApi2_0 })
+        {
+            var schemaRepository = new SchemaRepository();
+
+            var referenceSchema = Subject(configureGenerator: c =>
+                {
+                    c.UseAnnotatedEnumValues = true;
+                    c.AnnotatedEnumOpenApiVersion = version;
+                })
+                .GenerateSchema(typeof(IntEnumWithDescriptions), schemaRepository);
+
+            var reference = Assert.IsType<OpenApiSchemaReference>(referenceSchema);
+            var schema = schemaRepository.Schemas[reference.Reference.Id];
+
+            Assert.Null(schema.OneOf);
+            Assert.NotNull(schema.Enum);
+            Assert.Equal(3, schema.Enum.Count);
+        }
+    }
+
     private static SchemaGenerator Subject(
         Action<SchemaGeneratorOptions> configureGenerator = null,
         Action<JsonSerializerOptions> configureSerializer = null)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -1519,6 +1519,80 @@ public class JsonSerializerSchemaGeneratorTests
         Assert.Equal(JsonSchemaTypes.Integer, schema.Type);
     }
 
+    [Fact]
+    public void GenerateSchema_GeneratesOneOfEnumSchema_WhenUseAnnotatedEnumValuesEnabled()
+    {
+        var schemaRepository = new SchemaRepository();
+
+        var referenceSchema = Subject(configureGenerator: c => c.UseAnnotatedEnumValues = true)
+            .GenerateSchema(typeof(IntEnumWithDescriptions), schemaRepository);
+
+        var reference = Assert.IsType<OpenApiSchemaReference>(referenceSchema);
+        var schema = schemaRepository.Schemas[reference.Reference.Id];
+        Assert.NotNull(schema.OneOf);
+        Assert.Null(schema.Enum);
+        Assert.Equal(3, schema.OneOf.Count);
+        Assert.Equal("0", schema.OneOf[0].Const);
+        Assert.Equal("Value zero description", schema.OneOf[0].Description);
+        Assert.Equal("1", schema.OneOf[1].Const);
+        Assert.Equal("Value one description", schema.OneOf[1].Description);
+        Assert.Equal("2", schema.OneOf[2].Const);
+        Assert.Null(schema.OneOf[2].Description);
+    }
+
+    [Fact]
+    public void GenerateSchema_GeneratesOneOfEnumSchema_HonorsDisplayAttribute_ForEnumDescription()
+    {
+        var schemaRepository = new SchemaRepository();
+
+        var referenceSchema = Subject(configureGenerator: c => c.UseAnnotatedEnumValues = true)
+            .GenerateSchema(typeof(IntEnumWithDisplayDescriptions), schemaRepository);
+
+        var reference = Assert.IsType<OpenApiSchemaReference>(referenceSchema);
+        var schema = schemaRepository.Schemas[reference.Reference.Id];
+        Assert.NotNull(schema.OneOf);
+        Assert.Equal(3, schema.OneOf.Count);
+        Assert.Equal("Value zero display description", schema.OneOf[0].Description);
+        Assert.Equal("Value one display description", schema.OneOf[1].Description);
+        Assert.Null(schema.OneOf[2].Description);
+    }
+
+    [Fact]
+    public void GenerateSchema_StillGeneratesFlatEnum_WhenUseAnnotatedEnumValuesNotEnabled()
+    {
+        var schemaRepository = new SchemaRepository();
+
+        var referenceSchema = Subject()
+            .GenerateSchema(typeof(IntEnumWithDescriptions), schemaRepository);
+
+        var reference = Assert.IsType<OpenApiSchemaReference>(referenceSchema);
+        var schema = schemaRepository.Schemas[reference.Reference.Id];
+        Assert.NotNull(schema.Enum);
+        Assert.Null(schema.OneOf);
+    }
+
+    [Fact]
+    public void GenerateSchema_GeneratesOneOfEnumSchema_ForStringEnum_WhenUseAnnotatedEnumValuesEnabled()
+    {
+        var schemaRepository = new SchemaRepository();
+
+        var referenceSchema = Subject(
+                configureGenerator: c => c.UseAnnotatedEnumValues = true,
+                configureSerializer: c => c.Converters.Add(new JsonStringEnumConverter()))
+            .GenerateSchema(typeof(IntEnumWithDescriptions), schemaRepository);
+
+        var reference = Assert.IsType<OpenApiSchemaReference>(referenceSchema);
+        var schema = schemaRepository.Schemas[reference.Reference.Id];
+        Assert.NotNull(schema.OneOf);
+        Assert.Equal(3, schema.OneOf.Count);
+        Assert.Equal("\"Zero\"", schema.OneOf[0].Const);
+        Assert.Equal("Value zero description", schema.OneOf[0].Description);
+        Assert.Equal("\"One\"", schema.OneOf[1].Const);
+        Assert.Equal("Value one description", schema.OneOf[1].Description);
+        Assert.Equal("\"Two\"", schema.OneOf[2].Const);
+        Assert.Null(schema.OneOf[2].Description);
+    }
+
     private static SchemaGenerator Subject(
         Action<SchemaGeneratorOptions> configureGenerator = null,
         Action<JsonSerializerOptions> configureSerializer = null)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerSchemaGeneratorTests.cs
@@ -1585,11 +1585,11 @@ public class JsonSerializerSchemaGeneratorTests
         var schema = schemaRepository.Schemas[reference.Reference.Id];
         Assert.NotNull(schema.OneOf);
         Assert.Equal(3, schema.OneOf.Count);
-        Assert.Equal("\"Zero\"", schema.OneOf[0].Const);
+        Assert.Equal("Zero", schema.OneOf[0].Const);
         Assert.Equal("Value zero description", schema.OneOf[0].Description);
-        Assert.Equal("\"One\"", schema.OneOf[1].Const);
+        Assert.Equal("One", schema.OneOf[1].Const);
         Assert.Equal("Value one description", schema.OneOf[1].Description);
-        Assert.Equal("\"Two\"", schema.OneOf[2].Const);
+        Assert.Equal("Two", schema.OneOf[2].Const);
         Assert.Null(schema.OneOf[2].Description);
     }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/VerifyTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/VerifyTests.cs
@@ -1654,6 +1654,66 @@ public partial class VerifyTests
         await Verify(document);
     }
 
+    [Fact]
+    public async Task GenerateSchema_AnnotatedEnum_WhenDescriptionAttribute()
+    {
+        var subject = Subject(
+            apiDescriptions:
+            [
+                ApiDescriptionFactory.Create<FakeController>(
+                    c => nameof(c.ActionWithParameter),
+                    groupName: "v1",
+                    httpMethod: "GET",
+                    relativePath: "resource",
+                    parameterDescriptions:
+                    [
+                        new ApiParameterDescription
+                        {
+                            Name = "param",
+                            Source = BindingSource.Query,
+                            Type = typeof(IntEnumWithDescriptions),
+                            ModelMetadata = ModelMetadataFactory.CreateForType(typeof(IntEnumWithDescriptions)),
+                        },
+                    ]),
+            ],
+            configureSchemaGeneratorOptions: c => c.UseAnnotatedEnumValues = true
+        );
+
+        var document = subject.GetSwagger("v1");
+
+        await VerifyV31(document);
+    }
+
+    [Fact]
+    public async Task GenerateSchema_AnnotatedEnum_WhenDisplayDescriptionAttribute()
+    {
+        var subject = Subject(
+            apiDescriptions:
+            [
+                ApiDescriptionFactory.Create<FakeController>(
+                    c => nameof(c.ActionWithParameter),
+                    groupName: "v1",
+                    httpMethod: "GET",
+                    relativePath: "resource",
+                    parameterDescriptions:
+                    [
+                        new ApiParameterDescription
+                        {
+                            Name = "param",
+                            Source = BindingSource.Query,
+                            Type = typeof(IntEnumWithDisplayDescriptions),
+                            ModelMetadata = ModelMetadataFactory.CreateForType(typeof(IntEnumWithDisplayDescriptions)),
+                        },
+                    ]),
+            ],
+            configureSchemaGeneratorOptions: c => c.UseAnnotatedEnumValues = true
+        );
+
+        var document = subject.GetSwagger("v1");
+
+        await VerifyV31(document);
+    }
+
     private static SwaggerGenerator Subject(
             IEnumerable<ApiDescription> apiDescriptions,
             SwaggerGeneratorOptions options = null,
@@ -1693,6 +1753,22 @@ public partial class VerifyTests
     private static async Task Verify(OpenApiDocument document)
     {
         await Verifier.Verify(ToJson(document))
+                      .UseDirectory($"snapshots/{Environment.Version.Major}_{Environment.Version.Minor}");
+    }
+
+    private static string ToJsonV31(OpenApiDocument document)
+    {
+        using var stringWriter = new StringWriter();
+        var jsonWriter = new OpenApiJsonWriter(stringWriter);
+
+        document.SerializeAsV31(jsonWriter);
+
+        return NormalizeLineBreaks(stringWriter.ToString());
+    }
+
+    private static async Task VerifyV31(OpenApiDocument document)
+    {
+        await Verifier.Verify(ToJsonV31(document))
                       .UseDirectory($"snapshots/{Environment.Version.Major}_{Environment.Version.Minor}");
     }
 

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/VerifyTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/VerifyTests.cs
@@ -1714,6 +1714,90 @@ public partial class VerifyTests
         await VerifyV31(document);
     }
 
+    [Fact]
+    public async Task GenerateSchema_AnnotatedEnum_WhenXmlDocComment()
+    {
+        var subject = Subject(
+            apiDescriptions:
+            [
+                ApiDescriptionFactory.Create<FakeController>(
+                    c => nameof(c.ActionWithParameter),
+                    groupName: "v1",
+                    httpMethod: "GET",
+                    relativePath: "resource",
+                    parameterDescriptions:
+                    [
+                        new ApiParameterDescription
+                        {
+                            Name = "param",
+                            Source = BindingSource.Query,
+                            Type = typeof(IntEnumWithXmlComments),
+                            ModelMetadata = ModelMetadataFactory.CreateForType(typeof(IntEnumWithXmlComments)),
+                        },
+                    ]),
+            ],
+            configureSchemaGeneratorOptions: c =>
+            {
+                c.UseAnnotatedEnumValues = true;
+                c.EnumMemberDescriptionProviders.Add(field =>
+                    field.DeclaringType == typeof(IntEnumWithXmlComments)
+                        ? field.Name switch
+                        {
+                            "Two" => "Value two xml comment",
+                            "Four" => "Value four xml comment",
+                            _ => null,
+                        }
+                        : null);
+            }
+        );
+
+        var document = subject.GetSwagger("v1");
+
+        await VerifyV31(document);
+    }
+
+    [Fact]
+    public async Task GenerateSchema_AnnotatedEnum_WhenXmlDocCommentAndDescriptionAttribute_AttributeWins()
+    {
+        var subject = Subject(
+            apiDescriptions:
+            [
+                ApiDescriptionFactory.Create<FakeController>(
+                    c => nameof(c.ActionWithParameter),
+                    groupName: "v1",
+                    httpMethod: "GET",
+                    relativePath: "resource",
+                    parameterDescriptions:
+                    [
+                        new ApiParameterDescription
+                        {
+                            Name = "param",
+                            Source = BindingSource.Query,
+                            Type = typeof(IntEnumWithXmlCommentsAndDescriptionAttribute),
+                            ModelMetadata = ModelMetadataFactory.CreateForType(typeof(IntEnumWithXmlCommentsAndDescriptionAttribute)),
+                        },
+                    ]),
+            ],
+            configureSchemaGeneratorOptions: c =>
+            {
+                c.UseAnnotatedEnumValues = true;
+                c.EnumMemberDescriptionProviders.Add(field =>
+                    field.DeclaringType == typeof(IntEnumWithXmlCommentsAndDescriptionAttribute)
+                        ? field.Name switch
+                        {
+                            "Two" => "Should be ignored",
+                            "Four" => "Value four xml comment",
+                            _ => null,
+                        }
+                        : null);
+            }
+        );
+
+        var document = subject.GetSwagger("v1");
+
+        await VerifyV31(document);
+    }
+
     private static SwaggerGenerator Subject(
             IEnumerable<ApiDescription> apiDescriptions,
             SwaggerGeneratorOptions options = null,

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/10_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenDescriptionAttribute.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/10_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenDescriptionAttribute.verified.txt
@@ -1,0 +1,56 @@
+﻿{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
+  },
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/IntEnumWithDescriptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IntEnumWithDescriptions": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "const": "2",
+            "description": "Value two description"
+          },
+          {
+            "const": "4",
+            "description": "Value four description"
+          },
+          {
+            "const": "8"
+          }
+        ],
+        "format": "int32"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Fake"
+    }
+  ]
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/10_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenDisplayDescriptionAttribute.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/10_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenDisplayDescriptionAttribute.verified.txt
@@ -1,0 +1,56 @@
+﻿{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
+  },
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/IntEnumWithDisplayDescriptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IntEnumWithDisplayDescriptions": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "const": "2",
+            "description": "Value two display description"
+          },
+          {
+            "const": "4",
+            "description": "Value four display description"
+          },
+          {
+            "const": "8"
+          }
+        ],
+        "format": "int32"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Fake"
+    }
+  ]
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/10_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenXmlDocComment.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/10_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenXmlDocComment.verified.txt
@@ -1,0 +1,56 @@
+﻿{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
+  },
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/IntEnumWithXmlComments"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IntEnumWithXmlComments": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "const": "2",
+            "description": "Value two xml comment"
+          },
+          {
+            "const": "4",
+            "description": "Value four xml comment"
+          },
+          {
+            "const": "8"
+          }
+        ],
+        "format": "int32"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Fake"
+    }
+  ]
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/10_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenXmlDocCommentAndDescriptionAttribute_AttributeWins.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/10_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenXmlDocCommentAndDescriptionAttribute_AttributeWins.verified.txt
@@ -1,0 +1,56 @@
+﻿{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
+  },
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/IntEnumWithXmlCommentsAndDescriptionAttribute"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IntEnumWithXmlCommentsAndDescriptionAttribute": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "const": "2",
+            "description": "Attribute wins"
+          },
+          {
+            "const": "4",
+            "description": "Value four xml comment"
+          },
+          {
+            "const": "8"
+          }
+        ],
+        "format": "int32"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Fake"
+    }
+  ]
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/8_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenDescriptionAttribute.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/8_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenDescriptionAttribute.verified.txt
@@ -1,0 +1,56 @@
+﻿{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
+  },
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/IntEnumWithDescriptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IntEnumWithDescriptions": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "const": "2",
+            "description": "Value two description"
+          },
+          {
+            "const": "4",
+            "description": "Value four description"
+          },
+          {
+            "const": "8"
+          }
+        ],
+        "format": "int32"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Fake"
+    }
+  ]
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/8_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenDisplayDescriptionAttribute.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/8_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenDisplayDescriptionAttribute.verified.txt
@@ -1,0 +1,56 @@
+﻿{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
+  },
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/IntEnumWithDisplayDescriptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IntEnumWithDisplayDescriptions": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "const": "2",
+            "description": "Value two display description"
+          },
+          {
+            "const": "4",
+            "description": "Value four display description"
+          },
+          {
+            "const": "8"
+          }
+        ],
+        "format": "int32"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Fake"
+    }
+  ]
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/8_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenXmlDocComment.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/8_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenXmlDocComment.verified.txt
@@ -1,0 +1,56 @@
+﻿{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
+  },
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/IntEnumWithXmlComments"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IntEnumWithXmlComments": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "const": "2",
+            "description": "Value two xml comment"
+          },
+          {
+            "const": "4",
+            "description": "Value four xml comment"
+          },
+          {
+            "const": "8"
+          }
+        ],
+        "format": "int32"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Fake"
+    }
+  ]
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/8_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenXmlDocCommentAndDescriptionAttribute_AttributeWins.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/8_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenXmlDocCommentAndDescriptionAttribute_AttributeWins.verified.txt
@@ -1,0 +1,56 @@
+﻿{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
+  },
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/IntEnumWithXmlCommentsAndDescriptionAttribute"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IntEnumWithXmlCommentsAndDescriptionAttribute": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "const": "2",
+            "description": "Attribute wins"
+          },
+          {
+            "const": "4",
+            "description": "Value four xml comment"
+          },
+          {
+            "const": "8"
+          }
+        ],
+        "format": "int32"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Fake"
+    }
+  ]
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/9_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenDescriptionAttribute.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/9_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenDescriptionAttribute.verified.txt
@@ -1,0 +1,56 @@
+﻿{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
+  },
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/IntEnumWithDescriptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IntEnumWithDescriptions": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "const": "2",
+            "description": "Value two description"
+          },
+          {
+            "const": "4",
+            "description": "Value four description"
+          },
+          {
+            "const": "8"
+          }
+        ],
+        "format": "int32"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Fake"
+    }
+  ]
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/9_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenDisplayDescriptionAttribute.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/9_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenDisplayDescriptionAttribute.verified.txt
@@ -1,0 +1,56 @@
+﻿{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
+  },
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/IntEnumWithDisplayDescriptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IntEnumWithDisplayDescriptions": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "const": "2",
+            "description": "Value two display description"
+          },
+          {
+            "const": "4",
+            "description": "Value four display description"
+          },
+          {
+            "const": "8"
+          }
+        ],
+        "format": "int32"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Fake"
+    }
+  ]
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/9_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenXmlDocComment.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/9_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenXmlDocComment.verified.txt
@@ -1,0 +1,56 @@
+﻿{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
+  },
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/IntEnumWithXmlComments"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IntEnumWithXmlComments": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "const": "2",
+            "description": "Value two xml comment"
+          },
+          {
+            "const": "4",
+            "description": "Value four xml comment"
+          },
+          {
+            "const": "8"
+          }
+        ],
+        "format": "int32"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Fake"
+    }
+  ]
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/9_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenXmlDocCommentAndDescriptionAttribute_AttributeWins.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/9_0/VerifyTests.GenerateSchema_AnnotatedEnum_WhenXmlDocCommentAndDescriptionAttribute_AttributeWins.verified.txt
@@ -1,0 +1,56 @@
+﻿{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Test API",
+    "version": "V1"
+  },
+  "paths": {
+    "/resource": {
+      "get": {
+        "tags": [
+          "Fake"
+        ],
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/IntEnumWithXmlCommentsAndDescriptionAttribute"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IntEnumWithXmlCommentsAndDescriptionAttribute": {
+        "type": "integer",
+        "oneOf": [
+          {
+            "const": "2",
+            "description": "Attribute wins"
+          },
+          {
+            "const": "4",
+            "description": "Value four xml comment"
+          },
+          {
+            "const": "8"
+          }
+        ],
+        "format": "int32"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Fake"
+    }
+  ]
+}

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/Enums.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/Enums.cs
@@ -63,3 +63,26 @@ public enum IntEnumWithDisplayDescriptions : int
 
     Eight = 8,
 }
+
+public enum IntEnumWithXmlComments : int
+{
+    /// <summary>Value two xml comment</summary>
+    Two = 2,
+
+    /// <summary>Value four xml comment</summary>
+    Four = 4,
+
+    Eight = 8,
+}
+
+public enum IntEnumWithXmlCommentsAndDescriptionAttribute : int
+{
+    [Description("Attribute wins")]
+    /// <summary>Should be ignored</summary>
+    Two = 2,
+
+    /// <summary>Value four xml comment</summary>
+    Four = 4,
+
+    Eight = 8,
+}

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/Enums.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/Enums.cs
@@ -44,22 +44,22 @@ public enum IntEnumWithDuplicateValues : int
 
 public enum IntEnumWithDescriptions : int
 {
-    [Description("Value zero description")]
-    Zero = 0,
-
-    [Description("Value one description")]
-    One = 1,
-
+    [Description("Value two description")]
     Two = 2,
+
+    [Description("Value four description")]
+    Four = 4,
+
+    Eight = 8,
 }
 
 public enum IntEnumWithDisplayDescriptions : int
 {
-    [Display(Description = "Value zero display description")]
-    Zero = 0,
-
-    [Display(Description = "Value one display description")]
-    One = 1,
-
+    [Display(Description = "Value two display description")]
     Two = 2,
+
+    [Display(Description = "Value four display description")]
+    Four = 4,
+
+    Eight = 8,
 }

--- a/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/Enums.cs
+++ b/test/Swashbuckle.AspNetCore.TestSupport/Fixtures/Enums.cs
@@ -1,4 +1,7 @@
-﻿namespace Swashbuckle.AspNetCore.TestSupport;
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace Swashbuckle.AspNetCore.TestSupport;
 
 public enum ByteEnum : byte
 {
@@ -37,4 +40,26 @@ public enum IntEnumWithDuplicateValues : int
     Unknown = 0,
     PreferredName = 1,
     OldNameForBackwardsCompatibility = PreferredName,
+}
+
+public enum IntEnumWithDescriptions : int
+{
+    [Description("Value zero description")]
+    Zero = 0,
+
+    [Description("Value one description")]
+    One = 1,
+
+    Two = 2,
+}
+
+public enum IntEnumWithDisplayDescriptions : int
+{
+    [Display(Description = "Value zero display description")]
+    Zero = 0,
+
+    [Display(Description = "Value one display description")]
+    One = 1,
+
+    Two = 2,
 }


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

Fixes #3978

## Details on the issue fix or feature implementation

Adds a new UseAnnotatedEnumValues option to SchemaGeneratorOptions that, when enabled, generates richer enum schemas using oneOf with per-value const and description instead of a flat enum array.

How it works:

When `UseAnnotatedEnumValues = true` and at least one enum member carries a `[Description]` or `[Display(Description = "...")]` attribute, CreatePrimitiveSchema switches 
from:

`{ "enum": ["Zero", "One", "Two"] }`

to:

```
{
  "oneOf": [
    { "const": "Zero", "description": "Value zero description" },
    { "const": "One",  "description": "Value one description" },
    { "const": "Two" }
  ]
}
```

This allows OpenAPI consumers (e.g. Swagger UI, code generators) to surface human-readable descriptions per enum value, which is not possible with the plain enum keyword.

Changes:
- SchemaGeneratorOptions - new bool UseAnnotatedEnumValues property (defaults to false, fully opt-in, no breaking change).
- SchemaGenerator.CreatePrimitiveSchema - when the option is set and the enum type has any annotated members, builds OneOf sub-schemas with Const (unwrapped from JSON encoding via JsonModelFactory.CreateFromJson) and Description sourced from [Description] or [Display(Description)].
- Duplicate JSON values (e.g. aliased enum members) are collapsed via GroupBy before building the oneOf list.
- Tests added in JsonSerializerSchemaGeneratorTests covering [Description] and [Display] attributes, unannotated fallback, and JsonStringEnumConverter interaction.
