### PR TITLE
Do not mark nested form properties as required when their container property is optional

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiParameterDescriptionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/ApiParameterDescriptionExtensions.cs
@@ -36,14 +36,60 @@ public static class ApiParameterDescriptionExtensions
         // This is the default logic for IsRequired
         bool IsRequired() => apiParameter.CustomAttributes().Any(attr => RequiredAttributeTypes.Contains(attr.GetType()));
 
-        // This is to keep compatibility with MVC controller logic that has existed in the past
-        if (apiParameter.ParameterDescriptor is ControllerParameterDescriptor)
+        // This is to keep compatibility with MVC controller logic that has existed in the past.
+        // For non-controllers, prefer the IsRequired flag if we're not on netstandard 2.0, otherwise fallback to the default logic.
+        var isRequired = apiParameter.ParameterDescriptor is ControllerParameterDescriptor
+            ? IsRequired()
+            : apiParameter.IsRequired;
+
+        // A member flattened from a nested model (e.g. "Inner.Prop") can only be required
+        // if every property in its container chain is required as well
+        return isRequired && HasRequiredContainerChain(apiParameter);
+    }
+
+    private static bool HasRequiredContainerChain(ApiParameterDescription apiParameter)
+    {
+        var name = apiParameter.Name;
+        if (name is null || !name.Contains('.') || apiParameter.ModelMetadata?.ContainerType is null)
         {
-            return IsRequired();
+            return true;
         }
 
-        // For non-controllers, prefer the IsRequired flag if we're not on netstandard 2.0, otherwise fallback to the default logic.
-        return apiParameter.IsRequired;
+        var containerType =
+            apiParameter.ParameterDescriptor?.ParameterType ??
+            apiParameter.ParameterInfo()?.ParameterType;
+
+        var segments = name.Split('.');
+
+        // Walk the container chain, i.e. every segment except the last one, which is the
+        // member itself. If the chain cannot be resolved (custom binding names, collection
+        // indexers, etc.), assume the container is required to keep the previous behavior.
+        for (var i = 0; i < segments.Length - 1 && containerType is not null; i++)
+        {
+            PropertyInfo containerProperty;
+            try
+            {
+                containerProperty = containerType.GetProperty(segments[i], BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            }
+            catch (AmbiguousMatchException)
+            {
+                return true;
+            }
+
+            if (containerProperty is null)
+            {
+                return true;
+            }
+
+            if (!containerProperty.GetCustomAttributes(true).Any(attr => RequiredAttributeTypes.Contains(attr.GetType())))
+            {
+                return false;
+            }
+
+            containerType = Nullable.GetUnderlyingType(containerProperty.PropertyType) ?? containerProperty.PropertyType;
+        }
+
+        return true;
     }
 
     public static ParameterInfo ParameterInfo(this ApiParameterDescription apiParameter)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeController.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeController.cs
@@ -120,4 +120,6 @@ public class FakeController
     { }
     public void ActionHavingFromFormObjectAndString([FromForm] SwaggerIngoreAnnotatedType param1, [FromForm] string param2)
     { }
+    public void ActionHavingFromFormAttributeWithNestedModel([FromForm] FakeFormModelWithNestedType param1)
+    { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeFormModelWithNestedType.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeFormModelWithNestedType.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test.Fixtures;
+
+public class FakeFormModelWithNestedType
+{
+    public FakeFormNestedType Inner { get; set; }
+
+    [Required]
+    public string Other { get; set; }
+}
+
+public class FakeFormNestedType
+{
+    [Required]
+    public string Prop { get; set; }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -2138,6 +2138,61 @@ public class SwaggerGeneratorTests
     }
 
     [Fact]
+    public void GetSwagger_GenerateRequestBodyFromFormParameters_DoesNotRequireNestedPropertyOfOptionalContainer()
+    {
+        var modelParameterInfo = typeof(FakeController)
+            .GetMethod(nameof(FakeController.ActionHavingFromFormAttributeWithNestedModel))
+            .GetParameters()[0];
+
+        var apiDescription = ApiDescriptionFactory.Create<FakeController>(
+            c => nameof(c.ActionHavingFromFormAttributeWithNestedModel),
+            groupName: "v1",
+            httpMethod: "POST",
+            relativePath: "resource",
+            parameterDescriptions:
+            [
+                new ApiParameterDescription
+                {
+                    Name = "Inner.Prop",
+                    Source = BindingSource.Form,
+                    Type = typeof(string),
+                    ModelMetadata = ModelMetadataFactory.CreateForProperty(typeof(FakeFormNestedType), nameof(FakeFormNestedType.Prop))
+                },
+                new ApiParameterDescription
+                {
+                    Name = "Other",
+                    Source = BindingSource.Form,
+                    Type = typeof(string),
+                    ModelMetadata = ModelMetadataFactory.CreateForProperty(typeof(FakeFormModelWithNestedType), nameof(FakeFormModelWithNestedType.Other))
+                }
+            ]);
+
+        // ApiExplorer assigns the root parameter's descriptor to every flattened member,
+        // which ApiDescriptionFactory's name-based matching cannot express
+        foreach (var parameter in apiDescription.ParameterDescriptions)
+        {
+            parameter.ParameterDescriptor = new ControllerParameterDescriptor
+            {
+                Name = "param1",
+                ParameterInfo = modelParameterInfo,
+                ParameterType = typeof(FakeFormModelWithNestedType)
+            };
+        }
+
+        var subject = Subject(apiDescriptions: [apiDescription]);
+
+        var document = subject.GetSwagger("v1");
+
+        var operation = document.Paths["/resource"].Operations[HttpMethod.Post];
+        Assert.NotNull(operation.RequestBody);
+        var mediaType = operation.RequestBody.Content["multipart/form-data"];
+        Assert.NotNull(mediaType.Schema);
+        Assert.Equal(["Inner.Prop", "Other"], mediaType.Schema.Properties.Keys);
+        Assert.NotNull(mediaType.Schema.Required);
+        Assert.Equal(["Other"], mediaType.Schema.Required);
+    }
+
+    [Fact]
     public void GetSwagger_Works_As_Expected_When_FromFormObject()
     {
         var subject = Subject(


### PR DESCRIPTION
Fixes #3534

## Summary

When a `[FromForm]` model is flattened into dot-concatenated properties (e.g. `Inner.Prop`), a nested property marked `[Required]` ends up in the top-level `required` list of the form schema even when its container property is optional:

```csharp
public record Model(Inner? Inner, [Required] string Other);
public record Inner([Required] string Prop);

public IActionResult MyAction([FromForm, Required] Model model) => ...
```

Here `Inner.Prop` is generated as required, but the whole `Inner` subobject may legitimately be absent, so the field must be optional.

## Root cause

`ApiParameterDescriptionExtensions.IsRequiredParameter` only inspects the leaf member (via its `PropertyInfo` custom attributes or the `IsRequired` flag). The container chain of a flattened member is never considered.

## Fix

`IsRequiredParameter` now additionally verifies the container chain for flattened members: for a dotted name, every intermediate property (resolved by walking from `ParameterDescriptor.ParameterType`) must itself carry one of the required markers (`RequiredAttribute`, `BindRequiredAttribute`, `RequiredMemberAttribute` - the same set the leaf check uses). If any container is optional, the member is not required.

Deliberately conservative bail-outs (behavior stays exactly as before):

- name has no dots, or the member has no container metadata (regular top-level parameters)
- the chain cannot be resolved: custom binding names, collection indexers, ambiguous or missing properties
- the root parameter type is unavailable

No public API changes.

## Tests

TDD: the new test reproduces the issue first (`Inner.Prop` appeared in `required`), then the fix turns it green. A test infrastructure note: `ApiDescriptionFactory` reassigns `ParameterDescriptor` by name matching, which cannot express flattened members (real ApiExplorer assigns the root parameter's descriptor to every flattened member), so the test assigns descriptors after the factory call.

Full Swashbuckle.AspNetCore.SwaggerGen.Test suite: 740/740 passing on net8.0, net9.0, and net10.0.
