### PR TITLE
Convert the last hand-written C# example to a MarkdownSnippets snippet

### DIFF
--- a/docs/migrating-to-v10.md
+++ b/docs/migrating-to-v10.md
@@ -76,16 +76,22 @@ Migrating to Swashbuckle.AspNetCore v10+ will likely involve changes in the foll
 - Update any `using` directives that reference types from the `Microsoft.OpenApi.Models` namespace to use the new namespace `Microsoft.OpenApi`.
 - Update model references (e.g. `OpenApiSchema`) to use the new interfaces (e.g. `IOpenApiSchema`) and use the relevant concrete types to mutate them (e.g. `OpenApiSchema`). An example of this is shown below for an `ISchemaFilter` implementation:
 
-   ```csharp
-  public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
-  {
+   <!-- markdownlint-disable MD031 MD033 -->
+   <!-- snippet: Migrating-SchemaFilter -->
+   <a id='snippet-Migrating-SchemaFilter'></a>
+   ```cs
+   public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
+   {
        if (schema is OpenApiSchema openApiSchema)
        {
-            // The properties are only mutable on the concrete type
-            openApiSchema.Type = JsonSchemaType.String;
+           // The properties are only mutable on the concrete type
+           openApiSchema.Type = JsonSchemaType.String;
        }
-   }     
+   }
    ```
+   <sup><a href='/test/WebSites/DocumentationSnippets/MigrationSchemaFilter.cs#L8-L17' title='Snippet source file'>snippet source</a> | <a href='#snippet-Migrating-SchemaFilter' title='Start of snippet'>anchor</a></sup>
+   <!-- endSnippet -->
+   <!-- markdownlint-enable MD031 MD033 -->
 
 - Update any use of `.Reference` properties (e.g. `OpenApiSchema.ReferenceV3`) to use the new `*Reference` class instead (e.g. `OpenApiSchemaReference`).
 - Replace usage of the `OpenApiSchema.Type` property using a string (e.g. `"string"` or `"boolean"`) with the `JsonSchemaType` flags enumeration.

--- a/test/WebSites/DocumentationSnippets/MigrationSchemaFilter.cs
+++ b/test/WebSites/DocumentationSnippets/MigrationSchemaFilter.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.OpenApi;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace DocumentationSnippets;
+
+public class MigrationSchemaFilter : ISchemaFilter
+{
+    // begin-snippet: Migrating-SchemaFilter
+    public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
+    {
+        if (schema is OpenApiSchema openApiSchema)
+        {
+            // The properties are only mutable on the concrete type
+            openApiSchema.Type = JsonSchemaType.String;
+        }
+    }
+    // end-snippet
+}


### PR DESCRIPTION
Fixes #3413.

The conversion turned out to be nearly finished already. I inventoried every fence in every Markdown file in the repo, split by language and by whether it sits inside a `<!-- snippet: -->` region:

| File | C# fences | Outside a snippet |
|---|---|---|
| `docs/configure-and-customize-swaggergen.md` | 43 | 0 |
| `docs/configure-and-customize-annotations.md` | 13 | 0 |
| `docs/configure-and-customize-swaggerui.md` | 13 | 0 |
| `README.md` | 9 | 0 |
| `docs/configure-and-customize-redoc.md` | 8 | 0 |
| `docs/configure-and-customize-swagger.md` | 7 | 0 |
| `docs/configure-and-customize-cli.md` | 1 | 0 |
| `docs/migrating-to-v10.md` | 2 | **1** |

So the complete list of unconverted C# examples is one item: the `ISchemaFilter.Apply` example in `docs/migrating-to-v10.md`. `package-readme.md`, `CONTRIBUTING.md` and `SECURITY.md` have no fences, and `AGENTS.md` only has shell ones. The remaining non-C# fences are `terminal`, `yaml`, `json`, `xml` and one `diff` showing a public API signature change, none of which are compilable code.

That one example now comes from a new `MigrationSchemaFilter` type in `DocumentationSnippets`, so it compiles against the library like every other example.

One detail worth knowing, since no other snippet in the repo does this: the fence lives inside a bullet of the Migration Overview list. MarkdownSnippets preserves the indentation of the `<!-- snippet: -->` marker line, so an indented marker emits the anchor, the fence and the `<sup>` footer all indented to match and the bullet still renders as a single list item. If you would rather not depend on that, the alternative is restructuring the bullet so the example sits at column zero after the list, which is what every other snippet does. I left the code content identical, apart from the block's pre-existing mixed indentation and a trailing space on the closing brace, which the extraction normalises.

`dotnet mdsnippets` runs clean and is idempotent, `markdownlint-cli2` against the repo's `.markdownlint.json` reports 0 issues, and `DocumentationSnippets` builds on net8.0, net9.0 and net10.0 with 0 warnings and 0 errors.

Separately, on #4127: the C# fences I added there can become guarded snippets by putting the preprocessor directives outside the begin and end markers, so the rendered page shows clean code while net8.0 skips the .NET 9 example. The two examples both declare a type named `Priority`, so they need separate files with distinct namespaces to keep the rendered text identical. Happy to do that in a follow-up if you want it done there too.
