### PR TITLE
Fix #3240: keep a property's own summary when comments come from several XML files

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsSchemaFilter.cs
@@ -10,7 +10,7 @@ public class XmlCommentsSchemaFilter(IReadOnlyDictionary<string, XPathNavigator>
 
     public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        ApplyTypeTags(schema, context.Type);
+        ApplyTypeTags(schema, context);
 
         if (context.MemberInfo != null)
         {
@@ -18,16 +18,21 @@ public class XmlCommentsSchemaFilter(IReadOnlyDictionary<string, XPathNavigator>
         }
     }
 
-    private void ApplyTypeTags(IOpenApiSchema schema, Type type)
+    private void ApplyTypeTags(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        var typeMemberName = XmlCommentsNodeNameHelper.GetMemberNameForType(type);
+        var typeMemberName = XmlCommentsNodeNameHelper.GetMemberNameForType(context.Type);
 
         if (!_xmlDocMembers.TryGetValue(typeMemberName, out var memberNode)) return;
 
         var typeSummaryNode = memberNode.SelectFirstChild("summary");
 
-        if (typeSummaryNode != null)
+        if (typeSummaryNode != null && (context.MemberInfo is null || schema.Description is null))
         {
+            // For a member's schema the type's summary is only a fallback: it must not
+            // overwrite a description a member's summary has already provided, such as by
+            // an XmlCommentsSchemaFilter for another XML comments file when comments are
+            // included from multiple assemblies.
+            // See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3240.
             schema.Description = XmlCommentsTextHelper.Humanize(typeSummaryNode.InnerXml, _options?.XmlCommentEndOfLine);
         }
     }

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsSchemaFilterTests.cs
@@ -179,10 +179,99 @@ public class XmlCommentsSchemaFilterTests
         Assert.Equal(expectedValue, schema.Example.GetValue<float>());
     }
 
+    [Fact]
+    public void Apply_DoesNotOverridePropertySummary_WithTypeSummaryFromAnotherXmlCommentsDocument()
+    {
+        // Arrange
+        var propertyInfo = typeof(XmlAnnotatedType).GetProperty(nameof(XmlAnnotatedType.StringProperty));
+        var propertyMemberName = XmlCommentsNodeNameHelper.GetMemberNameForFieldOrProperty(propertyInfo);
+        var typeMemberName = XmlCommentsNodeNameHelper.GetMemberNameForType(propertyInfo.PropertyType);
+
+        // Simulates IncludeXmlComments() being called once for the assembly declaring the
+        // property and once for the assembly declaring the property's type.
+        // See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3240.
+        var propertyAssemblyFilter = Subject(
+            $"""
+             <doc>
+               <members>
+                 <member name="{propertyMemberName}">
+                   <summary>Summary for StringProperty</summary>
+                 </member>
+               </members>
+             </doc>
+             """);
+
+        var typeAssemblyFilter = Subject(
+            $"""
+             <doc>
+               <members>
+                 <member name="{typeMemberName}">
+                   <summary>Summary for the property's type</summary>
+                 </member>
+               </members>
+             </doc>
+             """);
+
+        var schema = new OpenApiSchema();
+        var filterContext = new SchemaFilterContext(propertyInfo.PropertyType, null, null, memberInfo: propertyInfo);
+
+        // Act
+        propertyAssemblyFilter.Apply(schema, filterContext);
+        typeAssemblyFilter.Apply(schema, filterContext);
+
+        // Assert
+        Assert.Equal("Summary for StringProperty", schema.Description);
+    }
+
+    [Fact]
+    public void Apply_SetsDescription_FromTypeSummaryTagInAnotherXmlCommentsDocument_WhenPropertyHasNoSummary()
+    {
+        // Arrange
+        var propertyInfo = typeof(XmlAnnotatedType).GetProperty(nameof(XmlAnnotatedType.StringProperty));
+        var typeMemberName = XmlCommentsNodeNameHelper.GetMemberNameForType(propertyInfo.PropertyType);
+
+        var propertyAssemblyFilter = Subject(
+            """
+            <doc>
+              <members>
+              </members>
+            </doc>
+            """);
+
+        var typeAssemblyFilter = Subject(
+            $"""
+             <doc>
+               <members>
+                 <member name="{typeMemberName}">
+                   <summary>Summary for the property's type</summary>
+                 </member>
+               </members>
+             </doc>
+             """);
+
+        var schema = new OpenApiSchema();
+        var filterContext = new SchemaFilterContext(propertyInfo.PropertyType, null, null, memberInfo: propertyInfo);
+
+        // Act
+        propertyAssemblyFilter.Apply(schema, filterContext);
+        typeAssemblyFilter.Apply(schema, filterContext);
+
+        // Assert
+        Assert.Equal("Summary for the property's type", schema.Description);
+    }
+
     private static XmlCommentsSchemaFilter Subject()
     {
         using var xml = File.OpenText(typeof(FakeControllerWithXmlComments).Assembly.GetName().Name + ".xml");
         var document = new XPathDocument(xml);
+        var members = XmlCommentsDocumentHelper.CreateMemberDictionary(document);
+        return new(members, new());
+    }
+
+    private static XmlCommentsSchemaFilter Subject(string xml)
+    {
+        using var reader = new StringReader(xml);
+        var document = new XPathDocument(reader);
         var members = XmlCommentsDocumentHelper.CreateMemberDictionary(document);
         return new(members, new());
     }


### PR DESCRIPTION
Fixes #3240.

The long thread here settles into two different problems. The original single-assembly complaint, a property's summary being discarded on a `$ref` property, is the OpenAPI 3.0 limitation with the documented opt-in remedy, `UseAllOfToExtendReferenceSchemas()`, and that part is working as intended. What remains is the multiple-XML-file case further down the thread, where the description you get depends on which XML file was loaded last.

That part is fixable. Each `IncludeXmlComments()` call registers its own `XmlCommentsSchemaFilter`, and `ApplyTypeTags` wrote the type's `<summary>` into `schema.Description` unconditionally. For a member's schema that means the filter for the assembly that knows the property sets the property summary, and then the filter for the assembly that only knows the class overwrites it with the class summary. Reverse the order of the two `IncludeXmlComments` calls and the output changes.

For a member's schema the type summary is now treated as a fallback and applies only when nothing has described the member yet:

```csharp
if (typeSummaryNode != null && (context.MemberInfo is null || schema.Description is null))
```

Definition schemas, where `MemberInfo` is null, are unchanged. The single-file case is unchanged too, since member tags are applied after type tags within one filter and still take precedence.

Two tests in `XmlCommentsSchemaFilterTests`: one reproduces the two-file clobber, and one guards that the type summary still applies as a fallback when the property has no summary of its own. Reverting the source change makes the first fail with the class summary as the actual value. With the change, `Swashbuckle.AspNetCore.SwaggerGen.Test` is 762 passed, 0 failed on net8.0.

Two observable changes worth stating rather than leaving to be found. For a member's schema, the type summary no longer overwrites a description that something else has already set, which includes a schema filter a user registered before `IncludeXmlComments`. And when two XML files both carry the same type's summary, the first loaded now wins as the fallback rather than the last. Both look like corrections rather than regressions to me, but they are behaviour changes and worth your call.
