### PR TITLE
Fix #3217: resolve enum contracts against the underlying type under source generation

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/SchemaGenerator/JsonSerializerDataContractResolver.cs
@@ -48,7 +48,7 @@ public class JsonSerializerDataContractResolver : ISerializerDataContractResolve
             // Test to determine if the serializer will treat as string
             var serializeAsString =
                 enumValues.Length > 0 &&
-                JsonConverterFunc(enumValues.GetValue(0), type).StartsWith('\"');
+                JsonConverterFunc(enumValues.GetValue(0), effectiveType).StartsWith('\"');
 
             var exampleType = serializeAsString ?
                 typeof(string) :
@@ -60,7 +60,7 @@ public class JsonSerializerDataContractResolver : ISerializerDataContractResolve
                 underlyingType: effectiveType,
                 dataType: primitiveTypeAndFormat.Item1,
                 dataFormat: primitiveTypeAndFormat.Item2,
-                jsonConverter: (value) => JsonConverterFunc(value, type));
+                jsonConverter: (value) => JsonConverterFunc(value, effectiveType));
         }
 
         if (IsSupportedDictionary(effectiveType, out Type keyType, out Type valueType))

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSourceGenerationSchemaGeneratorTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/SchemaGenerator/JsonSourceGenerationSchemaGeneratorTests.cs
@@ -1,0 +1,100 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Microsoft.OpenApi;
+
+namespace Swashbuckle.AspNetCore.SwaggerGen.Test;
+
+public class JsonSourceGenerationSchemaGeneratorTests
+{
+    [Fact]
+    public void GenerateSchema_GeneratesEnumValues_ForIntegerEnumResolvedBySourceGeneration()
+    {
+        var schema = GenerateSchemaFor(typeof(SourceGeneratedTimeRange));
+
+        Assert.Equal(JsonSchemaTypes.Integer, schema.Type);
+        Assert.Equal(["0", "1", "2"], schema.Enum.Select((p) => p.ToJsonString()));
+    }
+
+    [Fact]
+    public void GenerateSchema_GeneratesEnumValues_ForNullableIntegerEnumResolvedBySourceGeneration()
+    {
+        var schema = GenerateSchemaFor(typeof(SourceGeneratedTimeRange?));
+
+        Assert.Equal(JsonSchemaTypes.Integer, schema.Type);
+        Assert.Equal(["0", "1", "2"], schema.Enum.Select((p) => p.ToJsonString()));
+    }
+
+    [Fact]
+    public void GenerateSchema_GeneratesEnumValues_ForStringEnumResolvedBySourceGeneration()
+    {
+        var schema = GenerateSchemaFor(typeof(SourceGeneratedLevel));
+
+        Assert.Equal(JsonSchemaTypes.String, schema.Type);
+        Assert.Equal(["\"Low\"", "\"High\""], schema.Enum.Select((p) => p.ToJsonString()));
+    }
+
+    [Fact]
+    public void GenerateSchema_GeneratesEnumValues_ForEnumPropertyResolvedBySourceGeneration()
+    {
+        var repository = new SchemaRepository();
+
+        Subject().GenerateSchema(typeof(SourceGeneratedForecast), repository);
+
+        var schema = Assert.IsType<OpenApiSchema>(repository.Schemas[nameof(SourceGeneratedTimeRange)]);
+
+        Assert.Equal(JsonSchemaTypes.Integer, schema.Type);
+        Assert.Equal(["0", "1", "2"], schema.Enum.Select((p) => p.ToJsonString()));
+    }
+
+    private static OpenApiSchema GenerateSchemaFor(Type type)
+    {
+        var repository = new SchemaRepository();
+
+        Subject().GenerateSchema(type, repository);
+
+        var name = (Nullable.GetUnderlyingType(type) ?? type).Name;
+
+        return Assert.IsType<OpenApiSchema>(repository.Schemas[name]);
+    }
+
+    private static SchemaGenerator Subject()
+    {
+        // Reproduces an application that has disabled reflection-based serialization
+        // by only resolving JSON metadata through a source-generated context.
+        var serializerOptions = new JsonSerializerOptions()
+        {
+            TypeInfoResolver = SourceGenerationContext.Default,
+        };
+
+        var generatorOptions = new SchemaGeneratorOptions();
+
+        return new SchemaGenerator(generatorOptions, new JsonSerializerDataContractResolver(serializerOptions, generatorOptions));
+    }
+}
+
+public enum SourceGeneratedTimeRange
+{
+    Daily,
+    Weekly,
+    Monthly,
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter<SourceGeneratedLevel>))]
+public enum SourceGeneratedLevel
+{
+    Low,
+    High,
+}
+
+public class SourceGeneratedForecast
+{
+    public SourceGeneratedTimeRange Range { get; set; }
+
+    public int TemperatureC { get; set; }
+}
+
+[JsonSerializable(typeof(SourceGeneratedTimeRange))]
+[JsonSerializable(typeof(SourceGeneratedLevel))]
+[JsonSerializable(typeof(SourceGeneratedForecast))]
+internal sealed partial class SourceGenerationContext : JsonSerializerContext;


### PR DESCRIPTION
Fixes #3217.

The bug as filed no longer reproduces. The mechanism identified in the thread, `OpenApiAnyFactory.CreateFromJson` deserializing to a `JsonElement` and failing without reflection, went away when that path was replaced by `JsonModelFactory` using `JsonNode.Parse`, which needs no metadata. With a strict source-generated `TypeInfoResolver`, master emits enum values correctly today, both integer and string forms. Nothing guards that, which is part of why the issue stayed open.

What is still live is the nullable case, and it is fatal rather than null:

```
System.NotSupportedException : JsonTypeInfo metadata for type 'System.Nullable`1[TimeRange]'
was not provided by TypeInfoResolver of type 'SourceGenerationContext'.
   at JsonSerializerDataContractResolver.JsonConverterFunc(Object value, Type type)
   at JsonSerializerDataContractResolver.GetDataContractForType(Type type)
```

The enum branch of `GetDataContractForType` unwraps `Nullable<T>` into `effectiveType` for every purpose except the two calls that serialize a sample value, which still receive the original `type`. Under a reflection-based resolver that is invisible, because System.Text.Json synthesizes `Nullable<T>` metadata on demand. Under a source-generated context the metadata exists only if some registered type happens to have a `TEnum?` member, and an optional enum route or query parameter, which is the shape in the issue, gives it no reason to. So document generation throws.

The fix is to pass `effectiveType` to both.

Four tests in a new `JsonSourceGenerationSchemaGeneratorTests`, driven by a real `JsonSerializerContext` set as the sole `TypeInfoResolver`: an int-backed enum, a nullable int-backed enum, a string enum through `JsonStringEnumConverter<T>`, and an enum reached as a property. Against master's source three pass and the nullable one throws with the exception above. With the change, `Swashbuckle.AspNetCore.SwaggerGen.Test` is 764 passed, 0 failed on net8.0.

One thing to say before it gets asked: the identical mismatch exists in the adjacent primitive branch, so `int?` and `Guid?` under source generation have the same latent crash. I tried the same swap there and it broke twelve `GenerateSchema_SetsDefault_IfPropertyHasDefaultValueAttribute` cases, which serialize a null default through the nullable type on purpose. That needs the null-default path handled separately, so this PR is deliberately scoped to the enum branch.
