### PR TITLE
.NET 11 preparation

### DIFF
--- a/src/Shared/EmbeddedResourceProvider.cs
+++ b/src/Shared/EmbeddedResourceProvider.cs
@@ -70,17 +70,18 @@ internal sealed class EmbeddedResourceProvider(
         responseHeaders.ContentType = contentType;
         responseHeaders.ETag = etag;
 
-        using var compressed = GetResource(cacheEntry);
+        ReadOnlyMemory<byte> body;
 
         if (serveCompressed)
         {
-            await compressed.CopyToAsync(response.Body, httpContext.RequestAborted);
+            body = cacheEntry.Compressed;
         }
         else
         {
-            using var decompressed = new GZipStream(compressed, CompressionMode.Decompress);
-            await decompressed.CopyToAsync(response.Body, httpContext.RequestAborted);
+            body = cacheEntry.Decompressed;
         }
+
+        await response.BodyWriter.WriteAsync(body, httpContext.RequestAborted);
 
         return true;
     }
@@ -146,15 +147,26 @@ internal sealed class EmbeddedResourceProvider(
 
             gzip.CopyTo(decompressed);
 
-            compressed.Seek(0, SeekOrigin.Begin);
-            decompressed.Seek(0, SeekOrigin.Begin);
+            entry.Decompressed = decompressed.ToArray();
 
             // Some embedded resources may already be compressed or compress worse than the original
             entry.SupportsCompression = compressed.Length < decompressed.Length;
 
-            var content = entry.SupportsCompression
-                ? compressed
-                : decompressed;
+            byte[] content;
+
+            if (entry.SupportsCompression)
+            {
+                compressed.Seek(0, SeekOrigin.Begin);
+
+                using var memoryStream = new MemoryStream((int)compressed.Length);
+                compressed.CopyTo(memoryStream);
+
+                content = entry.Compressed = memoryStream.ToArray();
+            }
+            else
+            {
+                content = entry.Decompressed;
+            }
 
             var hash = SHA1.HashData(content);
 
@@ -182,5 +194,9 @@ internal sealed class EmbeddedResourceProvider(
         public string ResourceName { get; } = resourceName;
 
         public bool SupportsCompression { get; set; }
+
+        public byte[]? Compressed { get; set; }
+
+        public byte[]? Decompressed { get; set; }
     }
 }

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -995,8 +995,12 @@ public class SwaggerGenerator(
         ApiDescription apiDescription,
         SchemaRepository schemaRepository)
     {
+        // The order in which the API explorer returns the default response relative to
+        // numeric status codes is not stable across runtimes, so sort it to the end while
+        // preserving the relative order of the numeric status codes.
         var supportedResponseTypes = apiDescription.SupportedResponseTypes
-            .DefaultIfEmpty(new ApiResponseType { StatusCode = 200 });
+            .DefaultIfEmpty(new ApiResponseType { StatusCode = 200 })
+            .OrderBy((responseType) => responseType.IsDefaultResponse() ? 1 : 0);
 
         var responses = new OpenApiResponses();
         foreach (var responseType in supportedResponseTypes)

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/Swashbuckle.AspNetCore.IntegrationTests.csproj
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/Swashbuckle.AspNetCore.IntegrationTests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Swashbuckle.AspNetCore.TestSupport\Swashbuckle.AspNetCore.TestSupport.csproj" />
     <ProjectReference Include="..\WebSites\**\*.csproj" />
     <ProjectReference Remove="..\WebSites\TestFirst.IntegrationTests\TestFirst.IntegrationTests.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Cherry-pick changes from #3786:

- Use BodyWriter to write cached embedded resources directly to the HTTP response.
- Add explicit sorting for API responses.
- Added needed project reference.
