### PR TITLE
Fix parameter matching to consider location when names collide

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -426,7 +426,15 @@ public class SwaggerGenerator(
         // Schemas will be generated via Swashbuckle by default.
         foreach (var parameter in operation.Parameters ?? [])
         {
-            var apiParameter = apiDescription.ParameterDescriptions.SingleOrDefault((p) => p.Name == parameter.Name && !p.IsFromBody() && !p.IsFromForm() && !p.IsIllegalHeaderParameter());
+            var apiParameter = apiDescription.ParameterDescriptions.SingleOrDefault((p) =>
+                p.Name == parameter.Name &&
+                !p.IsFromBody() &&
+                !p.IsFromForm() &&
+                !p.IsIllegalHeaderParameter() &&
+                (parameter.In is null ||
+                 (p.Source != null &&
+                  ParameterLocationMap.TryGetValue(p.Source, out var parameterLocation) &&
+                  parameterLocation == parameter.In)));
             if (apiParameter is not null)
             {
                 var (parameterAndContext, filterContext) = GenerateParameterAndContext(apiParameter, schemaRepository, document);

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -426,15 +426,8 @@ public class SwaggerGenerator(
         // Schemas will be generated via Swashbuckle by default.
         foreach (var parameter in operation.Parameters ?? [])
         {
-            var apiParameter = apiDescription.ParameterDescriptions.SingleOrDefault((p) =>
-                p.Name == parameter.Name &&
-                !p.IsFromBody() &&
-                !p.IsFromForm() &&
-                !p.IsIllegalHeaderParameter() &&
-                (parameter.In is null ||
-                 (p.Source != null &&
-                  ParameterLocationMap.TryGetValue(p.Source, out var parameterLocation) &&
-                  parameterLocation == parameter.In)));
+            var apiParameter = apiDescription.ParameterDescriptions
+                .SingleOrDefault(p => IsMatchingMetadataParameter(p, parameter.Name, parameter.In));
             if (apiParameter is not null)
             {
                 var (parameterAndContext, filterContext) = GenerateParameterAndContext(apiParameter, schemaRepository, document);
@@ -1137,6 +1130,22 @@ public class SwaggerGenerator(
         ["PATCH"] = HttpMethod.Patch,
         ["TRACE"] = HttpMethod.Trace,
     };
+
+    private static bool IsMatchingMetadataParameter(ApiParameterDescription apiParameter, string name, ParameterLocation? location)
+    {
+        if (apiParameter.Name != name ||
+            apiParameter.IsFromBody() ||
+            apiParameter.IsFromForm() ||
+            apiParameter.IsIllegalHeaderParameter())
+        {
+            return false;
+        }
+
+        return location is null ||
+               (apiParameter.Source != null &&
+                ParameterLocationMap.TryGetValue(apiParameter.Source, out var parameterLocation) &&
+                parameterLocation == location);
+    }
 
     private static readonly Dictionary<BindingSource, ParameterLocation> ParameterLocationMap = new()
     {

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -398,6 +398,134 @@ public class SwaggerGeneratorTests
     }
 
     [Fact]
+    public void GetSwagger_GenerateParameterSchemas_ForProvidedOpenApiOperation_WhenQueryAndPathParametersShareSameName_QueryInMetadata()
+    {
+        var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));
+        var actionDescriptor = new ActionDescriptor
+        {
+            EndpointMetadata =
+            [
+                new OpenApiOperation
+                {
+                    Parameters =
+                    [
+                        new OpenApiParameter
+                        {
+                            Name = "id",
+                            In = ParameterLocation.Query
+                        }
+                    ]
+                }
+            ],
+            RouteValues = new Dictionary<string, string>
+            {
+                ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
+            }
+        };
+        var subject = Subject(
+            apiDescriptions:
+            [
+                ApiDescriptionFactory.Create(
+                    actionDescriptor,
+                    methodInfo,
+                    groupName: "v1",
+                    httpMethod: "GET",
+                    relativePath: "resource/{id}",
+                    parameterDescriptions:
+                    [
+                        new ApiParameterDescription
+                        {
+                            Name = "id",
+                            Source = BindingSource.Path,
+                            ModelMetadata = ModelMetadataFactory.CreateForType(typeof(int)),
+                            Type = typeof(int)
+                        },
+                        new ApiParameterDescription
+                        {
+                            Name = "id",
+                            Source = BindingSource.Query,
+                            ModelMetadata = ModelMetadataFactory.CreateForType(typeof(string)),
+                            Type = typeof(string)
+                        }
+                    ]),
+            ]
+        );
+
+        var document = subject.GetSwagger("v1");
+
+        var operation = document.Paths["/resource/{id}"].Operations[HttpMethod.Get];
+        var parameter = Assert.Single(operation.Parameters);
+        Assert.Equal("id", parameter.Name);
+        Assert.Equal(ParameterLocation.Query, parameter.In);
+        Assert.NotNull(parameter.Schema);
+        Assert.Equal(JsonSchemaTypes.String, parameter.Schema.Type);
+    }
+
+    [Fact]
+    public void GetSwagger_GenerateParameterSchemas_ForProvidedOpenApiOperation_WhenQueryAndPathParametersShareSameName_PathInMetadata()
+    {
+        var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));
+        var actionDescriptor = new ActionDescriptor
+        {
+            EndpointMetadata =
+            [
+                new OpenApiOperation
+                {
+                    Parameters =
+                    [
+                        new OpenApiParameter
+                        {
+                            Name = "id",
+                            In = ParameterLocation.Path
+                        }
+                    ]
+                }
+            ],
+            RouteValues = new Dictionary<string, string>
+            {
+                ["controller"] = methodInfo.DeclaringType.Name.Replace("Controller", string.Empty)
+            }
+        };
+        var subject = Subject(
+            apiDescriptions:
+            [
+                ApiDescriptionFactory.Create(
+                    actionDescriptor,
+                    methodInfo,
+                    groupName: "v1",
+                    httpMethod: "GET",
+                    relativePath: "resource/{id}",
+                    parameterDescriptions:
+                    [
+                        new ApiParameterDescription
+                        {
+                            Name = "id",
+                            Source = BindingSource.Path,
+                            ModelMetadata = ModelMetadataFactory.CreateForType(typeof(int)),
+                            Type = typeof(int)
+                        },
+                        new ApiParameterDescription
+                        {
+                            Name = "id",
+                            Source = BindingSource.Query,
+                            ModelMetadata = ModelMetadataFactory.CreateForType(typeof(string)),
+                            Type = typeof(string)
+                        }
+                    ]),
+            ]
+        );
+
+        var document = subject.GetSwagger("v1");
+
+        var operation = document.Paths["/resource/{id}"].Operations[HttpMethod.Get];
+        var parameter = Assert.Single(operation.Parameters);
+        Assert.Equal("id", parameter.Name);
+        Assert.Equal(ParameterLocation.Path, parameter.In);
+        Assert.NotNull(parameter.Schema);
+        Assert.Equal(JsonSchemaTypes.Integer, parameter.Schema.Type);
+    }
+
+    [Fact]
     public void GetSwagger_SetsOperationIdToNull_IfActionHasNoEndpointMetadata()
     {
         var methodInfo = typeof(FakeController).GetMethod(nameof(FakeController.ActionWithParameter));


### PR DESCRIPTION
## The issue or feature being addressed

Fixes #4123

When using `.WithOpenApi()` on a minimal API endpoint that has two
parameters sharing the same name but bound to different locations
(e.g. `[FromRoute] int id` and `[FromQuery(Name = "id")] string queryId`),
Swagger generation fails with `InvalidOperationException: Sequence
contains more than one matching element`.

## Details on the issue fix or feature implementation

The `SingleOrDefault` call in `GenerateOpenApiOperationFromMetadataAsync`
was matching `ApiParameterDescription` entries by name only. When two
parameters share a name but differ in binding source, this throws.

The fix adds an additional filter: when the metadata `OpenApiParameter`
has its `In` property set, the candidate `ApiParameterDescription` must
also have a `Source` that maps to the same `ParameterLocation` via the
existing `ParameterLocationMap`. When `In` is `null`, the original
name-only matching is preserved for backward compatibility.

Two regression tests are included covering both cases (metadata specifies
`In = Query` and `In = Path`).
