### PR TITLE
NET11 csharp unions schema support

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
@@ -108,6 +108,34 @@ public class JsonSerializerDataContractResolver : ISerializerDataContractResolve
         return JsonSerializer.Serialize(value, type, _serializerOptions);
     }
 
+#if NET11_0_OR_GREATER
+    // Detects C# union types (introduced in .NET 11). System.Text.Json represents a union
+    // transparently (no discriminator) as an "anyOf" of its case types, which the schema
+    // generator mirrors. Returns false for any non-union type or if metadata is unavailable.
+    internal bool TryGetUnionCaseTypes(Type type, out IReadOnlyList<Type> cases)
+    {
+        cases = null;
+
+        System.Text.Json.Serialization.Metadata.JsonTypeInfo typeInfo;
+        try
+        {
+            typeInfo = _serializerOptions.GetTypeInfo(type);
+        }
+        catch
+        {
+            return false;
+        }
+
+        if (typeInfo.Kind != System.Text.Json.Serialization.Metadata.JsonTypeInfoKind.Union)
+        {
+            return false;
+        }
+
+        cases = [.. typeInfo.UnionCases.Select(static c => c.CaseType)];
+        return true;
+    }
+#endif
+
     public bool IsSupportedDictionary(Type type, out Type keyType, out Type valueType)
     {
         if (type.IsConstructedFrom(typeof(IDictionary<,>), out Type constructedType)

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/SchemaGenerator.cs
@@ -23,6 +23,14 @@ public class SchemaGenerator(
         ParameterInfo parameterInfo = null,
         ApiParameterRouteInfo routeInfo = null)
     {
+#if NET11_0_OR_GREATER
+        if (TryGenerateUnionSchema(modelType, schemaRepository, out var unionSchema))
+        {
+            ApplyFilters(unionSchema, modelType, schemaRepository, memberInfo, parameterInfo);
+            return unionSchema;
+        }
+#endif
+
         if (memberInfo != null)
         {
             return GenerateSchemaForMember(modelType, schemaRepository, memberInfo);
@@ -197,6 +205,25 @@ public class SchemaGenerator(
 
         return schema;
     }
+
+#if NET11_0_OR_GREATER
+    private bool TryGenerateUnionSchema(Type modelType, SchemaRepository schemaRepository, out OpenApiSchema schema)
+    {
+        schema = null;
+
+        if (_serializerDataContractResolver is JsonSerializerDataContractResolver stjResolver &&
+            stjResolver.TryGetUnionCaseTypes(modelType, out var cases))
+        {
+            schema = new OpenApiSchema
+            {
+                AnyOf = [.. cases.Select(c => GenerateSchema(c, schemaRepository))],
+            };
+            return true;
+        }
+
+        return false;
+    }
+#endif
 
     private IOpenApiSchema GenerateSchemaForType(Type modelType, SchemaRepository schemaRepository)
     {

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerUnionSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSerializerUnionSchemaGeneratorTests.cs
@@ -1,0 +1,55 @@
+﻿#if NET11_0_OR_GREATER
+#nullable enable
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.OpenApi;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test;
+
+public class JsonSerializerUnionSchemaGeneratorTests
+{
+    private static readonly Action<JsonSerializerOptions> UseReflectionResolver =
+        static o => o.TypeInfoResolver = new DefaultJsonTypeInfoResolver();
+
+    [Fact]
+    public void GenerateSchema_GeneratesAnyOfSchema_ForUnionType()
+    {
+        var schemaRepository = new SchemaRepository();
+
+        var schema = Subject(configureSerializer: UseReflectionResolver).GenerateSchema(typeof(Pet), schemaRepository);
+
+        var concrete = Assert.IsType<OpenApiSchema>(schema);
+        Assert.NotNull(concrete.AnyOf);
+        Assert.Equal(2, concrete.AnyOf.Count);
+
+        var references = concrete.AnyOf.Select(s => Assert.IsType<OpenApiSchemaReference>(s)).ToArray();
+        var referencedIds = references.Select(r => r.Reference.Id).ToArray();
+
+        Assert.Contains(nameof(Cat), referencedIds);
+        Assert.Contains(nameof(Dog), referencedIds);
+
+        // Each case type schema is registered in the repository.
+        Assert.True(schemaRepository.Schemas.ContainsKey(nameof(Cat)));
+        Assert.True(schemaRepository.Schemas.ContainsKey(nameof(Dog)));
+    }
+
+    private static SchemaGenerator Subject(
+        Action<SchemaGeneratorOptions>? configureGenerator = null,
+        Action<JsonSerializerOptions>? configureSerializer = null)
+    {
+        var generatorOptions = new SchemaGeneratorOptions();
+        configureGenerator?.Invoke(generatorOptions);
+
+        var serializerOptions = new JsonSerializerOptions();
+        configureSerializer?.Invoke(serializerOptions);
+
+        return new SchemaGenerator(generatorOptions, new JsonSerializerDataContractResolver(serializerOptions, generatorOptions));
+    }
+
+    public record Cat(string Name, int Lives);
+
+    public record Dog(string Name, bool GoodBoy);
+
+    public union Pet(Cat, Dog);
+}
+#endif

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorUnionTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorUnionTests.cs
@@ -23,8 +23,10 @@ public class SwaggerGeneratorUnionTests
         public Cat GetCat() => throw new NotImplementedException();
     }
 
-    [Fact]
-    public void GetSwagger_EmitsUnionResponseAsAnyOfOfReferences_AndDeduplicatesSharedCaseType()
+    [Theory]
+    [InlineData(OpenApiSpecVersion.OpenApi3_0)]
+    [InlineData(OpenApiSpecVersion.OpenApi3_1)]
+    public void GetSwagger_EmitsUnionResponseAsAnyOfOfReferences_AndDeduplicatesSharedCaseType(OpenApiSpecVersion specVersion)
     {
         // Endpoint 1 returns a union (Pet), endpoint 2 returns one of its cases (Cat) explicitly.
         var petApi = ApiDescriptionFactory.Create<UnionFakeController>(
@@ -83,8 +85,9 @@ public class SwaggerGeneratorUnionTests
         Assert.Equal(1, document.Components.Schemas.Keys.Count(id => id == nameof(Dog)));
         Assert.Equal([nameof(Cat), nameof(Dog)], document.Components.Schemas.Keys.OrderBy(id => id).ToArray());
 
-        // Assert the same properties against the actually-serialized OpenAPI JSON.
-        var json = ToJson(document);
+        // The object-model assertions above are version-independent; the serialized JSON assertions
+        // below hold for both OpenAPI 3.0 and 3.1 (the anyOf/$ref shape is identical across versions).
+        var json = ToJson(document, specVersion);
 
         Assert.Contains("\"$ref\": \"#/components/schemas/Cat\"", json);
         Assert.Contains("\"$ref\": \"#/components/schemas/Dog\"", json);
@@ -122,11 +125,11 @@ public class SwaggerGeneratorUnionTests
             new FakeAuthenticationSchemeProvider([]));
     }
 
-    private static string ToJson(OpenApiDocument document)
+    private static string ToJson(OpenApiDocument document, OpenApiSpecVersion specVersion)
     {
         using var stringWriter = new StringWriter();
         var jsonWriter = new OpenApiJsonWriter(stringWriter);
-        document.SerializeAs(OpenApiSpecVersion.OpenApi3_0, jsonWriter);
+        document.SerializeAs(specVersion, jsonWriter);
         return stringWriter.ToString();
     }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorUnionTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorUnionTests.cs
@@ -1,0 +1,133 @@
+#if NET11_0_OR_GREATER
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.OpenApi;
+using Swashbuckle.AspNetCore.SwaggerGen.Test.Fixtures;
+using Swashbuckle.AspNetCore.TestSupport;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test;
+
+public class SwaggerGeneratorUnionTests
+{
+    public record Cat(string Name, int Lives);
+
+    public record Dog(string Name, bool GoodBoy);
+
+    public union Pet(Cat, Dog);
+
+    public class UnionFakeController
+    {
+        public Pet GetPet() => throw new NotImplementedException();
+
+        public Cat GetCat() => throw new NotImplementedException();
+    }
+
+    [Fact]
+    public void GetSwagger_EmitsUnionResponseAsAnyOfOfReferences_AndDeduplicatesSharedCaseType()
+    {
+        // Endpoint 1 returns a union (Pet), endpoint 2 returns one of its cases (Cat) explicitly.
+        var petApi = ApiDescriptionFactory.Create<UnionFakeController>(
+            c => nameof(c.GetPet),
+            groupName: "v1",
+            httpMethod: "GET",
+            relativePath: "pet",
+            supportedResponseTypes:
+            [
+                new ApiResponseType
+                {
+                    ApiResponseFormats = [new ApiResponseFormat { MediaType = "application/json" }],
+                    StatusCode = 200,
+                    Type = typeof(Pet),
+                },
+            ]);
+
+        var catApi = ApiDescriptionFactory.Create<UnionFakeController>(
+            c => nameof(c.GetCat),
+            groupName: "v1",
+            httpMethod: "GET",
+            relativePath: "cat",
+            supportedResponseTypes:
+            [
+                new ApiResponseType
+                {
+                    ApiResponseFormats = [new ApiResponseFormat { MediaType = "application/json" }],
+                    StatusCode = 200,
+                    Type = typeof(Cat),
+                },
+            ]);
+
+        var document = Subject([petApi, catApi]).GetSwagger("v1");
+
+        // (a) The union response is an anyOf of $refs, not inlined object schemas.
+        var unionSchema = document.Paths["/pet"].Operations[HttpMethod.Get].Responses["200"].Content["application/json"].Schema;
+
+        Assert.NotNull(unionSchema.AnyOf);
+        Assert.Equal(2, unionSchema.AnyOf.Count);
+
+        var unionRefs = unionSchema.AnyOf
+            .Select(s => Assert.IsType<OpenApiSchemaReference>(s))
+            .Select(r => r.Reference.Id)
+            .OrderBy(id => id)
+            .ToArray();
+
+        Assert.Equal([nameof(Cat), nameof(Dog)], unionRefs);
+
+        // (b) The explicit Cat endpoint references the same component id used by the union case.
+        var catSchema = document.Paths["/cat"].Operations[HttpMethod.Get].Responses["200"].Content["application/json"].Schema;
+        var catReference = Assert.IsType<OpenApiSchemaReference>(catSchema);
+        Assert.Equal(nameof(Cat), catReference.Reference.Id);
+
+        // (c) The shared case type is registered exactly once (no Cat/Cat2 duplication).
+        Assert.Equal(1, document.Components.Schemas.Keys.Count(id => id == nameof(Cat)));
+        Assert.Equal(1, document.Components.Schemas.Keys.Count(id => id == nameof(Dog)));
+        Assert.Equal([nameof(Cat), nameof(Dog)], document.Components.Schemas.Keys.OrderBy(id => id).ToArray());
+
+        // Assert the same properties against the actually-serialized OpenAPI JSON.
+        var json = ToJson(document);
+
+        Assert.Contains("\"$ref\": \"#/components/schemas/Cat\"", json);
+        Assert.Contains("\"$ref\": \"#/components/schemas/Dog\"", json);
+        Assert.Contains("\"anyOf\"", json);
+
+        // The union case schemas must not be inlined into the anyOf (no object body inside anyOf).
+        var anyOfIndex = json.IndexOf("\"anyOf\"", StringComparison.Ordinal);
+        var componentsIndex = json.IndexOf("\"components\"", StringComparison.Ordinal);
+        var anyOfBlock = json[anyOfIndex..componentsIndex];
+        Assert.DoesNotContain("\"properties\"", anyOfBlock);
+        Assert.DoesNotContain("\"type\": \"object\"", anyOfBlock);
+
+        // Cat is defined exactly once as a component schema.
+        Assert.DoesNotContain("\"Cat2\"", json);
+    }
+
+    private static SwaggerGenerator Subject(IEnumerable<ApiDescription> apiDescriptions)
+    {
+        var schemaGeneratorOptions = new SchemaGeneratorOptions();
+
+        // Production options come from DI with a configured resolver; a bare JsonSerializerOptions
+        // has no TypeInfoResolver, which is required to inspect union metadata.
+        var serializerOptions = new JsonSerializerOptions { TypeInfoResolver = new DefaultJsonTypeInfoResolver() };
+
+        return new SwaggerGenerator(
+            new SwaggerGeneratorOptions
+            {
+                SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                {
+                    ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" },
+                },
+            },
+            new FakeApiDescriptionGroupCollectionProvider(apiDescriptions),
+            new SchemaGenerator(schemaGeneratorOptions, new JsonSerializerDataContractResolver(serializerOptions, schemaGeneratorOptions)),
+            new FakeAuthenticationSchemeProvider([]));
+    }
+
+    private static string ToJson(OpenApiDocument document)
+    {
+        using var stringWriter = new StringWriter();
+        var jsonWriter = new OpenApiJsonWriter(stringWriter);
+        document.SerializeAs(OpenApiSpecVersion.OpenApi3_0, jsonWriter);
+        return stringWriter.ToString();
+    }
+}
+#endif

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.csproj
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Swashbuckle.AspNetCore.SwaggerGen.Test.csproj
@@ -9,6 +9,11 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\..\src\Swashbuckle.AspNetCore.Swagger\Swashbuckle.AspNetCore.Swagger.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
+  <!-- C# union types, exercised by the union schema tests, require the preview language version on .NET 11. -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net11.0'">
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\..\src\Shared\JsonExtensions.cs" Link="JsonExtensions.cs" />
   </ItemGroup>


### PR DESCRIPTION
.NET 11 introduces C# `union` types, which System.Text.Json represents transparently as an anyOf of the union's case types. This PR adds mirroring behavior compared to STJ and the in-box Microsoft.AspNetCore.OpenApi.

All union code and tests are guarded by `#if NET11_0_OR_GREATER` and the net11 TFM is added additively and gated on SDK support; no public API changes and no new dependencies. net8/9/10 behavior is unchanged.

Is a follow-up of https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/4100.
Related dotnet/aspnetcore#66544, domaindrivendev/Swashbuckle.AspNetCore#2743.