### PR TITLE
Handle leading slash on route prefix during index.html GET

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -55,7 +55,7 @@ internal sealed partial class SwaggerUIMiddleware
                 return;
             }
 
-            var match = Regex.Match(path, $"^/{Regex.Escape(_options.RoutePrefix)}/?(index.(html|js))$", RegexOptions.IgnoreCase);
+            var match = Regex.Match(path, $"^/?{Regex.Escape(_options.RoutePrefix)}/?(index.(html|js))$", RegexOptions.IgnoreCase);
 
             if (match.Success)
             {

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -37,6 +37,8 @@ public class SwaggerUIIntegrationTests(ITestOutputHelper outputHelper)
 
     [Theory]
     [InlineData(typeof(Basic.Startup), "/", "index.html")]
+    [InlineData(typeof(Basic.StartupWithAbsoluteRoutePrefix), "/abs", "abs/index.html")]
+    [InlineData(typeof(Basic.StartupWithRelativeRoutePrefix), "/rel", "rel/index.html")]
     [InlineData(typeof(CustomUIConfig.Startup), "/swagger", "swagger/index.html")]
     [InlineData(typeof(CustomUIConfig.Startup), "/swagger/", "index.html")]
     public async Task RoutePrefix_RedirectsToPathRelativeIndexUrl(
@@ -55,6 +57,8 @@ public class SwaggerUIIntegrationTests(ITestOutputHelper outputHelper)
 
     [Theory]
     [InlineData(typeof(Basic.Startup), "/index.html")]
+    [InlineData(typeof(Basic.StartupWithAbsoluteRoutePrefix), "/abs/index.html")]
+    [InlineData(typeof(Basic.StartupWithRelativeRoutePrefix), "/rel/index.html")]
     [InlineData(typeof(CustomUIConfig.Startup), "/swagger/index.html")]
     public async Task IndexUrl_HeadRequest_ReturnsMetadata(
         Type startupType,
@@ -72,6 +76,8 @@ public class SwaggerUIIntegrationTests(ITestOutputHelper outputHelper)
 
     [Theory]
     [InlineData(typeof(Basic.Startup), "/index.html", "/swagger-ui.js", "/index.css", "/swagger-ui.css")]
+    [InlineData(typeof(Basic.StartupWithAbsoluteRoutePrefix), "/abs/index.html", "/abs/swagger-ui.js", "/abs/index.css", "/abs/swagger-ui.css")]
+    [InlineData(typeof(Basic.StartupWithRelativeRoutePrefix), "/rel/index.html", "/rel/swagger-ui.js", "/rel/index.css", "/rel/swagger-ui.css")]
     [InlineData(typeof(CustomUIConfig.Startup), "/swagger/index.html", "/swagger/swagger-ui.js", "swagger/index.css", "/swagger/swagger-ui.css")]
     public async Task IndexUrl_ReturnsEmbeddedVersionOfTheSwaggerUI(
         Type startupType,

--- a/test/WebSites/Basic/StartupBase.cs
+++ b/test/WebSites/Basic/StartupBase.cs
@@ -1,0 +1,88 @@
+using System.Globalization;
+using System.Reflection;
+using Basic.Swagger;
+using Microsoft.AspNetCore.Localization;
+using Microsoft.OpenApi;
+
+namespace Basic;
+
+public class StartupBase
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddControllers();
+
+        services.AddSwaggerGen(c =>
+        {
+            c.SwaggerDoc("v1",
+                new OpenApiInfo
+                {
+                    Title = "Test API V1",
+                    Version = "v1",
+                    Description = "A sample API for testing Swashbuckle",
+                    TermsOfService = new Uri("http://tempuri.org/terms")
+                }
+            );
+
+            c.RequestBodyFilter<AssignRequestBodyVendorExtensions>();
+
+            c.OperationFilter<AssignOperationVendorExtensions>();
+
+            c.SchemaFilter<ExamplesSchemaFilter>();
+
+            c.DescribeAllParametersInCamelCase();
+
+            c.UseOneOfForPolymorphism();
+            c.UseAllOfForInheritance();
+
+            c.SelectDiscriminatorNameUsing((baseType) => "TypeName");
+            c.SelectDiscriminatorValueUsing((subType) => subType.Name);
+
+            c.IncludeXmlComments(Assembly.GetExecutingAssembly());
+
+            c.EnableAnnotations();
+        });
+    }
+
+    public virtual void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+    {
+        if (env.IsDevelopment())
+        {
+            app.UseDeveloperExceptionPage();
+        }
+
+        app.UseRouting();
+
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapControllers();
+
+            // Expose Swagger/OpenAPI JSON in different formats
+            endpoints.MapSwagger("swagger/{documentName}/swagger.json");
+            endpoints.MapSwagger("swagger/{documentName}/swaggerv2.json", c =>
+            {
+                c.OpenApiVersion = OpenApiSpecVersion.OpenApi2_0;
+            });
+            endpoints.MapSwagger("swagger/{documentName}/swaggerv3_1.json", c =>
+            {
+                c.OpenApiVersion = OpenApiSpecVersion.OpenApi3_1;
+            });
+        });
+
+        var supportedCultures = new[]
+        {
+            new CultureInfo("en-US"),
+            new CultureInfo("fr"),
+            new CultureInfo("sv-SE"),
+        };
+
+        app.UseRequestLocalization(new RequestLocalizationOptions
+        {
+            DefaultRequestCulture = new RequestCulture("en-US"),
+            // Formatting numbers, dates, etc.
+            SupportedCultures = supportedCultures,
+            // UI strings that we have localized.
+            SupportedUICultures = supportedCultures
+        });
+    }
+}

--- a/test/WebSites/Basic/StartupWithAbsoluteRoutePrefix.cs
+++ b/test/WebSites/Basic/StartupWithAbsoluteRoutePrefix.cs
@@ -1,20 +1,13 @@
-using System.Globalization;
-using System.Reflection;
-using Basic.Swagger;
-using Microsoft.AspNetCore.Localization;
-using Microsoft.OpenApi;
-
 namespace Basic;
 
-public class Startup : StartupBase
+public class StartupWithAbsoluteRoutePrefix : StartupBase
 {
-
     public override void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     {
         base.Configure(app, env);
         app.UseSwaggerUI(c =>
         {
-            c.RoutePrefix = ""; // serve the UI at root
+            c.RoutePrefix = "/abs"; // serve the UI under an absolute prefix
             c.SwaggerEndpoint("/swagger/v1/swagger.json", "V1 Docs");
         });
     }

--- a/test/WebSites/Basic/StartupWithRelativeRoutePrefix.cs
+++ b/test/WebSites/Basic/StartupWithRelativeRoutePrefix.cs
@@ -1,20 +1,13 @@
-using System.Globalization;
-using System.Reflection;
-using Basic.Swagger;
-using Microsoft.AspNetCore.Localization;
-using Microsoft.OpenApi;
-
 namespace Basic;
 
-public class Startup : StartupBase
+public class StartupWithRelativeRoutePrefix : StartupBase
 {
-
     public override void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     {
         base.Configure(app, env);
         app.UseSwaggerUI(c =>
         {
-            c.RoutePrefix = ""; // serve the UI at root
+            c.RoutePrefix = "rel"; // serve the UI under a relative prefix
             c.SwaggerEndpoint("/swagger/v1/swagger.json", "V1 Docs");
         });
     }


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

Minor bug encountered in #4083

## Details on the issue fix or feature implementation

This change modifies the regular expression used in `SwaggerUIMiddleware.cs` (line 58) to allow matching when `_options.RoutePrefix` contains a leading `/`. A similar regular expression is used on line 46 to match the route and return a redirect to `index.html`, but it already handles the presence or absence of a leading `/`, so this change simply brings them more in sync.