### PR TITLE
Strip query string from relative document URLs in Swagger UI

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerUI/index.js
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/index.js
@@ -36,7 +36,7 @@ window.onload = function () {
     // Workaround for https://github.com/swagger-api/swagger-ui/issues/5945
     configObject.urls.forEach(function (item) {
         if (item.url.startsWith("http") || item.url.startsWith("/")) return;
-        item.url = window.location.href.replace("index.html", item.url).split(/[?#]/)[0];
+        item.url = window.location.href.split(/[?#]/)[0].replace("index.html", item.url).split('#')[0];
     });
 
     // If validatorUrl is not explicitly provided, disable the feature by setting to null

--- a/src/Swashbuckle.AspNetCore.SwaggerUI/index.js
+++ b/src/Swashbuckle.AspNetCore.SwaggerUI/index.js
@@ -36,7 +36,7 @@ window.onload = function () {
     // Workaround for https://github.com/swagger-api/swagger-ui/issues/5945
     configObject.urls.forEach(function (item) {
         if (item.url.startsWith("http") || item.url.startsWith("/")) return;
-        item.url = window.location.href.replace("index.html", item.url).split('#')[0];
+        item.url = window.location.href.replace("index.html", item.url).split(/[?#]/)[0];
     });
 
     // If validatorUrl is not explicitly provided, disable the feature by setting to null

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -133,8 +133,7 @@ public class SwaggerUIIntegrationTests(ITestOutputHelper outputHelper)
 
         var jsContent = await response.Content.ReadAsStringAsync(cancellationToken);
 
-        Assert.Contains(".split(/[?#]/)[0]", jsContent);
-        Assert.DoesNotContain(".split('#')[0]", jsContent);
+        Assert.Contains("window.location.href.split(/[?#]/)[0].replace(\"index.html\", item.url)", jsContent);
     }
 
     [Theory]

--- a/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
+++ b/test/Swashbuckle.AspNetCore.IntegrationTests/SwaggerUIIntegrationTests.cs
@@ -119,6 +119,24 @@ public class SwaggerUIIntegrationTests(ITestOutputHelper outputHelper)
         }
     }
 
+    [Fact]
+    public async Task SwaggerUIMiddleware_InitializerScript_DropsQueryStringFromRelativeDocumentUrls()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        var site = new TestSite(typeof(Basic.Startup), outputHelper);
+        using var client = site.BuildClient();
+
+        using var response = await client.GetAsync("/index.js", cancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var jsContent = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        Assert.Contains(".split(/[?#]/)[0]", jsContent);
+        Assert.DoesNotContain(".split('#')[0]", jsContent);
+    }
+
     [Theory]
     [InlineData(typeof(Basic.Startup), "/index.js")]
     [InlineData(typeof(CustomUIConfig.Startup), "/swagger/index.js")]


### PR DESCRIPTION
# Pull Request

## The issue or feature being addressed

Fixes #2721

## Details on the issue fix or feature implementation

The Swagger UI initializer script (`index.js`) resolves relative document URLs against `window.location.href` and only stripped the fragment, so a request for `swagger/index.html?foo=bar` produced a document link of `swagger/swagger.json?foo=bar`. This is what scanners such as Burp Suite flag as a reflected open-redirect finding, as described in the issue.

The page URL now has its query string and fragment removed (`split(/[?#]/)[0]`) *before* the document URL is spliced in, so nothing from the page URL is carried over. The document URL itself is treated exactly as before: a configured query string such as `v1/swagger.json?tenant=foo` is kept, and only a fragment is dropped. Absolute and root-relative document URLs are not touched.

Added an integration test in `SwaggerUIIntegrationTests` (same style as `SwaggerUIMiddleware_ReturnsInitializerScript`) asserting the served script strips the page URL before the replacement; it failed before the change.
