### PR TITLE
Fix review issues for caching and encoding

### DIFF
--- a/src/Shared/EmbeddedResourceProvider.cs
+++ b/src/Shared/EmbeddedResourceProvider.cs
@@ -19,6 +19,7 @@ internal sealed class EmbeddedResourceProvider(
 {
     private const string GZipEncodingValue = "gzip";
     private static readonly StringValues GZipEncodingHeader = new(GZipEncodingValue);
+    private static readonly StringValues VaryAcceptEncodingHeader = new(HeaderNames.AcceptEncoding);
 
     private readonly Assembly _assembly = assembly;
     private readonly StringValues _cacheControl = GetCacheControlHeader(cacheLifetime);
@@ -32,33 +33,36 @@ internal sealed class EmbeddedResourceProvider(
 
     public async Task<bool> TryRespondWithFileAsync(HttpContext httpContext)
     {
-        var path = httpContext.Request.Path.Value ?? string.Empty;
-        if (!path.StartsWith(_pathPrefix, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        path = path[_pathPrefix.Length..].Replace('/', '.');
-
-        if (!_resourceCache.TryGetValue(path, out var cacheEntry))
+        if (!TryGetResourcePath(httpContext.Request.Path.Value, out var resourcePath) ||
+            !_resourceCache.TryGetValue(resourcePath, out var cacheEntry))
         {
             return false;
         }
 
         var contentType = GetContentType(cacheEntry);
-        var (etag, supportsCompression) = GetContentProperties(cacheEntry);
+        var content = GetContent(cacheEntry);
+
+        // The representation is selected before the conditional request is evaluated: the entity tag
+        // has to identify the representation that would actually be served, otherwise a client or a
+        // cache holding one representation is told that a different one has not been modified.
+        var serveCompressed = content.SupportsCompression && IsGZipAccepted(httpContext.Request);
+
+        var etag = serveCompressed ? content.CompressedETag : content.DecompressedETag;
+        var body = serveCompressed ? content.Compressed : content.Decompressed;
 
         var response = httpContext.Response;
-        var ifNoneMatch = httpContext.Request.Headers.IfNoneMatch;
+        var responseHeaders = response.Headers;
 
-        if (ifNoneMatch == etag)
+        // The response is negotiated on Accept-Encoding, so a cache must not share it between
+        // clients that sent different values for that header.
+        responseHeaders.Vary = VaryAcceptEncodingHeader;
+        responseHeaders.ETag = etag;
+
+        if (httpContext.Request.Headers.IfNoneMatch == etag)
         {
             response.StatusCode = StatusCodes.Status304NotModified;
             return true;
         }
-
-        var serveCompressed = supportsCompression && IsGZipAccepted(httpContext.Request);
-        var responseHeaders = response.Headers;
 
         if (serveCompressed)
         {
@@ -66,22 +70,35 @@ internal sealed class EmbeddedResourceProvider(
         }
 
         responseHeaders.CacheControl = _cacheControl;
-        responseHeaders.ContentLength = serveCompressed ? cacheEntry.CompressedLength : cacheEntry.DecompressedLength;
+        responseHeaders.ContentLength = body.Length;
         responseHeaders.ContentType = contentType;
-        responseHeaders.ETag = etag;
-
-        ReadOnlyMemory<byte> body;
-
-        if (serveCompressed)
-        {
-            body = cacheEntry.Compressed;
-        }
-        else
-        {
-            body = cacheEntry.Decompressed;
-        }
 
         await response.BodyWriter.WriteAsync(body, httpContext.RequestAborted);
+
+        return true;
+    }
+
+    private bool TryGetResourcePath(string? requestPath, out string resourcePath)
+    {
+        resourcePath = string.Empty;
+
+        var path = requestPath ?? string.Empty;
+
+        if (!path.StartsWith(_pathPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var relativePath = path[_pathPrefix.Length..];
+
+        // The prefix has to be followed by a segment boundary, otherwise a path such as
+        // "/swaggerXfoo.css" is treated as though it were below the configured route prefix.
+        if (relativePath.Length is 0 || relativePath[0] is not '/')
+        {
+            return false;
+        }
+
+        resourcePath = relativePath.Replace('/', '.');
 
         return true;
     }
@@ -137,45 +154,54 @@ internal sealed class EmbeddedResourceProvider(
                ? contentType
                : "application/octet-stream");
 
-    private (string ETag, bool Compressed) GetContentProperties(ResourceEntry entry)
+    private ResourceContent GetContent(ResourceEntry entry)
     {
-        if (entry.ETag == null)
+        // Published as a single reference so that a concurrent reader either sees nothing at all or
+        // sees a fully initialized value, rather than a partially populated set of fields.
+        if (Volatile.Read(ref entry.Content) is { } existing)
         {
-            using var compressed = GetResource(entry);
-            using var decompressed = new MemoryStream((int)compressed.Length * 2);
-            using var gzip = new GZipStream(compressed, CompressionMode.Decompress);
-
-            gzip.CopyTo(decompressed);
-
-            entry.Decompressed = decompressed.ToArray();
-
-            // Some embedded resources may already be compressed or compress worse than the original
-            entry.SupportsCompression = compressed.Length < decompressed.Length;
-
-            byte[] content;
-
-            if (entry.SupportsCompression)
-            {
-                compressed.Seek(0, SeekOrigin.Begin);
-
-                using var memoryStream = new MemoryStream((int)compressed.Length);
-                compressed.CopyTo(memoryStream);
-
-                content = entry.Compressed = memoryStream.ToArray();
-            }
-            else
-            {
-                content = entry.Decompressed;
-            }
-
-            var hash = SHA1.HashData(content);
-
-            entry.CompressedLength = compressed.Length;
-            entry.DecompressedLength = decompressed.Length;
-            entry.ETag = $"\"{Convert.ToBase64String(hash)}\"";
+            return existing;
         }
 
-        return (entry.ETag, entry.SupportsCompression);
+        using var compressed = GetResource(entry);
+        using var decompressed = new MemoryStream((int)compressed.Length * 2);
+
+        using (var gzip = new GZipStream(compressed, CompressionMode.Decompress, leaveOpen: true))
+        {
+            gzip.CopyTo(decompressed);
+        }
+
+        var decompressedBytes = decompressed.ToArray();
+
+        // Some embedded resources may already be compressed or compress worse than the original
+        var supportsCompression = compressed.Length < decompressedBytes.Length;
+
+        byte[]? compressedBytes = null;
+        string? compressedETag = null;
+
+        if (supportsCompression)
+        {
+            compressed.Seek(0, SeekOrigin.Begin);
+
+            using var memoryStream = new MemoryStream((int)compressed.Length);
+            compressed.CopyTo(memoryStream);
+
+            compressedBytes = memoryStream.ToArray();
+            compressedETag = ComputeETag(compressedBytes);
+        }
+
+        var content = new ResourceContent(
+            decompressedBytes,
+            compressedBytes,
+            ComputeETag(decompressedBytes),
+            compressedETag,
+            supportsCompression);
+
+        Volatile.Write(ref entry.Content, content);
+
+        return content;
+
+        static string ComputeETag(byte[] content) => $"\"{Convert.ToBase64String(SHA1.HashData(content))}\"";
     }
 
     private Stream GetResource(ResourceEntry entry)
@@ -183,20 +209,28 @@ internal sealed class EmbeddedResourceProvider(
 
     private sealed class ResourceEntry(string resourceName)
     {
-        public long? CompressedLength { get; set; }
+        public ResourceContent? Content;
 
         public string? ContentType { get; set; }
 
-        public long? DecompressedLength { get; set; }
-
-        public string? ETag { get; set; }
-
         public string ResourceName { get; } = resourceName;
+    }
 
-        public bool SupportsCompression { get; set; }
+    private sealed class ResourceContent(
+        byte[] decompressed,
+        byte[]? compressed,
+        string decompressedETag,
+        string? compressedETag,
+        bool supportsCompression)
+    {
+        public byte[] Decompressed { get; } = decompressed;
 
-        public byte[]? Compressed { get; set; }
+        public byte[] Compressed { get; } = compressed ?? decompressed;
 
-        public byte[]? Decompressed { get; set; }
+        public string DecompressedETag { get; } = decompressedETag;
+
+        public string CompressedETag { get; } = compressedETag ?? decompressedETag;
+
+        public bool SupportsCompression { get; } = supportsCompression;
     }
 }

--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Http;
 
 namespace Swashbuckle.AspNetCore.ReDoc;
 
-internal sealed class ReDocMiddleware
+internal sealed partial class ReDocMiddleware
 {
     private static readonly HashSet<string> AllowedHttpMethods = new(StringComparer.OrdinalIgnoreCase) { HttpMethods.Get, HttpMethods.Head };
     private static readonly string ReDocVersion = GetReDocVersion();
@@ -55,19 +55,21 @@ internal sealed class ReDocMiddleware
                 return;
             }
 
-            var match = Regex.Match(path, $"^/{Regex.Escape(_options.RoutePrefix)}/?(index.(html|css|js))$", RegexOptions.IgnoreCase);
+            var match = Regex.Match(path, $@"^/{Regex.Escape(_options.RoutePrefix)}/?(index\.(html|css|js))$", RegexOptions.IgnoreCase);
 
             if (match.Success)
             {
                 await RespondWithFile(httpContext, match.Groups[1].Value);
                 return;
             }
+
+            if (await _resourceProvider.TryRespondWithFileAsync(httpContext))
+            {
+                return;
+            }
         }
 
-        if (!await _resourceProvider.TryRespondWithFileAsync(httpContext))
-        {
-            await _next(httpContext);
-        }
+        await _next(httpContext);
     }
 
     private static string GetReDocVersion()
@@ -109,6 +111,9 @@ internal sealed class ReDocMiddleware
         response.Headers.Location = location;
     }
 
+    [GeneratedRegex(@"%\([A-Za-z]+\)")]
+    private static partial Regex IndexArgumentPattern();
+
     private async Task RespondWithFile(HttpContext context, string fileName)
     {
         var cancellationToken = context.RequestAborted;
@@ -118,22 +123,23 @@ internal sealed class ReDocMiddleware
 
         Stream stream;
 
-        switch (fileName)
+        // The route is matched case-insensitively, so the file must be selected the same way,
+        // otherwise a request for "INDEX.JS" is answered with the HTML document instead. The
+        // canonical name is used to look the resource up, as manifest names are case-sensitive.
+        if (string.Equals(fileName, "index.css", StringComparison.OrdinalIgnoreCase))
         {
-            case "index.css":
-                response.ContentType = "text/css";
-                stream = ResourceHelper.GetEmbeddedResource(fileName);
-                break;
-
-            case "index.js":
-                response.ContentType = "application/javascript;charset=utf-8";
-                stream = ResourceHelper.GetEmbeddedResource(fileName);
-                break;
-
-            default:
-                response.ContentType = "text/html;charset=utf-8";
-                stream = _options.IndexStream();
-                break;
+            response.ContentType = "text/css";
+            stream = ResourceHelper.GetEmbeddedResource("index.css");
+        }
+        else if (string.Equals(fileName, "index.js", StringComparison.OrdinalIgnoreCase))
+        {
+            response.ContentType = "application/javascript;charset=utf-8";
+            stream = ResourceHelper.GetEmbeddedResource("index.js");
+        }
+        else
+        {
+            response.ContentType = "text/html;charset=utf-8";
+            stream = _options.IndexStream();
         }
 
         using (stream)
@@ -146,14 +152,15 @@ internal sealed class ReDocMiddleware
                 template = await reader.ReadToEndAsync(cancellationToken);
             }
 
-            var content = new StringBuilder(template);
+            var arguments = GetIndexArguments();
 
-            foreach (var entry in GetIndexArguments())
-            {
-                content.Replace(entry.Key, entry.Value);
-            }
+            // Single pass over the original template: replacement values are never re-scanned for
+            // further placeholder matches, so a value that happens to look like another placeholder
+            // token cannot be substituted a second time.
+            var text = IndexArgumentPattern().Replace(
+                template,
+                (match) => arguments.TryGetValue(match.Value, out var value) ? value : match.Value);
 
-            var text = content.ToString();
             var etag = GetETag(text);
 
             var ifNoneMatch = context.Request.Headers.IfNoneMatch;
@@ -197,19 +204,22 @@ internal sealed class ReDocMiddleware
     private Dictionary<string, string> GetIndexArguments()
     {
         string configObject = null;
+        string specUrl = null;
 
         if (_jsonSerializerOptions is null)
         {
             configObject = JsonSerializer.Serialize(_options.ConfigObject, ReDocOptionsJsonContext.Default.ConfigObject);
+            specUrl = JsonSerializer.Serialize(_options.SpecUrl ?? string.Empty, ReDocOptionsJsonContext.Default.String);
         }
 
         configObject ??= JsonSerializer.Serialize(_options.ConfigObject, _jsonSerializerOptions);
+        specUrl ??= JsonSerializer.Serialize(_options.SpecUrl ?? string.Empty, _jsonSerializerOptions);
 
         return new Dictionary<string, string>()
         {
-            { "%(DocumentTitle)", _options.DocumentTitle },
+            { "%(DocumentTitle)", System.Net.WebUtility.HtmlEncode(_options.DocumentTitle) },
             { "%(HeadContent)", _options.HeadContent },
-            { "%(SpecUrl)", _options.SpecUrl },
+            { "%(SpecUrl)", specUrl },
             { "%(ConfigObject)", configObject },
         };
     }

--- a/src/Swashbuckle.AspNetCore.ReDoc/index.js
+++ b/src/Swashbuckle.AspNetCore.ReDoc/index.js
@@ -1,1 +1,1 @@
-Redoc.init('%(SpecUrl)', JSON.parse('%(ConfigObject)'), document.getElementById('redoc-container'));
+Redoc.init(%(SpecUrl), %(ConfigObject), document.getElementById('redoc-container'));

--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
@@ -47,9 +47,7 @@ internal sealed class SwaggerMiddleware
 
         try
         {
-            var basePath = httpContext.Request.PathBase.HasValue
-                ? httpContext.Request.PathBase.Value
-                : null;
+            var basePath = GetBasePath(httpContext.Request);
 
             OpenApiDocument swagger;
             var asyncSwaggerProvider = httpContext.RequestServices.GetService<IAsyncSwaggerProvider>();
@@ -75,6 +73,14 @@ internal sealed class SwaggerMiddleware
                 filter(swagger, httpContext.Request);
             }
 
+            if (basePath is not null)
+            {
+                // The document embeds the request's path base, which is not necessarily fixed by the
+                // application (see GetBasePath), so the response is not safe for a shared cache to
+                // store and replay to a client whose request had a different path base.
+                httpContext.Response.GetTypedHeaders().CacheControl = new() { Private = true };
+            }
+
             var isHeadRequest = HttpMethods.IsHead(httpContext.Request.Method);
 
             if (extension is ".yaml" or ".yml")
@@ -90,6 +96,38 @@ internal sealed class SwaggerMiddleware
         {
             httpContext.Response.StatusCode = 404;
         }
+    }
+
+    /// <summary>
+    /// Gets the base path to use for the document's server URL, or <see langword="null"/> if there is none.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The value becomes <c>servers[].url</c>, which consumers such as the Swagger UI resolve as a URI
+    /// reference to determine where to send requests. <see cref="HttpRequest.PathBase"/> is only ever a
+    /// path, but a value beginning <c>//</c> or <c>/\</c> is a network-path reference that a browser
+    /// resolves against a different authority, so such a value is discarded rather than emitted.
+    /// </para>
+    /// <para>
+    /// This matters because the path base is not necessarily fixed by the application: it is derived
+    /// from the request when <c>X-Forwarded-Prefix</c> is honoured by the forwarded headers middleware.
+    /// </para>
+    /// </remarks>
+    private static string GetBasePath(HttpRequest request)
+    {
+        if (!request.PathBase.HasValue)
+        {
+            return null;
+        }
+
+        var basePath = request.PathBase.Value;
+
+        if (basePath.Length > 1 && basePath[0] is '/' && basePath[1] is '/' or '\\')
+        {
+            return null;
+        }
+
+        return basePath;
     }
 
     private bool RequestingSwaggerDocument(HttpRequest request, out string documentName, out string extension)

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -55,7 +55,7 @@ internal sealed partial class SwaggerUIMiddleware
                 return;
             }
 
-            var match = Regex.Match(path, $"^/?{Regex.Escape(_options.RoutePrefix)}/?(index.(html|js))$", RegexOptions.IgnoreCase);
+            var match = Regex.Match(path, $@"^/?{Regex.Escape(_options.RoutePrefix)}/?(index\.(html|js))$", RegexOptions.IgnoreCase);
 
             if (match.Success)
             {
@@ -65,19 +65,21 @@ internal sealed partial class SwaggerUIMiddleware
 
             if (_options.ExposeSwaggerDocumentUrlsRoute)
             {
-                var pattern = $"^/?{Regex.Escape(_options.RoutePrefix)}/{_options.SwaggerDocumentUrlsPath}/?$";
+                var pattern = $"^/?{Regex.Escape(_options.RoutePrefix)}/{Regex.Escape(_options.SwaggerDocumentUrlsPath)}/?$";
                 if (Regex.IsMatch(path, pattern, RegexOptions.IgnoreCase))
                 {
                     await RespondWithDocumentUrls(httpContext);
                     return;
                 }
             }
+
+            if (await _resourceProvider.TryRespondWithFileAsync(httpContext))
+            {
+                return;
+            }
         }
 
-        if (!await _resourceProvider.TryRespondWithFileAsync(httpContext))
-        {
-            await _next(httpContext);
-        }
+        await _next(httpContext);
     }
 
     private static string GetSwaggerUIVersion()
@@ -119,6 +121,9 @@ internal sealed partial class SwaggerUIMiddleware
         response.Headers.Location = location;
     }
 
+    [GeneratedRegex(@"%\([A-Za-z]+\)")]
+    private static partial Regex IndexArgumentPattern();
+
     private async Task RespondWithFile(HttpContext context, string fileName)
     {
         var cancellationToken = context.RequestAborted;
@@ -127,10 +132,13 @@ internal sealed partial class SwaggerUIMiddleware
         string contentType;
         Stream stream;
 
-        if (fileName == "index.js")
+        // The route is matched case-insensitively, so the file must be selected the same way,
+        // otherwise a request for "INDEX.JS" is answered with the HTML document instead. The canonical
+        // name is used to look the resource up, as manifest resource names are case-sensitive.
+        if (string.Equals(fileName, "index.js", StringComparison.OrdinalIgnoreCase))
         {
             contentType = "application/javascript;charset=utf-8";
-            stream = ResourceHelper.GetEmbeddedResource(fileName);
+            stream = ResourceHelper.GetEmbeddedResource("index.js");
         }
         else
         {
@@ -148,14 +156,15 @@ internal sealed partial class SwaggerUIMiddleware
                 template = await reader.ReadToEndAsync(cancellationToken);
             }
 
-            var content = new StringBuilder(template);
+            var arguments = GetIndexArguments();
 
-            foreach (var entry in GetIndexArguments())
-            {
-                content.Replace(entry.Key, entry.Value);
-            }
+            // Single pass over the original template: replacement values are never re-scanned for
+            // further placeholder matches, so a value that happens to look like another placeholder
+            // token cannot be substituted a second time.
+            var text = IndexArgumentPattern().Replace(
+                template,
+                (match) => arguments.TryGetValue(match.Value, out var value) ? value : match.Value);
 
-            var text = content.ToString();
             var etag = GetETag(text);
 
             var ifNoneMatch = context.Request.Headers.IfNoneMatch;
@@ -255,7 +264,7 @@ internal sealed partial class SwaggerUIMiddleware
 
         return new Dictionary<string, string>()
         {
-            { "%(DocumentTitle)", _options.DocumentTitle },
+            { "%(DocumentTitle)", System.Net.WebUtility.HtmlEncode(_options.DocumentTitle) },
             { "%(HeadContent)", _options.HeadContent },
             { "%(StylesPath)", _options.StylesPath },
             { "%(ScriptBundlePath)", _options.ScriptBundlePath },

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/index.js
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/index.js
@@ -28,8 +28,10 @@ function parseFunction(str) {
 }
 
 window.onload = function () {
-    var configObject = JSON.parse('%(ConfigObject)');
-    var oauthConfigObject = JSON.parse('%(OAuthConfigObject)');
+    // The serialized JSON is emitted as a JavaScript object literal rather than being spliced into a
+    // quoted string, so it cannot terminate a string literal regardless of how it was encoded.
+    var configObject = %(ConfigObject);
+    var oauthConfigObject = %(OAuthConfigObject);
 
     // Workaround for https://github.com/swagger-api/swagger-ui/issues/5945
     configObject.urls.forEach(function (item) {
@@ -51,7 +53,7 @@ window.onload = function () {
     configObject.layout = "StandaloneLayout";
 
     // Parse and add interceptor functions
-    var interceptors = JSON.parse('%(Interceptors)');
+    var interceptors = %(Interceptors);
     if (interceptors.RequestInterceptorFunction)
         configObject.requestInterceptor = parseFunction(interceptors.RequestInterceptorFunction);
     if (interceptors.ResponseInterceptorFunction)

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
@@ -2,6 +2,8 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
+using System.Text.Encodings.Web;
+using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Swashbuckle.AspNetCore.ReDoc;
@@ -348,5 +350,87 @@ public class ReDocIntegrationTests(ITestOutputHelper outputHelper)
         Assert.Equal(TimeSpan.Zero, response.Headers.CacheControl.MaxAge);
 
         Assert.Equal(response.Content.Headers.ContentLength, actual.Length);
+    }
+
+    [Fact]
+    public async Task ReDocMiddleware_Encodes_SpecUrl()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        const string Payload = "x',alert(1),'y";
+
+        using var server = TestSite.CreateServer((app) => app.UseReDoc((options) => options.SpecUrl = Payload));
+        using var client = server.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync("/api-docs/index.js", cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        outputHelper.WriteLine(body);
+
+        Assert.DoesNotContain(Payload, body);
+        Assert.DoesNotContain("Redoc.init('x',alert(1),'y'", body);
+
+        Assert.Contains("Redoc.init(\"x\\u0027,alert(1),\\u0027y\"", body);
+    }
+
+    [Fact]
+    public async Task ReDocMiddleware_SpecUrl_Stays_Encoded_With_The_Relaxed_Json_Encoder()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseReDoc((options) =>
+        {
+            options.SpecUrl = "x\",alert(1),\"y";
+            options.JsonSerializerOptions = new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+        }));
+
+        using var client = server.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync("/api-docs/index.js", cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        outputHelper.WriteLine(body);
+
+        Assert.Contains(@"Redoc.init(""x\"",alert(1),\""y""", body);
+    }
+
+    [Fact]
+    public async Task ReDocMiddleware_ConfigObject_Is_Not_Spliced_Into_A_String_Literal()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseReDoc((options) =>
+        {
+            options.ConfigObject.AdditionalItems["theme"] = "x');alert(1);//";
+            options.JsonSerializerOptions = new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+        }));
+
+        using var client = server.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync("/api-docs/index.js", cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        outputHelper.WriteLine(body);
+
+        Assert.DoesNotContain("JSON.parse('", body);
+
+        using var config = JsonDocument.Parse(body[body.IndexOf('{')..(body.LastIndexOf('}') + 1)]);
+
+        Assert.Equal("x');alert(1);//", config.RootElement.GetProperty("theme").GetString());
     }
 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerIntegrationTests.cs
@@ -3,6 +3,11 @@ using System.Net;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi;
+using Swashbuckle.AspNetCore.SwaggerGen;
 using ReDocApp = ReDoc;
 
 namespace Swashbuckle.AspNetCore.IntegrationTests;
@@ -224,5 +229,157 @@ public class SwaggerIntegrationTests(ITestOutputHelper outputHelper)
         Assert.NotNull(diagnostic);
         Assert.Empty(diagnostic.Errors);
         Assert.Empty(diagnostic.Warnings);
+    }
+
+    [Theory]
+    [InlineData("//evil.example.com")]
+    [InlineData("/\\evil.example.com")]
+    public async Task SwaggerMiddleware_Discards_A_Path_Base_That_Is_Not_Same_Origin(string forwardedPrefix)
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) =>
+        {
+            app.UseForwardedHeaders(new() { ForwardedHeaders = ForwardedHeaders.XForwardedPrefix });
+            app.UseSwagger();
+        });
+
+        using var client = server.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/swagger/v1/swagger.json");
+        request.Headers.TryAddWithoutValidation("X-Forwarded-Prefix", forwardedPrefix);
+
+        // Act
+        using var response = await client.SendAsync(request, cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        outputHelper.WriteLine(json);
+
+        using var document = JsonDocument.Parse(json);
+
+        Assert.False(document.RootElement.TryGetProperty("servers", out var servers), $"servers was emitted as {servers}.");
+        Assert.DoesNotContain("evil.example.com", json);
+    }
+
+    [Theory]
+    [InlineData("/api")]
+    [InlineData("/some/nested/prefix")]
+    public async Task SwaggerMiddleware_Still_Emits_A_Same_Origin_Path_Base(string forwardedPrefix)
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) =>
+        {
+            app.UseForwardedHeaders(new() { ForwardedHeaders = ForwardedHeaders.XForwardedPrefix });
+            app.UseSwagger();
+        });
+
+        using var client = server.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/swagger/v1/swagger.json");
+        request.Headers.TryAddWithoutValidation("X-Forwarded-Prefix", forwardedPrefix);
+
+        // Act
+        using var response = await client.SendAsync(request, cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        outputHelper.WriteLine(json);
+
+        using var document = JsonDocument.Parse(json);
+
+        var serverUrl = document.RootElement
+            .GetProperty("servers")[0]
+            .GetProperty("url")
+            .GetString();
+
+        Assert.Equal(forwardedPrefix, serverUrl);
+
+        var documentUrl = new Uri("https://victim.example.org/swagger/v1/swagger.json");
+        var resolved = new Uri(documentUrl, serverUrl);
+
+        Assert.Equal(documentUrl.Host, resolved.Host);
+    }
+
+    [Fact]
+    public async Task SwaggerMiddleware_Marks_A_Request_Derived_Document_As_Private()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) =>
+        {
+            app.UseForwardedHeaders(new() { ForwardedHeaders = ForwardedHeaders.XForwardedPrefix });
+            app.UseSwagger();
+        });
+
+        using var client = server.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/swagger/v1/swagger.json");
+        request.Headers.TryAddWithoutValidation("X-Forwarded-Prefix", "/api");
+
+        // Act
+        using var response = await client.SendAsync(request, cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        Assert.NotNull(response.Headers.CacheControl);
+        Assert.True(response.Headers.CacheControl.Private);
+    }
+
+    [Fact]
+    public async Task SwaggerMiddleware_Leaves_Caching_Alone_When_There_Is_No_Path_Base()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseSwagger());
+        using var client = server.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync("/swagger/v1/swagger.json", cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Null(response.Headers.CacheControl);
+    }
+
+    [Fact]
+    public async Task SwaggerMiddleware_Regenerates_The_Document_For_Every_Request()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer(
+            (app) => app.UseSwagger(),
+            (services) => services.AddSwaggerGen((options) => options.DocumentFilter<CountingDocumentFilter>()));
+
+        using var client = server.CreateClient();
+
+        CountingDocumentFilter.Invocations = 0;
+
+        // Act
+        for (int i = 0; i < 5; i++)
+        {
+            using var response = await client.GetAsync("/swagger/v1/swagger.json", cancellationToken);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        // Assert
+        outputHelper.WriteLine($"The document was generated {CountingDocumentFilter.Invocations} times for 5 requests.");
+        Assert.Equal(5, CountingDocumentFilter.Invocations);
+    }
+
+    private sealed class CountingDocumentFilter : IDocumentFilter
+    {
+        public static int Invocations;
+
+        public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+            => Interlocked.Increment(ref Invocations);
     }
 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -1,12 +1,16 @@
 ﻿using System.IO.Compression;
 using System.Net;
 using System.Security.Cryptography;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
 
 namespace Swashbuckle.AspNetCore.IntegrationTests;
 
 [Collection("TestSite")]
 public class SwaggerUIIntegrationTests(ITestOutputHelper outputHelper)
 {
+    private const string CssAsset = "/swagger/swagger-ui.css";
     private const string EmptyStringSha256Hash = "2jmj7l5rSw0yVb/vlWAYkK/YBwk=";
 
     public static TheoryData<string, string> SwaggerUIFiles()
@@ -456,5 +460,351 @@ public class SwaggerUIIntegrationTests(ITestOutputHelper outputHelper)
 
         using var stream = await cached.Content.ReadAsStreamAsync(cancellationToken);
         Assert.Equal(0, stream.Length);
+    }
+
+    [Fact]
+    public async Task SwaggerUIMiddleware_Uses_A_Distinct_ETag_Per_Representation()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseSwaggerUI());
+        using var client = server.CreateClient();
+
+        using var identityRequest = new HttpRequestMessage(HttpMethod.Get, CssAsset);
+
+        using var gzipRequest = new HttpRequestMessage(HttpMethod.Get, CssAsset);
+        gzipRequest.Headers.AcceptEncoding.Add(new("gzip"));
+
+        // Act
+        using var identity = await client.SendAsync(identityRequest, cancellationToken);
+        using var gzip = await client.SendAsync(gzipRequest, cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, identity.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, gzip.StatusCode);
+
+        var identityBody = await identity.Content.ReadAsByteArrayAsync(cancellationToken);
+        var gzipBody = await gzip.Content.ReadAsByteArrayAsync(cancellationToken);
+
+        outputHelper.WriteLine($"identity: {identityBody.Length} bytes, ETag {identity.Headers.ETag}");
+        outputHelper.WriteLine($"gzip:     {gzipBody.Length} bytes, ETag {gzip.Headers.ETag}");
+
+        Assert.Empty(identity.Content.Headers.ContentEncoding);
+        Assert.Equal(["gzip"], [.. gzip.Content.Headers.ContentEncoding]);
+        Assert.NotEqual(identityBody.Length, gzipBody.Length);
+
+        Assert.NotNull(identity.Headers.ETag);
+        Assert.NotNull(gzip.Headers.ETag);
+        Assert.NotEqual(identity.Headers.ETag, gzip.Headers.ETag);
+
+        Assert.Equal(["Accept-Encoding"], [.. identity.Headers.Vary]);
+        Assert.Equal(["Accept-Encoding"], [.. gzip.Headers.Vary]);
+
+        Assert.Equal($"\"{Convert.ToBase64String(SHA1.HashData(identityBody))}\"", identity.Headers.ETag.ToString());
+        Assert.Equal($"\"{Convert.ToBase64String(SHA1.HashData(gzipBody))}\"", gzip.Headers.ETag.ToString());
+    }
+
+    [Fact]
+    public async Task SwaggerUIMiddleware_Does_Not_Return_NotModified_For_A_Representation_The_Client_Never_Received()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseSwaggerUI());
+        using var client = server.CreateClient();
+
+        using var identity = await client.GetAsync(CssAsset, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, identity.StatusCode);
+        Assert.Empty(identity.Content.Headers.ContentEncoding);
+
+        var etag = identity.Headers.ETag;
+        Assert.NotNull(etag);
+
+        // Act
+        using var request = new HttpRequestMessage(HttpMethod.Get, CssAsset);
+        request.Headers.IfNoneMatch.Add(etag);
+        request.Headers.AcceptEncoding.Add(new("gzip"));
+
+        using var response = await client.SendAsync(request, cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(["gzip"], [.. response.Content.Headers.ContentEncoding]);
+        Assert.NotEqual(etag, response.Headers.ETag);
+    }
+
+    [Fact]
+    public async Task SwaggerUIMiddleware_Returns_NotModified_For_The_Representation_The_Client_Holds()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseSwaggerUI());
+        using var client = server.CreateClient();
+
+        using var firstRequest = new HttpRequestMessage(HttpMethod.Get, CssAsset);
+        firstRequest.Headers.AcceptEncoding.Add(new("gzip"));
+
+        using var first = await client.SendAsync(firstRequest, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+        Assert.NotNull(first.Headers.ETag);
+
+        // Act
+        using var request = new HttpRequestMessage(HttpMethod.Get, CssAsset);
+        request.Headers.IfNoneMatch.Add(first.Headers.ETag);
+        request.Headers.AcceptEncoding.Add(new("gzip"));
+
+        using var response = await client.SendAsync(request, cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotModified, response.StatusCode);
+        Assert.Equal(["Accept-Encoding"], [.. response.Headers.Vary]);
+    }
+
+    [Fact]
+    public async Task SwaggerUIMiddleware_DocumentUrlsPath_Is_Treated_As_A_Literal_Path()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseSwaggerUI((options) =>
+        {
+            options.ExposeSwaggerDocumentUrlsRoute = true;
+            options.SwaggerDocumentUrlsPath = ".*";
+        }));
+
+        using var client = server.CreateClient();
+
+        // Act
+        using var shadowed = await client.GetAsync("/swagger/v1/swagger.json", cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, shadowed.StatusCode);
+
+        using var literal = await client.GetAsync("/swagger/.*", cancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, literal.StatusCode);
+        Assert.Equal("application/javascript", literal.Content.Headers.ContentType?.MediaType);
+
+        var body = await literal.Content.ReadAsStringAsync(cancellationToken);
+        outputHelper.WriteLine(body);
+
+        Assert.StartsWith("[", body);
+    }
+
+    [Fact]
+    public async Task SwaggerUIMiddleware_DocumentUrlsPath_Containing_Regex_Metacharacters_Does_Not_Fault()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseSwaggerUI((options) =>
+        {
+            options.ExposeSwaggerDocumentUrlsRoute = true;
+            options.SwaggerDocumentUrlsPath = "urls(";
+        }));
+
+        using var client = server.CreateClient();
+
+        // Act
+        using var unrelated = await client.GetAsync("/some/unrelated/path", cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, unrelated.StatusCode);
+
+        using var literal = await client.GetAsync("/swagger/urls(", cancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, literal.StatusCode);
+        Assert.Equal("application/javascript", literal.Content.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
+    public async Task SwaggerUIMiddleware_Does_Not_Serve_Html_For_Paths_That_Are_Not_index_html()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseSwaggerUI());
+        using var client = server.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync("/swagger/indexXjs", cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("/swagger/index.html", "text/html", "<div id=\"swagger-ui\"></div>")]
+    [InlineData("/swagger/INDEX.HTML", "text/html", "<div id=\"swagger-ui\"></div>")]
+    [InlineData("/swagger/index.js", "application/javascript", "var configObject")]
+    [InlineData("/swagger/INDEX.JS", "application/javascript", "var configObject")]
+    public async Task SwaggerUIMiddleware_Selects_The_File_Case_Insensitively(
+        string requestPath,
+        string expectedMediaType,
+        string expectedContent)
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseSwaggerUI());
+        using var client = server.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync(requestPath, cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(expectedMediaType, response.Content.Headers.ContentType?.MediaType);
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        Assert.Contains(expectedContent, body);
+    }
+
+    [Theory]
+    [InlineData("POST")]
+    [InlineData("PUT")]
+    [InlineData("DELETE")]
+    [InlineData("TRACE")]
+    public async Task SwaggerUIMiddleware_Does_Not_Serve_Assets_For_Unsupported_Http_Methods(string method)
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseSwaggerUI());
+        using var client = server.CreateClient();
+
+        using var request = new HttpRequestMessage(new(method), CssAsset);
+
+        // Act
+        using var response = await client.SendAsync(request, cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("HEAD")]
+    public async Task SwaggerUIMiddleware_Still_Serves_Assets_For_Supported_Http_Methods(string method)
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseSwaggerUI());
+        using var client = server.CreateClient();
+
+        using var request = new HttpRequestMessage(new(method), CssAsset);
+
+        // Act
+        using var response = await client.SendAsync(request, cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("text/css", response.Content.Headers.ContentType?.MediaType);
+        Assert.True(response.Content.Headers.ContentLength > 0);
+    }
+
+    [Theory]
+    [InlineData("/swagger.swagger-ui.css")]
+    [InlineData("/swaggerXswagger-ui.css")]
+    public async Task SwaggerUIMiddleware_Requires_A_Segment_Boundary_After_The_Route_Prefix(string requestPath)
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseSwaggerUI());
+        using var client = server.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync(requestPath, cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("swagger")]
+    [InlineData("a/nested/prefix")]
+    public async Task SwaggerUIMiddleware_Still_Serves_Assets_Below_The_Route_Prefix(string routePrefix)
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseSwaggerUI((options) => options.RoutePrefix = routePrefix));
+        using var client = server.CreateClient();
+
+        var requestPath = string.IsNullOrEmpty(routePrefix) ? "/swagger-ui.css" : $"/{routePrefix}/swagger-ui.css";
+
+        // Act
+        using var response = await client.GetAsync(requestPath, cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("text/css", response.Content.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
+    public async Task SwaggerUIMiddleware_Encodes_DocumentTitle()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseSwaggerUI(
+            (options) => options.DocumentTitle = "</title><script>alert(1)</script>"));
+
+        using var client = server.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync("/swagger/index.html", cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        outputHelper.WriteLine(body);
+
+        Assert.DoesNotContain("<title></title><script>alert(1)</script></title>", body);
+        Assert.Contains("<title>&lt;/title&gt;&lt;script&gt;alert(1)&lt;/script&gt;</title>", body);
+    }
+
+    [Fact]
+    public async Task SwaggerUIMiddleware_ConfigObject_Is_Not_Spliced_Into_A_String_Literal()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseSwaggerUI((options) =>
+        {
+            options.ConfigObject.Urls = [new() { Url = "v1/swagger.json", Name = "x');alert(1);//" }];
+            options.JsonSerializerOptions = new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+        }));
+
+        using var client = server.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync("/swagger/index.js", cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        const string Prefix = "var configObject =";
+
+        var line = body.Split('\n').First((p) => p.Contains(Prefix));
+        outputHelper.WriteLine(line);
+
+        Assert.DoesNotContain("JSON.parse('", body);
+
+        var json = line[(line.IndexOf(Prefix, StringComparison.Ordinal) + Prefix.Length)..].Trim().TrimEnd(';');
+
+        using var config = JsonDocument.Parse(json);
+
+        Assert.Equal("x');alert(1);//", config.RootElement.GetProperty("urls")[0].GetProperty("name").GetString());
     }
 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/TestSite.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/TestSite.cs
@@ -14,6 +14,30 @@ public class TestSite(Type startupType, ITestOutputHelper outputHelper)
     private IHost _host;
     private TestServer _server;
 
+    public static TestServer CreateServer(
+        Action<IApplicationBuilder> configure,
+        Action<IServiceCollection> configureServices = null)
+    {
+        var builder = new HostBuilder()
+            .ConfigureWebHost((webHost) =>
+            {
+                webHost.UseTestServer();
+                webHost.ConfigureServices((services) =>
+                {
+                    services.AddRouting();
+                    services.AddControllers();
+                    services.AddSwaggerGen();
+                    configureServices?.Invoke(services);
+                });
+                webHost.Configure(configure);
+            });
+
+        var host = builder.Build();
+        host.Start();
+
+        return host.GetTestServer();
+    }
+
     public virtual TestServer BuildServer()
     {
         if (_server is null)


### PR DESCRIPTION
Resolve a number of code correctness issued identified by scanning the repository's code with GitHub Copilot and Claude Code.

- Discard a request path base that a browser resolves to another authority (`//host`, `/\host`) instead of emitting it as `servers[].url`, and mark path-base-derived documents `private` so a shared cache cannot replay one client's prefix to another.
- Use a distinct ETag per content-coding and send `Vary: Accept-Encoding`, so a conditional request is no longer answered `304` for a representation the client never held.
- Escape `SwaggerDocumentUrlsPath` before interpolating it into a regular expression.
- Emit the serialized config as a JavaScript object literal instead of splicing it into `JSON.parse('...')` to ensure things are encoded correctly.
- Escape the `.` in the `index.(html|js)` route patterns, select the file case-insensitively, serve the embedded assets only for GET and HEAD, and require a segment boundary after the route prefix.
