### PR TITLE
Fix #2951: drop the regex route constraint from the default Swagger route

### DIFF
--- a/src/Swashbuckle.AspNetCore.Swagger/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Swashbuckle.AspNetCore.Swagger/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿
+*REMOVED*static Microsoft.AspNetCore.Builder.SwaggerBuilderExtensions.MapSwagger(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, string pattern = "/swagger/{documentName}/swagger.{extension:regex(^(json|ya?ml)$)}", System.Action<Swashbuckle.AspNetCore.Swagger.SwaggerEndpointOptions> setupAction = null) -> Microsoft.AspNetCore.Builder.IEndpointConventionBuilder
+static Microsoft.AspNetCore.Builder.SwaggerBuilderExtensions.MapSwagger(this Microsoft.AspNetCore.Routing.IEndpointRouteBuilder endpoints, string pattern = "/swagger/{documentName}/swagger.{extension}", System.Action<Swashbuckle.AspNetCore.Swagger.SwaggerEndpointOptions> setupAction = null) -> Microsoft.AspNetCore.Builder.IEndpointConventionBuilder

--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerMiddleware.cs
@@ -14,10 +14,13 @@ internal sealed class SwaggerMiddleware
     private static readonly Encoding UTF8WithoutBom = new UTF8Encoding(false);
     private static readonly HashSet<string> AllowedHttpMethods = new(StringComparer.OrdinalIgnoreCase) { HttpMethods.Get, HttpMethods.Head };
 
+    private static readonly HashSet<string> DefaultAllowedExtensions = new(StringComparer.OrdinalIgnoreCase) { "json", "yaml", "yml" };
+
     private readonly RequestDelegate _next;
     private readonly SwaggerOptions _options;
     private readonly TemplateMatcher _requestMatcher;
     private readonly TemplateBinder _templateBinder;
+    private readonly bool _applyDefaultExtensionConstraint;
 
     public SwaggerMiddleware(
         RequestDelegate next,
@@ -25,7 +28,16 @@ internal sealed class SwaggerMiddleware
     {
         _next = next;
         _options = options ?? new SwaggerOptions();
-        _requestMatcher = new TemplateMatcher(TemplateParser.Parse(_options.RouteTemplate), []);
+
+        var routeTemplate = TemplateParser.Parse(_options.RouteTemplate);
+        _requestMatcher = new TemplateMatcher(routeTemplate, []);
+
+        // The default route template uses an unconstrained {extension} parameter so that applications
+        // configured with CreateSlimBuilder()/AddRoutingCore(), which do not register the regex route
+        // constraint, can still resolve a TemplateBinder for it (see #2951). To keep only the supported
+        // extensions matching, apply the equivalent allow-list in code when the parameter is unconstrained.
+        _applyDefaultExtensionConstraint = routeTemplate.Parameters.Any(
+            static parameter => parameter.Name == "extension" && !parameter.InlineConstraints.Any());
     }
 
     [ActivatorUtilitiesConstructor]
@@ -150,15 +162,22 @@ internal sealed class SwaggerMiddleware
 
             if (routeValues.TryGetValue("documentName", out var documentNameObject) && documentNameObject is string documentNameString)
             {
-                documentName = documentNameString;
                 if (routeValues.TryGetValue("extension", out var extensionObject))
                 {
+                    if (_applyDefaultExtensionConstraint &&
+                        (extensionObject is not string extensionString || !DefaultAllowedExtensions.Contains(extensionString)))
+                    {
+                        return false;
+                    }
+
                     extension = $".{extensionObject}";
                 }
                 else
                 {
                     extension = Path.GetExtension(request.Path.Value);
                 }
+
+                documentName = documentNameString;
                 return true;
             }
         }

--- a/src/Swashbuckle.AspNetCore.Swagger/SwaggerOptions.cs
+++ b/src/Swashbuckle.AspNetCore.Swagger/SwaggerOptions.cs
@@ -5,7 +5,7 @@ namespace Swashbuckle.AspNetCore.Swagger;
 
 public class SwaggerOptions
 {
-    internal const string DefaultRouteTemplate = "/swagger/{documentName}/swagger.{extension:regex(^(json|ya?ml)$)}";
+    internal const string DefaultRouteTemplate = "/swagger/{documentName}/swagger.{extension}";
 
     public SwaggerOptions()
     {

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerMiddlewareRouteTemplateTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SwaggerMiddlewareRouteTemplateTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi;
+using NSubstitute;
+using Swashbuckle.AspNetCore.Swagger;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test;
+
+public static class SwaggerMiddlewareRouteTemplateTests
+{
+    [Fact]
+    public static void UseSwagger_Does_Not_Require_Regex_Route_Constraint()
+    {
+        // See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/2951.
+        // AddRoutingCore(), as used by WebApplication.CreateSlimBuilder(), does not
+        // register the regex route constraint, so building the pipeline must not
+        // require it for the default route template.
+        var (pipeline, _) = CreatePipeline();
+        Assert.NotNull(pipeline);
+    }
+
+    [Theory]
+    [InlineData("/swagger/v1/swagger.json", 200, "application/json;charset=utf-8")]
+    [InlineData("/swagger/v1/swagger.yaml", 200, "text/yaml;charset=utf-8")]
+    [InlineData("/swagger/v1/swagger.yml", 200, "text/yaml;charset=utf-8")]
+    [InlineData("/swagger/v1/swagger.JSON", 200, "application/json;charset=utf-8")]
+    [InlineData("/swagger/v1/swagger.YAML", 200, "application/json;charset=utf-8")]
+    [InlineData("/swagger/v1/swagger.txt", 404, null)]
+    [InlineData("/swagger/v1/swagger.html", 404, null)]
+    [InlineData("/swagger/v1/swagger.jsonx", 404, null)]
+    public static async Task UseSwagger_Default_Route_Template_Only_Matches_Supported_Extensions(
+        string path,
+        int expectedStatusCode,
+        string expectedContentType)
+    {
+        var (pipeline, services) = CreatePipeline();
+
+        using var scope = services.CreateScope();
+
+        var context = new DefaultHttpContext()
+        {
+            RequestServices = scope.ServiceProvider,
+        };
+
+        context.Request.Method = HttpMethods.Get;
+        context.Request.Path = path;
+        context.Response.Body = new MemoryStream();
+
+        await pipeline(context);
+
+        Assert.Equal(expectedStatusCode, context.Response.StatusCode);
+        Assert.Equal(expectedContentType, context.Response.ContentType);
+    }
+
+    private static (RequestDelegate Pipeline, IServiceProvider Services) CreatePipeline()
+    {
+        var swaggerProvider = Substitute.For<ISwaggerProvider>();
+        swaggerProvider
+            .GetSwagger("v1", Arg.Any<string>(), Arg.Any<string>())
+            .Returns(new OpenApiDocument()
+            {
+                Info = new OpenApiInfo() { Title = "Test API", Version = "v1" },
+            });
+        var services = new ServiceCollection()
+            .AddRoutingCore()
+            .AddSingleton(swaggerProvider)
+            .BuildServiceProvider();
+
+        var app = new ApplicationBuilder(services);
+        app.UseSwagger(new SwaggerOptions());
+
+        return (app.Build(), services);
+    }
+}
+

--- a/test/WebSites/WebApi.Aot/Program.cs
+++ b/test/WebSites/WebApi.Aot/Program.cs
@@ -1,11 +1,7 @@
 using System.Text.Json.Serialization;
-using Microsoft.AspNetCore.Routing.Constraints;
 using Microsoft.OpenApi;
 
 var builder = WebApplication.CreateSlimBuilder(args);
-
-builder.Services.Configure<RouteOptions>(
-    options => options.SetParameterPolicy<RegexInlineRouteConstraint>("regex"));
 
 builder.Services.ConfigureHttpJsonOptions(options =>
 {


### PR DESCRIPTION
Fixes #2951. This takes up the offer above: "We'd be happy to take a PR that changes the route template ... that doesn't need a Regex."

It still reproduces on master. `SwaggerOptions.DefaultRouteTemplate` is `/swagger/{documentName}/swagger.{extension:regex(^(json|ya?ml)$)}`, and `SwaggerMiddleware`'s constructor eagerly resolves a `TemplateBinder` for it. An application built with `CreateSlimBuilder` or `AddRoutingCore` does not register the regex constraint, so a standalone app against master throws at startup with the exception in the report, from `SwaggerMiddleware..ctor`.

The default template drops the constraint, and the middleware applies the equivalent allow-list in code, but only when the `extension` parameter has no inline constraint of its own. A custom template that brings its own constraints keeps going through the `TemplateBinder` path unchanged. The allow-list is `json`, `yaml`, `yml`, compared with `OrdinalIgnoreCase`, matching the case-insensitivity of the regex it replaces.

`MapSwagger`'s default parameter value changes with it, so `PublicAPI.Unshipped.txt` carries the `*REMOVED*` and replacement pair the analyzers require.

This also deletes the repo's own workaround: `test/WebSites/WebApi.Aot/Program.cs` was registering `SetParameterPolicy<RegexInlineRouteConstraint>` to get around exactly this, so the in-repo AoT slim-builder site now exercises the fix rather than papering over it.

`SwaggerMiddlewareRouteTemplateTests` covers building the pipeline under `AddRoutingCore()` with no regex constraint registered, plus eight route cases: `.json`, `.yaml`, `.yml`, `.JSON` and `.YAML` serve 200, and `.txt`, `.html` and `.jsonx` fall through to a 404. All nine fail against master's source with the same `RouteCreationException` from the report. With the change, `Swashbuckle.AspNetCore.SwaggerGen.Test` is 769 passed, 0 failed on net8.0. I also confirmed the standalone slim-builder app end to end: it crashed before, and after the change it starts, serves a valid document at `swagger.json`, serves `swagger.yaml` as `text/yaml`, and 404s `swagger.txt`.

Two things I did not change, deliberately. `.YAML` returns 200 with JSON content, because the old regex was case-insensitive while the json/yaml switch downstream is case-sensitive; that is master's existing behaviour and this PR is not the place to change it. And a user with a custom, unconstrained `{extension}` template, say `docs/{documentName}/spec.{extension}`, previously got JSON for any extension and now sees anything outside the allow-list fall through to the next middleware. That is the same tightening #2418 intended for the default template, but it is a behaviour change and worth your call.
