### PR TITLE
Document that System.Text.Json ignores [EnumMember]

### DIFF
--- a/docs/configure-and-customize-swaggergen.md
+++ b/docs/configure-and-customize-swaggergen.md
@@ -750,6 +750,62 @@ services.AddSwaggerGen(options =>
 > [!NOTE]
 > See [this GitHub issue](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2703) for support for nested types.
 
+## Rename Enum Values in Schemas
+
+When an enum is serialized as a string, the values that appear in the generated schema come from the serializer, not from
+Swashbuckle.AspNetCore. Which attribute renames a member therefore depends on which serializer your application uses, and the
+two do not agree.
+
+`System.Text.Json` does not implement `[EnumMember]`. It is ignored for both serialization and schema generation, so this enum:
+
+```csharp
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum Priority
+{
+    Low = 1,
+    [EnumMember(Value = "very-high")]
+    VeryHigh = 2
+}
+```
+
+produces the member name, not the value you asked for:
+
+```json
+{
+  "type": "string",
+  "enum": [
+    "Low",
+    "VeryHigh"
+  ]
+}
+```
+
+Use `[JsonStringEnumMemberName]`, added to `System.Text.Json` in .NET 9, which `System.Text.Json` does implement:
+
+```csharp
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum Priority
+{
+    Low = 1,
+    [JsonStringEnumMemberName("very-high")]
+    VeryHigh = 2
+}
+```
+
+```json
+{
+  "type": "string",
+  "enum": [
+    "Low",
+    "very-high"
+  ]
+}
+```
+
+> [!NOTE]
+> `Newtonsoft.Json` does honor `[EnumMember]`, so an application using the `Swashbuckle.AspNetCore.Newtonsoft` package gets
+> `very-high` from the first example. The difference is in the serializers, not in Swashbuckle.AspNetCore.
+
 ## Override Schema for Specific Types
 
 Out-of-the-box, Swashbuckle.AspNetCore performs a best-effort generating JSON schemas that accurately describe your request and response payloads.


### PR DESCRIPTION
Fixes #3328.

Adds a `Rename Enum Values in Schemas` section to the SwaggerGen docs, covering the difference you agreed was worth writing down: `System.Text.Json` does not implement `[EnumMember]`, `Newtonsoft.Json` does, and `[JsonStringEnumMemberName]` is the native option.

I verified all three claims against `master` rather than trusting the issue, by generating the schema for the same enum through each resolver:

| Serializer | Attribute | `enum` in the generated schema |
|---|---|---|
| `System.Text.Json` | `[EnumMember(Value = "X-foo")]` | `Value1`, `X` |
| `System.Text.Json` | `[JsonStringEnumMemberName("X-foo")]` | `Value1`, `X-foo` |
| `Newtonsoft.Json` | `[EnumMember(Value = "X-foo")]` | `Value1`, `X-foo` |

The C# examples are plain fenced blocks rather than MarkdownSnippets snippets. `JsonStringEnumMemberNameAttribute` is .NET 9 and later, and `DocumentationSnippets` multi-targets down to net8.0, so a compiled snippet would need an `#if NET9_0_OR_GREATER` around it that would then show up in the rendered page. Happy to switch it to a snippet with the guard, or to a net9.0-and-later snippet project, if you would rather have it compiled.

`markdownlint-cli2` with the repo's `.markdownlint.json` reports 0 issues, and `dotnet mdsnippets` leaves the file unchanged.
