### PR TITLE
Update to ASP.NET Core 11 preview 5

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,10 +15,10 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Build" Version="18.6.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="11.0.0-preview.4.26230.115" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="11.0.0-preview.5.26302.115" />
     <PackageVersion Include="Microsoft.Kiota.Bundle" Version="2.0.0" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="3.6.0" />
-    <PackageVersion Include="Microsoft.OpenApi.YamlReader" Version="3.6.0" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="3.7.0" />
+    <PackageVersion Include="Microsoft.OpenApi.YamlReader" Version="3.7.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.61.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="MSBuild.ProjectCreation" Version="19.1.2" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.4.26230.115",
+    "version": "11.0.100-preview.5.26302.115",
     "allowPrerelease": false,
     "paths": [ ".dotnet", "$host$" ]
   }

--- a/src/Swashbuckle.AspNetCore.ApiTesting/Swashbuckle.AspNetCore.ApiTesting.csproj
+++ b/src/Swashbuckle.AspNetCore.ApiTesting/Swashbuckle.AspNetCore.ApiTesting.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi" VersionOverride="2.8.0" />
+    <PackageReference Include="Microsoft.OpenApi" VersionOverride="2.9.0" />
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
@@ -19,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net11.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="11.0.0-preview.4.26230.115" />
-    <PackageReference Update="Microsoft.OpenApi" VersionOverride="3.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="11.0.0-preview.5.26302.115" />
+    <PackageReference Update="Microsoft.OpenApi" VersionOverride="3.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Swashbuckle.AspNetCore.Newtonsoft/Swashbuckle.AspNetCore.Newtonsoft.csproj
+++ b/src/Swashbuckle.AspNetCore.Newtonsoft/Swashbuckle.AspNetCore.Newtonsoft.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net11.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" VersionOverride="11.0.0-preview.4.26230.115" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" VersionOverride="11.0.0-preview.5.26302.115" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Swashbuckle.AspNetCore.Swagger/Swashbuckle.AspNetCore.Swagger.csproj
+++ b/src/Swashbuckle.AspNetCore.Swagger/Swashbuckle.AspNetCore.Swagger.csproj
@@ -17,11 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi" VersionOverride="2.8.0" />
+    <PackageReference Include="Microsoft.OpenApi" VersionOverride="2.9.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net11.0' ">
-    <PackageReference Update="Microsoft.OpenApi" VersionOverride="3.6.0" />
+    <PackageReference Update="Microsoft.OpenApi" VersionOverride="3.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Swashbuckle.AspNetCore/Swashbuckle.AspNetCore.nuspec
+++ b/src/Swashbuckle.AspNetCore/Swashbuckle.AspNetCore.nuspec
@@ -23,7 +23,7 @@
         <dependency id="Swashbuckle.AspNetCore.Swagger" version="$version$" exclude="Build,Analyzers" />
         <dependency id="Swashbuckle.AspNetCore.SwaggerGen" version="$version$" exclude="Build,Analyzers" />
         <dependency id="Swashbuckle.AspNetCore.SwaggerUI" version="$version$" exclude="Build,Analyzers" />
-        <dependency id="Microsoft.Extensions.ApiDescription.Server" version="11.0.0-preview.4.26230.115" />
+        <dependency id="Microsoft.Extensions.ApiDescription.Server" version="11.0.0-preview.5.26302.115" />
       </group>
     </dependencies>
   </metadata>

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/Swashbuckle.AspNetCore.IntegrationTests.csproj
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/Swashbuckle.AspNetCore.IntegrationTests.csproj
@@ -52,8 +52,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
-    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="11.0.0-preview.4.26230.115" />
-    <PackageReference Update="Microsoft.AspNetCore.TestHost" VersionOverride="11.0.0-preview.4.26230.115" />
+    <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="11.0.0-preview.5.26302.115" />
+    <PackageReference Update="Microsoft.AspNetCore.TestHost" VersionOverride="11.0.0-preview.5.26302.115" />
   </ItemGroup>
 
 </Project>

--- a/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
+++ b/test/WebSites/OAuth2Integration/OAuth2Integration.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="11.0.0-preview.4.26230.115" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" VersionOverride="11.0.0-preview.5.26302.115" />
   </ItemGroup>
 
 </Project>

--- a/test/WebSites/TodoApp/TodoApp.csproj
+++ b/test/WebSites/TodoApp/TodoApp.csproj
@@ -17,6 +17,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" VersionOverride="10.0.9" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" VersionOverride="11.0.0-preview.4.26230.115" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" VersionOverride="11.0.0-preview.5.26302.115" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Update to preview 5 of ASP.NET Core 11.
- Update Microsoft.OpenApi to the latest releases.
