### PR TITLE
Fix Swagger sort key fallback for empty endpoint tags metadata

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGeneratorOptions.cs
@@ -110,7 +110,10 @@ public class SwaggerGeneratorOptions
 
     private string DefaultSortKeySelector(ApiDescription apiDescription)
     {
-        return TagsSelector(apiDescription).First();
+        return TagsSelector(apiDescription).FirstOrDefault()
+            ?? apiDescription.RelativePath
+            ?? apiDescription.ActionDescriptor?.DisplayName
+            ?? string.Empty;
     }
 
     private static string DefaultPathGroupSelector(ApiDescription apiDescription)

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -1409,6 +1409,32 @@ public class SwaggerGeneratorTests
     }
 
     [Fact]
+    public void GetSwagger_DoesNotThrow_WhenTagsMetadataIsEmpty()
+    {
+        var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));
+        var actionDescriptor = new ActionDescriptor
+        {
+            EndpointMetadata = [new TagsAttribute()],
+            RouteValues = new Dictionary<string, string>
+            {
+                ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
+            }
+        };
+        var subject = Subject(
+            apiDescriptions:
+            [
+                ApiDescriptionFactory.Create(actionDescriptor, methodInfo, groupName: "v1", httpMethod: "POST", relativePath: "resource"),
+            ]
+        );
+
+        var document = subject.GetSwagger("v1");
+
+        Assert.Equal(["/resource"], [.. document.Paths.Keys]);
+        Assert.Single(document.Paths["/resource"].Operations);
+        Assert.Empty(document.Paths["/resource"].Operations[HttpMethod.Post].Tags);
+    }
+
+    [Fact]
     public void GetSwagger_CanReadEndpointSummaryFromMetadata()
     {
         var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));


### PR DESCRIPTION
Fixes Swagger generation failure when endpoint tags metadata is empty (for example `WithTags()` with no values or `[Tags()]`), which currently throws `InvalidOperationException: Sequence contains no elements` from the default sort key selector.

## The issue or feature being addressed

Fixes #4124 

## Details on the issue fix or feature implementation

- Updated the default sort key selection in `SwaggerGeneratorOptions` to handle empty tags safely.
- Kept existing behavior for normal cases: when tags exist, the first tag is still used as the sort key.
- Added fallback chain for empty-tag scenarios:
  1. first tag (if present)
  2. `ApiDescription.RelativePath`
  3. `ApiDescription.ActionDescriptor?.DisplayName`
  4. empty string
- Added a test in `SwaggerGeneratorTests`: `GetSwagger_DoesNotThrow_WhenTagsMetadataIsEmpty`