### PR TITLE
Fix #3153: serialize custom values in the UI ConfigObject AdditionalItems

### DIFF
--- a/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.ReDoc/ReDocMiddleware.cs
@@ -1,8 +1,10 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 
@@ -12,6 +14,7 @@ internal sealed partial class ReDocMiddleware
 {
     private static readonly HashSet<string> AllowedHttpMethods = new(StringComparer.OrdinalIgnoreCase) { HttpMethods.Get, HttpMethods.Head };
     private static readonly string ReDocVersion = GetReDocVersion();
+    private static readonly JsonSerializerOptions DefaultJsonSerializerOptions = CreateDefaultJsonSerializerOptions();
 
     private readonly RequestDelegate _next;
     private readonly ReDocOptions _options;
@@ -23,10 +26,7 @@ internal sealed partial class ReDocMiddleware
         _next = next;
         _options = options ?? new ReDocOptions();
 
-        if (options.JsonSerializerOptions != null)
-        {
-            _jsonSerializerOptions = options.JsonSerializerOptions;
-        }
+        _jsonSerializerOptions = _options.JsonSerializerOptions ?? DefaultJsonSerializerOptions;
 
         var pathPrefix = options.RoutePrefix.StartsWith('/') ? options.RoutePrefix : $"/{options.RoutePrefix}";
         _resourceProvider = new(
@@ -70,6 +70,32 @@ internal sealed partial class ReDocMiddleware
         }
 
         await _next(httpContext);
+    }
+
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL2026:RequiresUnreferencedCode",
+        Justification = "The reflection-based resolver is only used when dynamic code is supported (i.e. not native AoT) to serialize custom values in ConfigObject.AdditionalItems. See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3153.")]
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050:RequiresDynamicCode",
+        Justification = "The reflection-based resolver is only used when dynamic code is supported (i.e. not native AoT) to serialize custom values in ConfigObject.AdditionalItems. See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3153.")]
+    private static JsonSerializerOptions CreateDefaultJsonSerializerOptions()
+    {
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            // Only source-generated metadata can be used with native AoT
+            return null;
+        }
+
+        // Chain a reflection-based resolver after the source-generated one so that custom
+        // values in ConfigObject.AdditionalItems (e.g. anonymous types) can be serialized.
+        return new JsonSerializerOptions(ReDocOptionsJsonContext.Default.Options)
+        {
+            TypeInfoResolver = JsonTypeInfoResolver.Combine(
+                ReDocOptionsJsonContext.Default,
+                new DefaultJsonTypeInfoResolver()),
+        };
     }
 
     private static string GetReDocVersion()
@@ -196,11 +222,11 @@ internal sealed partial class ReDocMiddleware
     [UnconditionalSuppressMessage(
         "AOT",
         "IL2026:RequiresUnreferencedCode",
-        Justification = "Method is only called if the user provides their own custom JsonSerializerOptions.")]
+        Justification = "Reflection-based serialization is only used if the user provides their own custom JsonSerializerOptions or when dynamic code is supported.")]
     [UnconditionalSuppressMessage(
         "AOT",
         "IL3050:RequiresDynamicCode",
-        Justification = "Method is only called if the user provides their own custom JsonSerializerOptions.")]
+        Justification = "Reflection-based serialization is only used if the user provides their own custom JsonSerializerOptions or when dynamic code is supported.")]
     private Dictionary<string, string> GetIndexArguments()
     {
         string configObject = null;

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/SwaggerUIMiddleware.cs
@@ -1,8 +1,10 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 
@@ -12,6 +14,7 @@ internal sealed partial class SwaggerUIMiddleware
 {
     private static readonly HashSet<string> AllowedHttpMethods = new(StringComparer.OrdinalIgnoreCase) { HttpMethods.Get, HttpMethods.Head };
     private static readonly string SwaggerUIVersion = GetSwaggerUIVersion();
+    private static readonly JsonSerializerOptions DefaultJsonSerializerOptions = CreateDefaultJsonSerializerOptions();
 
     private readonly RequestDelegate _next;
     private readonly SwaggerUIOptions _options;
@@ -23,10 +26,7 @@ internal sealed partial class SwaggerUIMiddleware
         _next = next;
         _options = options ?? new();
 
-        if (options.JsonSerializerOptions != null)
-        {
-            _jsonSerializerOptions = options.JsonSerializerOptions;
-        }
+        _jsonSerializerOptions = _options.JsonSerializerOptions ?? DefaultJsonSerializerOptions;
 
         var pathPrefix = options.RoutePrefix.StartsWith('/') ? options.RoutePrefix : $"/{options.RoutePrefix}";
         _resourceProvider = new(
@@ -80,6 +80,32 @@ internal sealed partial class SwaggerUIMiddleware
         }
 
         await _next(httpContext);
+    }
+
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL2026:RequiresUnreferencedCode",
+        Justification = "The reflection-based resolver is only used when dynamic code is supported (i.e. not native AoT) to serialize custom values in ConfigObject.AdditionalItems. See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3153.")]
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050:RequiresDynamicCode",
+        Justification = "The reflection-based resolver is only used when dynamic code is supported (i.e. not native AoT) to serialize custom values in ConfigObject.AdditionalItems. See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3153.")]
+    private static JsonSerializerOptions CreateDefaultJsonSerializerOptions()
+    {
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            // Only source-generated metadata can be used with native AoT
+            return null;
+        }
+
+        // Chain a reflection-based resolver after the source-generated one so that custom
+        // values in ConfigObject.AdditionalItems (e.g. anonymous types) can be serialized.
+        return new JsonSerializerOptions(SwaggerUIOptionsJsonContext.Default.Options)
+        {
+            TypeInfoResolver = JsonTypeInfoResolver.Combine(
+                SwaggerUIOptionsJsonContext.Default,
+                new DefaultJsonTypeInfoResolver()),
+        };
     }
 
     private static string GetSwaggerUIVersion()
@@ -196,11 +222,11 @@ internal sealed partial class SwaggerUIMiddleware
     [UnconditionalSuppressMessage(
         "AOT",
         "IL2026:RequiresUnreferencedCode",
-        Justification = "Method is only called if the user provides their own custom JsonSerializerOptions.")]
+        Justification = "Reflection-based serialization is only used if the user provides their own custom JsonSerializerOptions or when dynamic code is supported.")]
     [UnconditionalSuppressMessage(
         "AOT",
         "IL3050:RequiresDynamicCode",
-        Justification = "Method is only called if the user provides their own custom JsonSerializerOptions.")]
+        Justification = "Reflection-based serialization is only used if the user provides their own custom JsonSerializerOptions or when dynamic code is supported.")]
     private async Task RespondWithDocumentUrls(HttpContext context)
     {
         var response = context.Response;
@@ -240,11 +266,11 @@ internal sealed partial class SwaggerUIMiddleware
     [UnconditionalSuppressMessage(
         "AOT",
         "IL2026:RequiresUnreferencedCode",
-        Justification = "Method is only called if the user provides their own custom JsonSerializerOptions.")]
+        Justification = "Reflection-based serialization is only used if the user provides their own custom JsonSerializerOptions or when dynamic code is supported.")]
     [UnconditionalSuppressMessage(
         "AOT",
         "IL3050:RequiresDynamicCode",
-        Justification = "Method is only called if the user provides their own custom JsonSerializerOptions.")]
+        Justification = "Reflection-based serialization is only used if the user provides their own custom JsonSerializerOptions or when dynamic code is supported.")]
     private Dictionary<string, string> GetIndexArguments()
     {
         string configObject = null;

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/ReDocIntegrationTests.cs
@@ -433,4 +433,32 @@ public class ReDocIntegrationTests(ITestOutputHelper outputHelper)
 
         Assert.Equal("x');alert(1);//", config.RootElement.GetProperty("theme").GetString());
     }
+
+    [Fact]
+    public async Task ReDocMiddleware_Serializes_Custom_Object_In_AdditionalItems()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseReDoc((options) =>
+        {
+            // See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3153
+            options.ConfigObject.AdditionalItems["theme"] = new { colors = new { primary = "#086eaa" } };
+        }));
+
+        using var client = server.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync("/api-docs/index.js", cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        outputHelper.WriteLine(body);
+
+        using var config = JsonDocument.Parse(body[body.IndexOf('{')..(body.LastIndexOf('}') + 1)]);
+
+        Assert.Equal("#086eaa", config.RootElement.GetProperty("theme").GetProperty("colors").GetProperty("primary").GetString());
+    }
 }

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -807,4 +807,38 @@ public class SwaggerUIIntegrationTests(ITestOutputHelper outputHelper)
 
         Assert.Equal("x');alert(1);//", config.RootElement.GetProperty("urls")[0].GetProperty("name").GetString());
     }
+
+    [Fact]
+    public async Task SwaggerUIMiddleware_Serializes_Custom_Object_In_AdditionalItems()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        using var server = TestSite.CreateServer((app) => app.UseSwaggerUI((options) =>
+        {
+            // See https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/3153
+            options.ConfigObject.AdditionalItems["theme"] = new { colors = new { primary = "#086eaa" } };
+        }));
+
+        using var client = server.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync("/swagger/index.js", cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        const string Prefix = "var configObject =";
+
+        var line = body.Split('\n').First((p) => p.Contains(Prefix));
+        outputHelper.WriteLine(line);
+
+        var json = line[(line.IndexOf(Prefix, StringComparison.Ordinal) + Prefix.Length)..].Trim().TrimEnd(';');
+
+        using var config = JsonDocument.Parse(json);
+
+        Assert.Equal("#086eaa", config.RootElement.GetProperty("theme").GetProperty("colors").GetProperty("primary").GetString());
+    }
 }


### PR DESCRIPTION
Fixes #3153.

This is not fixed by the Microsoft.OpenApi v2 move, which only changed how the OpenAPI document is serialized. The failure is in the UI config serialization and still happens on master. With `c.ConfigObject.AdditionalItems.Add("theme", new { colors = new { primary = "#086eaa" } })`, exercised through the real middleware:

```
NotSupportedException: JsonTypeInfo metadata for type '<>f__AnonymousType0`1[...]' was not
provided by TypeInfoResolver of type 'ReDocOptionsJsonContext'
```

and the identical failure from `SwaggerUIOptionsJsonContext`.

Both middlewares serialize `ConfigObject` with the source-generated context alone whenever the application has not supplied its own `JsonSerializerOptions`. #2890 whitelisted primitives in those contexts, but `AdditionalItems` is `[JsonExtensionData]`, so any complex value in it has no metadata and throws.

When `RuntimeFeature.IsDynamicCodeSupported`, the default options now chain a reflection-based resolver after the source-generated one:

```csharp
TypeInfoResolver = JsonTypeInfoResolver.Combine(
    ReDocOptionsJsonContext.Default,
    new DefaultJsonTypeInfoResolver())
```

Registered types still resolve through source generation first, so the emitted config is byte-identical for everything that worked before, including the camelCase naming. On native AoT the resolver stays source-generated only, so AoT support is untouched. Application-supplied `JsonSerializerOptions` still win, as they did. No public API change.

Two regression tests, one per middleware, styled after the adjacent splice tests. Against master's source both fail with the exception above. With the change, `Swashbuckle.AspNetCore.IntegrationTests` is 224 passed, 0 failed on net8.0.

The tradeoff worth stating: `RuntimeFeature.IsDynamicCodeSupported` distinguishes native AoT, not trimming, so in a trimmed-but-JIT application a user's custom config type could in principle be trimmed away and serialize incompletely. That is the same exposure as the pre-6.6 behaviour this restores, and it matches the suppression pattern already used in these two files.
