### PR TITLE
Add coverage for AddServer across multiple documents

### DIFF
--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -1623,6 +1623,33 @@ public class SwaggerGeneratorTests
     }
 
     [Fact]
+    public void GetSwagger_SupportsOption_Servers_ForEveryDocument()
+    {
+        var subject = Subject(
+            apiDescriptions: [],
+            options: new SwaggerGeneratorOptions
+            {
+                SwaggerDocs = new Dictionary<string, OpenApiInfo>
+                {
+                    ["v1"] = new OpenApiInfo { Version = "V1", Title = "Test API" },
+                    ["v2"] = new OpenApiInfo { Version = "V2", Title = "Test API" }
+                },
+                Servers =
+                [
+                    new OpenApiServer { Url = "http://tempuri.org/api" }
+                ]
+            }
+        );
+
+        foreach (var documentName in new[] { "v1", "v2" })
+        {
+            var document = subject.GetSwagger(documentName);
+            var server = Assert.Single(document.Servers);
+            Assert.Equal("http://tempuri.org/api", server.Url);
+        }
+    }
+
+    [Fact]
     public void GetSwagger_SupportsOption_SecuritySchemes()
     {
         var subject = Subject(


### PR DESCRIPTION
`GetSwagger_SupportsOption_Servers` generates a single document, so nothing currently pins that servers configured through `AddServer` reach every document rather than only the first one requested. This adds a two-document variant that asserts it for both.

Test only, no source changes. `Swashbuckle.AspNetCore.SwaggerGen.Test` passes on net8.0, net9.0 and net10.0 with 761 tests, 0 failed.

I wrote this while looking into #3306 and thought the coverage was worth keeping regardless of where that issue lands; it asserts current behaviour and is not a fix for anything.
