### PR TITLE
Adding HTTP new QUERY method support

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -1093,6 +1093,11 @@ public class SwaggerGenerator(
         ["HEAD"] = HttpMethod.Head,
         ["PATCH"] = HttpMethod.Patch,
         ["TRACE"] = HttpMethod.Trace,
+#if NET10_0_OR_GREATER
+        ["QUERY"] = HttpMethod.Query,
+#else
+        ["QUERY"] = new HttpMethod("QUERY"),
+#endif
     };
 
     private static readonly Dictionary<BindingSource, ParameterLocation> ParameterLocationMap = new()

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-﻿
+Swashbuckle.AspNetCore.SwaggerUI.SubmitMethod.Query = 8 -> Swashbuckle.AspNetCore.SwaggerUI.SubmitMethod

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SubmitMethod.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SubmitMethod.cs
@@ -10,4 +10,5 @@ public enum SubmitMethod
     Head,
     Patch,
     Trace,
+    Query,
 }

--- a/test/Swashbuckle.AspNetCore.ApiTesting.Test/RequestValidatorTests.cs
+++ b/test/Swashbuckle.AspNetCore.ApiTesting.Test/RequestValidatorTests.cs
@@ -31,6 +31,8 @@ public class RequestValidatorTests
     [Theory]
     [InlineData("POST", "GET", "Request method 'POST' does not match specified operation type 'GET'")]
     [InlineData("GET", "GET", null)]
+    [InlineData("GET", "QUERY", "Request method 'GET' does not match specified operation type 'QUERY'")]
+    [InlineData("QUERY", "QUERY", null)]
     public void Validate_ThrowsException_IfMethodDoesNotMatchOperationType(
         string methodString,
         string operationType,

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -2005,6 +2005,32 @@ public class SwaggerGeneratorTests
         Assert.Equal($"The \"{httpMethod}\" HTTP method is not supported.", exception.Message);
     }
 
+    [Theory]
+    [InlineData("query")]
+    [InlineData("QUERY")]
+    public void GetSwagger_GeneratesSwaggerDocument_ForQueryHttpMethod(string httpMethod)
+    {
+        var subject = Subject(
+            apiDescriptions:
+            [
+                ApiDescriptionFactory.Create<FakeController>(
+                    c => nameof(c.ActionWithNoParameters), groupName: "v1", httpMethod: httpMethod, relativePath: "resource"),
+            ],
+            options: new SwaggerGeneratorOptions
+            {
+                SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                {
+                    ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" }
+                }
+            }
+        );
+
+        var document = subject.GetSwagger("v1");
+
+        var operation = Assert.Single(document.Paths["/resource"].Operations);
+        Assert.Equal(new HttpMethod("QUERY"), operation.Key);
+    }
+
     [Fact]
     public void GetSwagger_Throws_Exception_When_FromForm_Attribute_Used_With_IFormFile()
     {


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

Adds support for the HTTP `QUERY` method (the emerging IETF-draft method for
safe, idempotent requests that carry a request body). Today, an action routed
to `QUERY` causes Swagger generation to throw
`The "QUERY" HTTP method is not supported.`, so the endpoint can't be
documented at all.

This aligns with the project goal of describing *actual* API behavior: if a
route is bound to `QUERY`, that operation should appear in the generated
OpenAPI document.

<!-- No existing issue found; happy to open one first if the maintainers prefer. -->

## Details on the issue fix or feature implementation

- **SwaggerGen** — added `"QUERY"` to `OperationTypeMap` in `SwaggerGenerator`,
  so `QUERY`-bound actions are emitted as a `query` path-item operation. Uses
  `HttpMethod.Query` on `net10.0` (where the property exists) and falls back to
  `new HttpMethod("QUERY")` on `net8.0`/`net9.0` via a `NET10_0_OR_GREATER`
  conditional.
- **SwaggerUI** — added `Query` to the `SubmitMethod` enum so the generated
  `supportedSubmitMethods` config can include `"query"` (enabling "Try it out"
  for `QUERY` operations). Public API surface recorded in
  `PublicAPI.Unshipped.txt`.
- **Tests** — `SwaggerGeneratorTests` covers `QUERY` operation generation
  (both `"query"`/`"QUERY"` casing); `RequestValidatorTests` covers `QUERY`
  request validation. Added tests pass locally.

