### PR TITLE
Fix #3169: emit form encoding for properties of a complex form parameter

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/OpenApiSchemaExtensions.cs
@@ -167,6 +167,48 @@ public static class OpenApiSchemaExtensions
         return schema.Type;
     }
 
+    internal static Dictionary<string, IOpenApiSchema> ResolveProperties(this IOpenApiSchema schema, SchemaRepository schemaRepository)
+    {
+        var properties = new Dictionary<string, IOpenApiSchema>();
+        CollectProperties(schema, schemaRepository, properties, []);
+        return properties;
+
+        static void CollectProperties(
+            IOpenApiSchema schema,
+            SchemaRepository schemaRepository,
+            Dictionary<string, IOpenApiSchema> properties,
+            HashSet<string> visitedReferenceIds)
+        {
+            if (schema is OpenApiSchemaReference reference)
+            {
+                if (!string.IsNullOrEmpty(reference.Reference.Id) &&
+                    visitedReferenceIds.Add(reference.Reference.Id) &&
+                    schemaRepository.Schemas.TryGetValue(reference.Reference.Id, out var definitionSchema))
+                {
+                    CollectProperties(definitionSchema, schemaRepository, properties, visitedReferenceIds);
+                }
+
+                return;
+            }
+
+            if (schema.Properties is not null)
+            {
+                foreach (var property in schema.Properties)
+                {
+                    properties.TryAdd(property.Key, property.Value);
+                }
+            }
+
+            if (schema.AllOf is not null)
+            {
+                foreach (var subSchema in schema.AllOf)
+                {
+                    CollectProperties(subSchema, schemaRepository, properties, visitedReferenceIds);
+                }
+            }
+        }
+    }
+
     private static void ApplyDataTypeAttribute(OpenApiSchema schema, DataTypeAttribute dataTypeAttribute)
     {
         if (DataFormatMappings.TryGetValue(dataTypeAttribute.DataType, out string format))

--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SwaggerGenerator/SwaggerGenerator.cs
@@ -894,9 +894,10 @@ public class SwaggerGenerator(
 
         var schema = GenerateSchemaFromFormParameters(formParameters, schemaRepository);
 
-        var totalProperties = schema.AllOf
-            ?.FirstOrDefault((p) => p.Properties?.Count > 0)
-            ?.Properties ?? schema.Properties;
+        // Resolve the properties through any schema references so that properties
+        // bound from a complex type also get an encoding entry. Otherwise arrays
+        // within such types are not exploded into multiple form fields. See #3169.
+        var totalProperties = schema.ResolveProperties(schemaRepository);
 
         return new OpenApiRequestBody
         {
@@ -905,10 +906,10 @@ public class SwaggerGenerator(
                 (contentType) => new OpenApiMediaType
                 {
                     Schema = schema,
-                    Encoding = totalProperties?.ToDictionary(
+                    Encoding = totalProperties.ToDictionary(
                         (entry) => entry.Key,
                         (entry) => new OpenApiEncoding { Style = ParameterStyle.Form }
-                    ) ?? []
+                    )
                 })
         };
     }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/10_0/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/10_0/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.verified.txt
@@ -58,11 +58,27 @@
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/PersonAnnotated"
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
               "schema": {
                 "$ref": "#/components/schemas/PersonAnnotated"
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -98,6 +114,26 @@
                     "$ref": "#/components/schemas/AddressAnnotated"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
@@ -110,6 +146,26 @@
                     "$ref": "#/components/schemas/AddressAnnotated"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -254,6 +310,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -279,6 +341,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -491,6 +559,26 @@
                     "$ref": "#/components/schemas/Address"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
@@ -503,6 +591,26 @@
                     "$ref": "#/components/schemas/Address"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -772,6 +880,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -797,6 +911,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/10_0/VerifyTests.TypesAreRenderedCorrectly.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/10_0/VerifyTests.TypesAreRenderedCorrectly.verified.txt
@@ -58,11 +58,27 @@
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/PersonAnnotated"
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
               "schema": {
                 "$ref": "#/components/schemas/PersonAnnotated"
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -98,6 +114,26 @@
                     "$ref": "#/components/schemas/AddressAnnotated"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
@@ -110,6 +146,26 @@
                     "$ref": "#/components/schemas/AddressAnnotated"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -254,6 +310,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -279,6 +341,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -491,6 +559,26 @@
                     "$ref": "#/components/schemas/Address"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
@@ -503,6 +591,26 @@
                     "$ref": "#/components/schemas/Address"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -772,6 +880,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -797,6 +911,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/8_0/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/8_0/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.verified.txt
@@ -58,11 +58,27 @@
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/PersonAnnotated"
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
               "schema": {
                 "$ref": "#/components/schemas/PersonAnnotated"
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -98,6 +114,26 @@
                     "$ref": "#/components/schemas/AddressAnnotated"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
@@ -110,6 +146,26 @@
                     "$ref": "#/components/schemas/AddressAnnotated"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -254,6 +310,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -279,6 +341,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -491,6 +559,26 @@
                     "$ref": "#/components/schemas/Address"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
@@ -503,6 +591,26 @@
                     "$ref": "#/components/schemas/Address"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -772,6 +880,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -797,6 +911,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/8_0/VerifyTests.TypesAreRenderedCorrectly.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/8_0/VerifyTests.TypesAreRenderedCorrectly.verified.txt
@@ -58,11 +58,27 @@
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/PersonAnnotated"
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
               "schema": {
                 "$ref": "#/components/schemas/PersonAnnotated"
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -98,6 +114,26 @@
                     "$ref": "#/components/schemas/AddressAnnotated"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
@@ -110,6 +146,26 @@
                     "$ref": "#/components/schemas/AddressAnnotated"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -254,6 +310,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -279,6 +341,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -491,6 +559,26 @@
                     "$ref": "#/components/schemas/Address"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
@@ -503,6 +591,26 @@
                     "$ref": "#/components/schemas/Address"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -772,6 +880,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -797,6 +911,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/9_0/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/9_0/VerifyTests.Swagger_IsValidJson_No_Startup_entryPointType=WebApi.Program_swaggerRequestUri=v1.verified.txt
@@ -58,11 +58,27 @@
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/PersonAnnotated"
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
               "schema": {
                 "$ref": "#/components/schemas/PersonAnnotated"
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -98,6 +114,26 @@
                     "$ref": "#/components/schemas/AddressAnnotated"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
@@ -110,6 +146,26 @@
                     "$ref": "#/components/schemas/AddressAnnotated"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -254,6 +310,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -279,6 +341,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -491,6 +559,26 @@
                     "$ref": "#/components/schemas/Address"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
@@ -503,6 +591,26 @@
                     "$ref": "#/components/schemas/Address"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -772,6 +880,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -797,6 +911,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/9_0/VerifyTests.TypesAreRenderedCorrectly.verified.txt
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/snapshots/9_0/VerifyTests.TypesAreRenderedCorrectly.verified.txt
@@ -58,11 +58,27 @@
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/PersonAnnotated"
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
               "schema": {
                 "$ref": "#/components/schemas/PersonAnnotated"
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -98,6 +114,26 @@
                     "$ref": "#/components/schemas/AddressAnnotated"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
@@ -110,6 +146,26 @@
                     "$ref": "#/components/schemas/AddressAnnotated"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -254,6 +310,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -279,6 +341,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -491,6 +559,26 @@
                     "$ref": "#/components/schemas/Address"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             },
             "application/x-www-form-urlencoded": {
@@ -503,6 +591,26 @@
                     "$ref": "#/components/schemas/Address"
                   }
                 ]
+              },
+              "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
+                "street": {
+                  "style": "form"
+                },
+                "city": {
+                  "style": "form"
+                },
+                "state": {
+                  "style": "form"
+                },
+                "zipCode": {
+                  "style": "form"
+                }
               }
             }
           }
@@ -772,6 +880,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }
@@ -797,6 +911,12 @@
                 ]
               },
               "encoding": {
+                "firstName": {
+                  "style": "form"
+                },
+                "lastName": {
+                  "style": "form"
+                },
                 "tags": {
                   "style": "form"
                 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeController.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/FakeController.cs
@@ -120,4 +120,6 @@ public class FakeController
     { }
     public void ActionHavingFromFormObjectAndString([FromForm] SwaggerIngoreAnnotatedType param1, [FromForm] string param2)
     { }
+    public void ActionHavingFromFormObjectWithArrayProperty([FromForm] TypeWithArrayProperty param1)
+    { }
 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TypeWithArrayProperty.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/Fixtures/TypeWithArrayProperty.cs
@@ -1,0 +1,8 @@
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test.Fixtures;
+
+public class TypeWithArrayProperty
+{
+    public string StringProperty { get; set; }
+
+    public int[] ArrayProperty { get; set; }
+}

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerGenerator/SwaggerGeneratorTests.cs
@@ -2298,7 +2298,9 @@ public class SwaggerGeneratorTests
         Assert.NotNull(mediaType.Schema);
         var reference = Assert.IsType<OpenApiSchemaReference>(mediaType.Schema);
         Assert.Equal(nameof(SwaggerIngoreAnnotatedType), reference.Reference.Id);
-        Assert.Empty(mediaType.Encoding);
+        Assert.NotNull(mediaType.Encoding);
+        Assert.Equal([nameof(SwaggerIngoreAnnotatedType.NotIgnoredString)], mediaType.Encoding.Keys);
+        Assert.Equal(ParameterStyle.Form, mediaType.Encoding[nameof(SwaggerIngoreAnnotatedType.NotIgnoredString)].Style);
     }
 
     [Fact]
@@ -2345,7 +2347,45 @@ public class SwaggerGeneratorTests
         Assert.NotEmpty(mediaType.Schema.AllOf[1].Properties);
         Assert.Equal(["param2"], mediaType.Schema.AllOf[1].Properties.Keys);
         Assert.NotEmpty(mediaType.Encoding);
-        Assert.Equal(["param2"], mediaType.Encoding.Keys);
+        Assert.Equal([nameof(SwaggerIngoreAnnotatedType.NotIgnoredString), "param2"], mediaType.Encoding.Keys);
+    }
+
+    [Fact]
+    public void GetSwagger_GeneratesEncodingForArrayProperties_OfComplexTypeBoundFromForm()
+    {
+        var subject = Subject(
+            apiDescriptions:
+            [
+               ApiDescriptionFactory.Create<FakeController>(
+                    c => nameof(c.ActionHavingFromFormObjectWithArrayProperty),
+                    groupName: "v1",
+                    httpMethod: "POST",
+                    relativePath: "resource",
+                    parameterDescriptions:
+                    [
+                        new ApiParameterDescription
+                        {
+                            Name = "param1",
+                            Source = BindingSource.Form,
+                            Type = typeof(TypeWithArrayProperty),
+                            ModelMetadata = ModelMetadataFactory.CreateForType(typeof(TypeWithArrayProperty))
+                        }
+                    ])
+            ]
+        );
+        var document = subject.GetSwagger("v1");
+
+        var operation = document.Paths["/resource"].Operations[HttpMethod.Post];
+        Assert.NotNull(operation.RequestBody);
+        Assert.Equal(["multipart/form-data"], operation.RequestBody.Content.Keys);
+        var mediaType = operation.RequestBody.Content["multipart/form-data"];
+        var reference = Assert.IsType<OpenApiSchemaReference>(mediaType.Schema);
+        Assert.Equal(nameof(TypeWithArrayProperty), reference.Reference.Id);
+        Assert.NotNull(mediaType.Encoding);
+        Assert.Equal(
+            [nameof(TypeWithArrayProperty.StringProperty), nameof(TypeWithArrayProperty.ArrayProperty)],
+            mediaType.Encoding.Keys);
+        Assert.Equal(ParameterStyle.Form, mediaType.Encoding[nameof(TypeWithArrayProperty.ArrayProperty)].Style);
     }
 
     [Fact]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/10_0/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithSeveralFromForms.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/10_0/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithSeveralFromForms.verified.txt
@@ -20,6 +20,17 @@
                     "$ref": "#/components/schemas/TypeWithDefaultAttributeOnEnum"
                   }
                 ]
+              },
+              "encoding": {
+                "Prop1": {
+                  "style": "form"
+                },
+                "EnumWithDefault": {
+                  "style": "form"
+                },
+                "EnumArrayWithDefault": {
+                  "style": "form"
+                }
               }
             }
           }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/10_0/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/10_0/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject.verified.txt
@@ -15,6 +15,11 @@
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/SwaggerIngoreAnnotatedType"
+              },
+              "encoding": {
+                "NotIgnoredString": {
+                  "style": "form"
+                }
               }
             }
           }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/10_0/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject_AndString.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/10_0/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject_AndString.verified.txt
@@ -29,6 +29,9 @@
                 ]
               },
               "encoding": {
+                "NotIgnoredString": {
+                  "style": "form"
+                },
                 "param2": {
                   "style": "form"
                 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/8_0/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithSeveralFromForms.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/8_0/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithSeveralFromForms.verified.txt
@@ -20,6 +20,17 @@
                     "$ref": "#/components/schemas/TypeWithDefaultAttributeOnEnum"
                   }
                 ]
+              },
+              "encoding": {
+                "Prop1": {
+                  "style": "form"
+                },
+                "EnumWithDefault": {
+                  "style": "form"
+                },
+                "EnumArrayWithDefault": {
+                  "style": "form"
+                }
               }
             }
           }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/8_0/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/8_0/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject.verified.txt
@@ -15,6 +15,11 @@
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/SwaggerIngoreAnnotatedType"
+              },
+              "encoding": {
+                "NotIgnoredString": {
+                  "style": "form"
+                }
               }
             }
           }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/8_0/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject_AndString.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/8_0/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject_AndString.verified.txt
@@ -29,6 +29,9 @@
                 ]
               },
               "encoding": {
+                "NotIgnoredString": {
+                  "style": "form"
+                },
                 "param2": {
                   "style": "form"
                 }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/9_0/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithSeveralFromForms.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/9_0/VerifyTests.GetSwagger_GenerateConsumesSchemas_ForProvidedOpenApiOperationWithSeveralFromForms.verified.txt
@@ -20,6 +20,17 @@
                     "$ref": "#/components/schemas/TypeWithDefaultAttributeOnEnum"
                   }
                 ]
+              },
+              "encoding": {
+                "Prop1": {
+                  "style": "form"
+                },
+                "EnumWithDefault": {
+                  "style": "form"
+                },
+                "EnumArrayWithDefault": {
+                  "style": "form"
+                }
               }
             }
           }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/9_0/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/9_0/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject.verified.txt
@@ -15,6 +15,11 @@
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/SwaggerIngoreAnnotatedType"
+              },
+              "encoding": {
+                "NotIgnoredString": {
+                  "style": "form"
+                }
               }
             }
           }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/9_0/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject_AndString.verified.txt
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/snapshots/9_0/VerifyTests.GetSwagger_Works_As_Expected_When_FromFormObject_AndString.verified.txt
@@ -29,6 +29,9 @@
                 ]
               },
               "encoding": {
+                "NotIgnoredString": {
+                  "style": "form"
+                },
                 "param2": {
                   "style": "form"
                 }


### PR DESCRIPTION
Fixes #3169.

`GenerateRequestBodyFromFormParameters` built the encoding map from the media type schema's own properties:

```csharp
var totalProperties = schema.AllOf?.FirstOrDefault((p) => p.Properties?.Count > 0)?.Properties ?? schema.Properties;
```

When a form parameter is a complex type, that schema is an unattached `OpenApiSchemaReference` whose `Properties` proxy to a null target while the document is still being generated, so its properties produced no encoding entries and the map came out empty. Parameters bound flat did get `style: form`, which is what makes Swagger UI explode an array into repeated fields, so an array behaved differently depending only on whether it sat inside a complex object.

The properties are now resolved through `SchemaRepository` before the map is built, by a new internal `ResolveProperties` extension that mirrors the existing `ResolveType` helper: it follows the reference, walks `allOf`, guards against cycles with a visited-id set, and takes the first value on a key collision.

Two things worth stating rather than leaving to be found in the diff.

The map now covers every `allOf` member and the schema's own properties, where the old expression took only the first member that had any. Every entry maps to the same `Style = Form`, so this is strictly broader coverage with identical values.

This changes the emitted document for any application with a complex form parameter: those properties now get `style: form` encoding entries they previously lacked. That is the fix, not a side effect.

On the spec: OpenAPI 3.0 says an encoding key "MUST exist in the schema as a property". Here that is read as the resolved schema, which is the only coherent reading when the media type schema is a `$ref`, since every consumer resolves the reference before applying encoding. It also matches the document produced by the workaround in the issue.

A regression test in `SwaggerGeneratorTests` pins the encoding entries for an array property on a complex form-bound type, and three `VerifyTests` snapshots in the SwaggerGen tests plus six integration snapshots gain encoding blocks. Every snapshot was regenerated from a real run rather than edited by hand. `Swashbuckle.AspNetCore.SwaggerGen.Test` is 761 passed, 0 failed on net8.0, net9.0 and net10.0, and the integration `VerifyTests` are 27 passed, 0 failed on all three.
